### PR TITLE
Add a CDDL Parser

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "editor.formatOnSave": true
+}

--- a/cuddle.cabal
+++ b/cuddle.cabal
@@ -19,6 +19,7 @@ common warnings
 library
     import:           warnings
     exposed-modules:
+        Codec.CBOR.Cuddle.Builder
         Codec.CBOR.Cuddle.CDDL
         Codec.CBOR.Cuddle.Parser
         Codec.CBOR.Cuddle.Pretty

--- a/cuddle.cabal
+++ b/cuddle.cabal
@@ -60,4 +60,8 @@ test-suite cuddle-test
     build-depends:
         base ^>=4.16.3.0,
         cuddle,
-        prettyprinter
+        hspec,
+        hspec-megaparsec,
+        megaparsec,
+        prettyprinter,
+        text

--- a/cuddle.cabal
+++ b/cuddle.cabal
@@ -21,6 +21,7 @@ library
     exposed-modules:
         Codec.CBOR.Cuddle.Builder
         Codec.CBOR.Cuddle.CDDL
+        Codec.CBOR.Cuddle.CDDL.CtlOp
         Codec.CBOR.Cuddle.Parser
         Codec.CBOR.Cuddle.Pretty
     other-modules:

--- a/cuddle.cabal
+++ b/cuddle.cabal
@@ -27,6 +27,8 @@ library
         base ^>=4.16.3.0,
         bytestring,
         cborg,
+        megaparsec,
+        parser-combinators,
         prettyprinter,
         text
     hs-source-dirs:   src

--- a/cuddle.cabal
+++ b/cuddle.cabal
@@ -20,6 +20,7 @@ library
     import:           warnings
     exposed-modules:
         Codec.CBOR.Cuddle.CDDL
+        Codec.CBOR.Cuddle.Parser
         Codec.CBOR.Cuddle.Pretty
     other-modules:
     -- other-extensions:
@@ -44,7 +45,9 @@ executable example
     build-depends:
         base ^>=4.16.3.0,
         cuddle,
-        prettyprinter
+        megaparsec,
+        prettyprinter,
+        text
 
 test-suite cuddle-test
     import:           warnings

--- a/example/Main.hs
+++ b/example/Main.hs
@@ -12,15 +12,6 @@ import Prettyprinter.Util (putDocW)
 import System.Environment (getArgs)
 import Text.Megaparsec (ParseErrorBundle, Parsec, errorBundlePretty, runParser)
 
--- ex1 :: Rule
--- ex1 =
---   Rule
---     (Name "test1")
---     (Just . GenericParam $ NE.singleton (Name "a"))
---     AssignEq
---     ( TOGType $ mkType (T2Value $ VNum 3) <> mkType (T2Value $ VText "3")
---     )
-
 main :: IO ()
 main = do
   args <- getArgs

--- a/example/Main.hs
+++ b/example/Main.hs
@@ -1,21 +1,40 @@
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Main (main) where
 
-import Codec.CBOR.Cuddle.CDDL
+import Codec.CBOR.Cuddle.Parser (pCDDL)
 import Codec.CBOR.Cuddle.Pretty ()
-import Prettyprinter
+import Data.Text qualified as T
+import Data.Text.IO qualified as T
+import Prettyprinter (Pretty (pretty))
 import Prettyprinter.Util (putDocW)
-import qualified Data.List.NonEmpty as NE
+import System.Environment (getArgs)
+import Text.Megaparsec (ParseErrorBundle, Parsec, errorBundlePretty, runParser)
 
-ex1 :: Rule
-ex1 =
-  Rule
-    (Name "test1")
-    (Just . GenericParam $ NE.singleton (Name "a"))
-    AssignEq
-    ( TOGType $ mkType (T2Value $ VNum 3) <> mkType  (T2Value $ VText "3")
-    )
+-- ex1 :: Rule
+-- ex1 =
+--   Rule
+--     (Name "test1")
+--     (Just . GenericParam $ NE.singleton (Name "a"))
+--     AssignEq
+--     ( TOGType $ mkType (T2Value $ VNum 3) <> mkType (T2Value $ VText "3")
+--     )
 
 main :: IO ()
-main = putDocW 80 $ pretty ex1
+main = do
+  args <- getArgs
+  case args of
+    [fn] -> do
+      parseFromFile pCDDL fn >>= \case
+        Left err -> putStrLn $ errorBundlePretty err
+        Right res -> do
+          print res
+          putDocW 80 $ pretty res
+    _ -> putStrLn "Expected filename"
+
+parseFromFile ::
+  Parsec e T.Text a ->
+  String ->
+  IO (Either (ParseErrorBundle T.Text e) a)
+parseFromFile p file = runParser p file <$> T.readFile file

--- a/example/cddl-files/basic_assign.cddl
+++ b/example/cddl-files/basic_assign.cddl
@@ -4,4 +4,6 @@ epoch = uint
 header =
   [ header_body
   , body_signature : $kes_signature
+  , test : coin / null
+  , withComment : null ; This is a comment
   ]

--- a/example/cddl-files/basic_assign.cddl
+++ b/example/cddl-files/basic_assign.cddl
@@ -1,0 +1,7 @@
+coin = uint
+epoch = uint
+
+header =
+  [ header_body
+  , body_signature : $kes_signature
+  ]

--- a/example/cddl-files/shelley.cddl
+++ b/example/cddl-files/shelley.cddl
@@ -1,0 +1,258 @@
+; Shelley Types
+
+block =
+  [ header
+  , transaction_bodies         : [* transaction_body]
+  , transaction_witness_sets   : [* transaction_witness_set]
+  , transaction_metadata_set   :
+      { * transaction_index => transaction_metadata }
+  ]; Valid blocks must also satisfy the following two constraints:
+   ; 1) the length of transaction_bodies and transaction_witness_sets
+   ;    must be the same
+   ; 2) every transaction_index must be strictly smaller than the
+   ;    length of transaction_bodies
+
+transaction =
+  [ transaction_body
+  , transaction_witness_set
+  , transaction_metadata / null
+  ]
+
+transaction_index = uint .size 2
+
+header =
+  [ header_body
+  , body_signature : $kes_signature
+  ]
+
+header_body =
+  [ block_number     : uint
+  , slot             : uint
+  , prev_hash        : $hash32 / null
+  , issuer_vkey      : $vkey
+  , vrf_vkey         : $vrf_vkey
+  , nonce_vrf        : $vrf_cert
+  , leader_vrf       : $vrf_cert
+  , block_body_size  : uint
+  , block_body_hash  : $hash32 ; merkle triple root
+  , operational_cert
+  , protocol_version
+  ]
+
+operational_cert =
+  ( hot_vkey        : $kes_vkey
+  , sequence_number : uint
+  , kes_period      : uint
+  , sigma           : $signature
+  )
+
+next_major_protocol_version = 3
+
+major_protocol_version = 1..next_major_protocol_version
+
+protocol_version = (major_protocol_version, uint)
+
+transaction_body =
+  { 0 : set<transaction_input>
+  , 1 : [* transaction_output]
+  , 2 : coin ; fee
+  , 3 : uint ; ttl
+  , ? 4 : [* certificate]
+  , ? 5 : withdrawals
+  , ? 6 : update
+  , ? 7 : metadata_hash
+  }
+
+transaction_input = [ transaction_id : $hash32
+                    , index : uint
+                    ]
+
+transaction_output = [address, amount : coin]
+
+; address = bytes
+; reward_account = bytes
+
+; address format:
+; [ 8 bit header | payload ];
+;
+; shelley payment addresses:
+; bit 7: 0
+; bit 6: base/other
+; bit 5: pointer/enterprise [for base: stake cred is keyhash/scripthash]
+; bit 4: payment cred is keyhash/scripthash
+; bits 3-0: network id
+;
+; reward addresses:
+; bits 7-5: 111
+; bit 4: credential is keyhash/scripthash
+; bits 3-0: network id
+;
+; byron addresses:
+; bits 7-4: 1000
+
+; 0000: base address: keyhash28,keyhash28
+; 0001: base address: scripthash28,keyhash28
+; 0010: base address: keyhash28,scripthash28
+; 0011: base address: scripthash28,scripthash28
+; 0100: pointer address: keyhash28, 3 variable length uint
+; 0101: pointer address: scripthash28, 3 variable length uint
+; 0110: enterprise address: keyhash28
+; 0111: enterprise address: scripthash28
+; 1000: byron address
+; 1110: reward account: keyhash28
+; 1111: reward account: scripthash28
+; 1001 - 1101: future formats
+
+certificate =
+  [ stake_registration
+  // stake_deregistration
+  // stake_delegation
+  // pool_registration
+  // pool_retirement
+  // genesis_key_delegation
+  // move_instantaneous_rewards_cert
+  ]
+
+stake_registration = (0, stake_credential)
+stake_deregistration = (1, stake_credential)
+stake_delegation = (2, stake_credential, pool_keyhash)
+pool_registration = (3, pool_params)
+pool_retirement = (4, pool_keyhash, epoch)
+genesis_key_delegation = (5, genesishash, genesis_delegate_hash, vrf_keyhash)
+move_instantaneous_rewards_cert = (6, move_instantaneous_reward)
+
+move_instantaneous_reward = [ 0 / 1, { * stake_credential => coin } ]
+; The first field determines where the funds are drawn from.
+; 0 denotes the reserves, 1 denotes the treasury.
+
+stake_credential =
+  [  0, addr_keyhash
+  // 1, scripthash
+  ]
+
+pool_params = ( operator:       pool_keyhash
+              , vrf_keyhash:    vrf_keyhash
+              , pledge:         coin
+              , cost:           coin
+              , margin:         unit_interval
+              , reward_account: reward_account
+              , pool_owners:    set<addr_keyhash>
+              , relays:         [* relay]
+              , pool_metadata:  pool_metadata / null
+              )
+
+port = uint .le 65535
+ipv4 = bytes .size 4
+ipv6 = bytes .size 16
+dns_name = tstr .size (0..64)
+
+single_host_addr = ( 0
+                   , port / null
+                   , ipv4 / null
+                   , ipv6 / null
+                   )
+single_host_name = ( 1
+                   , port / null
+                   , dns_name ; An A or AAAA DNS record
+                   )
+multi_host_name = ( 2
+                   , dns_name ; A SRV DNS record
+                   )
+relay =
+  [  single_host_addr
+  // single_host_name
+  // multi_host_name
+  ]
+
+pool_metadata = [url, metadata_hash]
+url = tstr .size (0..64)
+
+withdrawals = { * reward_account => coin }
+
+update = [ proposed_protocol_parameter_updates
+         , epoch
+         ]
+
+proposed_protocol_parameter_updates =
+  { * genesishash => protocol_param_update }
+
+protocol_param_update =
+  { ? 0:  uint               ; minfee A
+  , ? 1:  uint               ; minfee B
+  , ? 2:  uint               ; max block body size
+  , ? 3:  uint               ; max transaction size
+  , ? 4:  uint               ; max block header size
+  , ? 5:  coin               ; key deposit
+  , ? 6:  coin               ; pool deposit
+  , ? 7: epoch               ; maximum epoch
+  , ? 8: uint                ; n_opt: desired number of stake pools
+  , ? 9: rational            ; pool pledge influence
+  , ? 10: unit_interval      ; expansion rate
+  , ? 11: unit_interval      ; treasury growth rate
+  , ? 12: unit_interval      ; d. decentralization constant
+  , ? 13: $nonce             ; extra entropy
+  , ? 14: [protocol_version] ; protocol version
+  , ? 15: coin               ; min utxo value
+  }
+
+transaction_witness_set =
+  { ?0 => [* vkeywitness ]
+  , ?1 => [* multisig_script ]
+  , ?2 => [* bootstrap_witness ]
+  ; In the future, new kinds of witnesses can be added like this:
+  ; , ?3 => [* monetary_policy_script ]
+  ; , ?4 => [* plutus_script ]
+  }
+
+transaction_metadatum =
+    { * transaction_metadatum => transaction_metadatum }
+  / [ * transaction_metadatum ]
+  / int
+  / bytes .size (0..64)
+  / text .size (0..64)
+
+transaction_metadatum_label = uint
+
+transaction_metadata =
+  { * transaction_metadatum_label => transaction_metadatum }
+
+vkeywitness = [ $vkey, $signature ]
+
+bootstrap_witness =
+  [ public_key : $vkey
+  , signature  : $signature
+  , chain_code : bytes .size 32
+  , attributes : bytes
+  ]
+
+multisig_script =
+  [ multisig_pubkey
+  // multisig_all
+  // multisig_any
+  // multisig_n_of_k
+  ]
+
+multisig_pubkey = (0, addr_keyhash)
+multisig_all = (1, [ * multisig_script ])
+multisig_any = (2, [ * multisig_script ])
+multisig_n_of_k = (3, n: uint, [ * multisig_script ])
+
+coin = uint
+epoch = uint
+
+addr_keyhash          = $hash28
+genesis_delegate_hash = $hash28
+pool_keyhash          = $hash28
+genesishash           = $hash28
+
+vrf_keyhash           = $hash32
+metadata_hash         = $hash32
+
+; To compute a script hash, note that you must prepend
+; a tag to the bytes of the script before hashing.
+; The tag is determined by the language.
+; In the Shelley era there is only one such tag,
+; namely "\x00" for multisig scripts.
+scripthash            = $hash28
+
+$nonce /= [ 0 // 1, bytes .size 32 ]

--- a/src/Codec/CBOR/Cuddle/Builder.hs
+++ b/src/Codec/CBOR/Cuddle/Builder.hs
@@ -1,0 +1,26 @@
+-- \* CDDL Builder
+--
+-- Helps to build CDDL values in Haskell
+module Codec.CBOR.Cuddle.Builder where
+
+import Codec.CBOR.Cuddle.CDDL
+import Data.Text qualified as T
+
+class IsName a where
+  toName :: a -> Name
+
+instance IsName T.Text where
+  toName = Name
+
+instance IsName Name where
+  toName = id
+
+class IsTypeOrGroup a where
+  toTypeOrGroup :: a -> TypeOrGroup
+
+(=:=) :: (IsName a, IsTypeOrGroup b) => a -> b -> Rule
+a =:= b = Rule (toName a) Nothing AssignEq (toTypeOrGroup b)
+
+-- | Extend an assignment
+(//=) :: (IsName a, IsTypeOrGroup b) => a -> b -> Rule
+a //= b = Rule (toName a) Nothing AssignExt (toTypeOrGroup b)

--- a/src/Codec/CBOR/Cuddle/CDDL.hs
+++ b/src/Codec/CBOR/Cuddle/CDDL.hs
@@ -49,24 +49,22 @@ newtype Name = Name T.Text
 --   side the first entry in the choice being created.)
 data Assign = AssignEq | AssignExt
 
-{- |
-  Generics
-
-   Using angle brackets, the left-hand side of a rule can add formal
-   parameters after the name being defined, as in:
-
-      messages = message<"reboot", "now"> / message<"sleep", 1..100>
-      message<t, v> = {type: t, value: v}
-
-   When using a generic rule, the formal parameters are bound to the
-   actual arguments supplied (also using angle brackets), within the
-   scope of the generic rule (as if there were a rule of the form
-   parameter = argument).
-
-   Generic rules can be used for establishing names for both types and
-   groups.
-
--}
+-- |
+--  Generics
+--
+--   Using angle brackets, the left-hand side of a rule can add formal
+--   parameters after the name being defined, as in:
+--
+--      messages = message<"reboot", "now"> / message<"sleep", 1..100>
+--      message<t, v> = {type: t, value: v}
+--
+--   When using a generic rule, the formal parameters are bound to the
+--   actual arguments supplied (also using angle brackets), within the
+--   scope of the generic rule (as if there were a rule of the form
+--   parameter = argument).
+--
+--   Generic rules can be used for establishing names for both types and
+--   groups.
 newtype GenericParam = GenericParam (NE.NonEmpty Name)
   deriving (Show)
 
@@ -97,6 +95,12 @@ newtype GenericArg = GenericArg (NE.NonEmpty Type1)
 --   definitions before a determination can be made.)
 data Rule = Rule Name (Maybe GenericParam) Assign TypeOrGroup
 
+-- |
+--   A range operator can be used to join two type expressions that stand
+--   for either two integer values or two floating-point values; it
+--   matches any value that is between the two values, where the first
+--   value is always included in the matching set and the second value is
+--   included for ".." and excluded for "...".
 data RangeBound = ClOpen | Closed
 
 data TyOp = RangeOp RangeBound | CtrlOp Name
@@ -190,7 +194,10 @@ type GrpChoice = [GroupEntry]
 --  the memberkey is given.  If the memberkey is not given, the entry can
 --  only be used for matching arrays, not for maps.  (See below for how
 --  that is modified by the occurrence indicator.)
-data GroupEntry = GroupEntry (Maybe OccurrenceIndicator) (Maybe MemberKey) Type0
+data GroupEntry
+  = GEType (Maybe OccurrenceIndicator) (Maybe MemberKey) Type0
+  | GERef (Maybe OccurrenceIndicator) Name (Maybe GenericArg)
+  | GEGroup (Maybe OccurrenceIndicator) Group
 
 -- |
 --  Key types can be given by a type expression, a bareword (which stands

--- a/src/Codec/CBOR/Cuddle/CDDL.hs
+++ b/src/Codec/CBOR/Cuddle/CDDL.hs
@@ -110,7 +110,7 @@ data RangeBound = ClOpen | Closed
 data TyOp = RangeOp RangeBound | CtrlOp Name
   deriving (Show)
 
-data TypeOrGroup = TOGType Type0 | TOGGroup Group
+data TypeOrGroup = TOGType Type0 | TOGGroup GroupEntry
   deriving (Show)
 
 -- |

--- a/src/Codec/CBOR/Cuddle/CDDL.hs
+++ b/src/Codec/CBOR/Cuddle/CDDL.hs
@@ -32,7 +32,7 @@ type CDDL = NE.NonEmpty Rule
 --  *  Rule names (types or groups) do not appear in the actual CBOR
 --      encoding, but names used as "barewords" in member keys do.
 newtype Name = Name T.Text
-  deriving (Show)
+  deriving (Eq, Show)
 
 -- |
 --   assignt = "=" / "/="
@@ -48,7 +48,7 @@ newtype Name = Name T.Text
 --   a rule name that has not yet been defined; this makes the right-hand
 --   side the first entry in the choice being created.)
 data Assign = AssignEq | AssignExt
-  deriving (Show)
+  deriving (Eq, Show)
 
 -- |
 --  Generics
@@ -67,10 +67,10 @@ data Assign = AssignEq | AssignExt
 --   Generic rules can be used for establishing names for both types and
 --   groups.
 newtype GenericParam = GenericParam (NE.NonEmpty Name)
-  deriving (Show)
+  deriving (Eq, Show)
 
 newtype GenericArg = GenericArg (NE.NonEmpty Type1)
-  deriving (Show)
+  deriving (Eq, Show)
 
 -- |
 --  rule = typename [genericparm] S assignt S type
@@ -96,7 +96,7 @@ newtype GenericArg = GenericArg (NE.NonEmpty Type1)
 --   this semantic processing may need to span several levels of rule
 --   definitions before a determination can be made.)
 data Rule = Rule Name (Maybe GenericParam) Assign TypeOrGroup
-  deriving (Show)
+  deriving (Eq, Show)
 
 -- |
 --   A range operator can be used to join two type expressions that stand
@@ -105,20 +105,20 @@ data Rule = Rule Name (Maybe GenericParam) Assign TypeOrGroup
 --   value is always included in the matching set and the second value is
 --   included for ".." and excluded for "...".
 data RangeBound = ClOpen | Closed
-  deriving (Show)
+  deriving (Eq, Show)
 
 data TyOp = RangeOp RangeBound | CtrlOp Name
-  deriving (Show)
+  deriving (Eq, Show)
 
 data TypeOrGroup = TOGType Type0 | TOGGroup GroupEntry
-  deriving (Show)
+  deriving (Eq, Show)
 
 -- |
 -- A type can be given as a choice between one or more types.  The
 --   choice matches a data item if the data item matches any one of the
 --   types given in the choice.
 newtype Type0 = Type0 (NE.NonEmpty Type1)
-  deriving (Show)
+  deriving (Eq, Show)
 
 instance Semigroup Type0 where
   (Type0 a) <> (Type0 b) = Type0 $ a <> b
@@ -126,7 +126,7 @@ instance Semigroup Type0 where
 -- |
 -- Two types can be combined with a range operator (see below)
 data Type1 = Type1 Type2 (Maybe (TyOp, Type2))
-  deriving (Show)
+  deriving (Eq, Show)
 
 data Type2
   = -- | A type can be just a single value (such as 1 or "icecream" or
@@ -162,7 +162,7 @@ data Type2
     T2DataItem Int (Maybe Int)
   | -- | Any data item
     T2Any
-  deriving (Show)
+  deriving (Eq, Show)
 
 mkType :: Type2 -> Type0
 mkType t = Type0 $ NE.singleton $ Type1 t Nothing
@@ -189,13 +189,13 @@ data OccurrenceIndicator
   | OIZeroOrMore
   | OIOneOrMore
   | OIBounded (Maybe Int) (Maybe Int)
-  deriving (Show)
+  deriving (Eq, Show)
 
 -- |
 --   A group matches any sequence of key/value pairs that matches any of
 --   the choices given (again using PEG semantics).
 newtype Group = Group (NE.NonEmpty GrpChoice)
-  deriving (Show)
+  deriving (Eq, Show)
 
 type GrpChoice = [GroupEntry]
 
@@ -210,7 +210,7 @@ data GroupEntry
   = GEType (Maybe OccurrenceIndicator) (Maybe MemberKey) Type0
   | GERef (Maybe OccurrenceIndicator) Name (Maybe GenericArg)
   | GEGroup (Maybe OccurrenceIndicator) Group
-  deriving (Show)
+  deriving (Eq, Show)
 
 -- |
 --  Key types can be given by a type expression, a bareword (which stands
@@ -224,14 +224,14 @@ data MemberKey
   = MKType Type1
   | MKBareword Name
   | MKValue Value
-  deriving (Show)
+  deriving (Eq, Show)
 
 data Value
   = -- Should be bigger than just Int
     VNum Int
   | VText T.Text
   | VBytes B.ByteString
-  deriving (Show)
+  deriving (Eq, Show)
 
 newtype Comment = Comment T.Text
-  deriving (Show)
+  deriving (Eq, Show)

--- a/src/Codec/CBOR/Cuddle/CDDL.hs
+++ b/src/Codec/CBOR/Cuddle/CDDL.hs
@@ -6,7 +6,7 @@ import Data.ByteString qualified as B
 import Data.List.NonEmpty qualified as NE
 import Data.Text qualified as T
 
-type CDDL = [Rule]
+type CDDL = NE.NonEmpty Rule
 
 -- |
 --  A name can consist of any of the characters from the set {"A" to

--- a/src/Codec/CBOR/Cuddle/CDDL.hs
+++ b/src/Codec/CBOR/Cuddle/CDDL.hs
@@ -48,6 +48,7 @@ newtype Name = Name T.Text
 --   a rule name that has not yet been defined; this makes the right-hand
 --   side the first entry in the choice being created.)
 data Assign = AssignEq | AssignExt
+  deriving (Show)
 
 -- |
 --  Generics
@@ -69,6 +70,7 @@ newtype GenericParam = GenericParam (NE.NonEmpty Name)
   deriving (Show)
 
 newtype GenericArg = GenericArg (NE.NonEmpty Type1)
+  deriving (Show)
 
 -- |
 --  rule = typename [genericparm] S assignt S type
@@ -94,6 +96,7 @@ newtype GenericArg = GenericArg (NE.NonEmpty Type1)
 --   this semantic processing may need to span several levels of rule
 --   definitions before a determination can be made.)
 data Rule = Rule Name (Maybe GenericParam) Assign TypeOrGroup
+  deriving (Show)
 
 -- |
 --   A range operator can be used to join two type expressions that stand
@@ -102,16 +105,20 @@ data Rule = Rule Name (Maybe GenericParam) Assign TypeOrGroup
 --   value is always included in the matching set and the second value is
 --   included for ".." and excluded for "...".
 data RangeBound = ClOpen | Closed
+  deriving (Show)
 
 data TyOp = RangeOp RangeBound | CtrlOp Name
+  deriving (Show)
 
 data TypeOrGroup = TOGType Type0 | TOGGroup Group
+  deriving (Show)
 
 -- |
 -- A type can be given as a choice between one or more types.  The
 --   choice matches a data item if the data item matches any one of the
 --   types given in the choice.
 newtype Type0 = Type0 (NE.NonEmpty Type1)
+  deriving (Show)
 
 instance Semigroup Type0 where
   (Type0 a) <> (Type0 b) = Type0 $ a <> b
@@ -119,6 +126,7 @@ instance Semigroup Type0 where
 -- |
 -- Two types can be combined with a range operator (see below)
 data Type1 = Type1 Type2 (Maybe (TyOp, Type2))
+  deriving (Show)
 
 data Type2
   = -- | A type can be just a single value (such as 1 or "icecream" or
@@ -154,6 +162,7 @@ data Type2
     T2DataItem Int (Maybe Int)
   | -- | Any data item
     T2Any
+  deriving (Show)
 
 mkType :: Type2 -> Type0
 mkType t = Type0 $ NE.singleton $ Type1 t Nothing
@@ -180,11 +189,13 @@ data OccurrenceIndicator
   | OIZeroOrMore
   | OIOneOrMore
   | OIBounded (Maybe Int) (Maybe Int)
+  deriving (Show)
 
 -- |
 --   A group matches any sequence of key/value pairs that matches any of
 --   the choices given (again using PEG semantics).
 newtype Group = Group (NE.NonEmpty GrpChoice)
+  deriving (Show)
 
 type GrpChoice = [GroupEntry]
 
@@ -199,6 +210,7 @@ data GroupEntry
   = GEType (Maybe OccurrenceIndicator) (Maybe MemberKey) Type0
   | GERef (Maybe OccurrenceIndicator) Name (Maybe GenericArg)
   | GEGroup (Maybe OccurrenceIndicator) Group
+  deriving (Show)
 
 -- |
 --  Key types can be given by a type expression, a bareword (which stands
@@ -212,11 +224,14 @@ data MemberKey
   = MKType Type1
   | MKBareword Name
   | MKValue Value
+  deriving (Show)
 
 data Value
   = -- Should be bigger than just Int
     VNum Int
   | VText T.Text
   | VBytes B.ByteString
+  deriving (Show)
 
 newtype Comment = Comment T.Text
+  deriving (Show)

--- a/src/Codec/CBOR/Cuddle/CDDL.hs
+++ b/src/Codec/CBOR/Cuddle/CDDL.hs
@@ -67,10 +67,10 @@ data Assign = AssignEq | AssignExt
 --   Generic rules can be used for establishing names for both types and
 --   groups.
 newtype GenericParam = GenericParam (NE.NonEmpty Name)
-  deriving (Eq, Show)
+  deriving (Eq, Show, Semigroup)
 
 newtype GenericArg = GenericArg (NE.NonEmpty Type1)
-  deriving (Eq, Show)
+  deriving (Eq, Show, Semigroup)
 
 -- |
 --  rule = typename [genericparm] S assignt S type
@@ -118,10 +118,7 @@ data TypeOrGroup = TOGType Type0 | TOGGroup GroupEntry
 --   choice matches a data item if the data item matches any one of the
 --   types given in the choice.
 newtype Type0 = Type0 (NE.NonEmpty Type1)
-  deriving (Eq, Show)
-
-instance Semigroup Type0 where
-  (Type0 a) <> (Type0 b) = Type0 $ a <> b
+  deriving (Eq, Show, Semigroup)
 
 -- |
 -- Two types can be combined with a range operator (see below)
@@ -195,7 +192,7 @@ data OccurrenceIndicator
 --   A group matches any sequence of key/value pairs that matches any of
 --   the choices given (again using PEG semantics).
 newtype Group = Group (NE.NonEmpty GrpChoice)
-  deriving (Eq, Show)
+  deriving (Eq, Show, Semigroup)
 
 type GrpChoice = [GroupEntry]
 

--- a/src/Codec/CBOR/Cuddle/CDDL.hs
+++ b/src/Codec/CBOR/Cuddle/CDDL.hs
@@ -6,7 +6,8 @@ import Data.ByteString qualified as B
 import Data.List.NonEmpty qualified as NE
 import Data.Text qualified as T
 
-type CDDL = NE.NonEmpty Rule
+newtype CDDL = CDDL (NE.NonEmpty Rule)
+  deriving (Eq, Show)
 
 -- |
 --  A name can consist of any of the characters from the set {"A" to

--- a/src/Codec/CBOR/Cuddle/CDDL.hs
+++ b/src/Codec/CBOR/Cuddle/CDDL.hs
@@ -144,10 +144,11 @@ data Type2
     T2Unwrapped Name (Maybe GenericArg)
   | -- | an enumeration expression, which matches any value that is within the
     --  set of values that the values of the group given can take, or
-    T2Enum Group (Maybe GenericArg)
+    T2Enum Group
+  | T2EnumRef Name (Maybe GenericArg)
   | -- | a tagged data item, tagged with the "uint" given and containing the
     --  type given as the tagged value, or
-    T2Tag Int Type0
+    T2Tag (Maybe Int) Type0
   | -- | a data item of a major type (given by the DIGIT), optionally
     --  constrained to the additional information given by the uint, or
     T2DataItem Int (Maybe Int)

--- a/src/Codec/CBOR/Cuddle/CDDL/CtlOp.hs
+++ b/src/Codec/CBOR/Cuddle/CDDL/CtlOp.hs
@@ -1,0 +1,30 @@
+module Codec.CBOR.Cuddle.CDDL.CtlOp where
+
+-- | A _control_ allows relating a _target_ type with a _controller_ type
+--  via a _control operator_.
+
+--  The syntax for a control type is "target .control-operator
+--  controller", where control operators are special identifiers prefixed
+--  by a dot.  (Note that _target_ or _controller_ might need to be
+--  parenthesized.)
+
+--  A number of control operators are defined at this point.  Further
+--  control operators may be defined by new versions of this
+--  specification or by registering them according to the procedures in
+--  Section 6.1.
+data CtlOp
+  = Size
+  | Bits
+  | Regexp
+  | Cbor
+  | Cborseq
+  | Within
+  | And
+  | Lt
+  | Le
+  | Gt
+  | Ge
+  | Eq
+  | Ne
+  | Default
+  deriving (Eq, Show)

--- a/src/Codec/CBOR/Cuddle/Parser.hs
+++ b/src/Codec/CBOR/Cuddle/Parser.hs
@@ -80,7 +80,7 @@ pGenericArg =
       (NE.sepBy1 (space *> pType1 <* space) (char ','))
 
 pType0 :: Parser Type0
-pType0 = Type0 <$> NE.sepBy1 (space *> pType1 <* space) (char ',')
+pType0 = Type0 <$> NE.sepBy1 (space *> pType1 <* space) (char '/')
 
 pType1 :: Parser Type1
 pType1 = Type1 <$> pType2 <*> optcomp ((,) <$> pTyOp <*> pType2)

--- a/src/Codec/CBOR/Cuddle/Parser.hs
+++ b/src/Codec/CBOR/Cuddle/Parser.hs
@@ -3,8 +3,11 @@
 module Codec.CBOR.Cuddle.Parser where
 
 import Codec.CBOR.Cuddle.CDDL
+import Control.Applicative (Applicative (liftA2))
 import Control.Applicative.Combinators.NonEmpty qualified as NE
 import Data.Functor (void, ($>))
+import Data.List.NonEmpty (NonEmpty)
+import Data.List.NonEmpty qualified as NE
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Void (Void)
@@ -330,3 +333,9 @@ RFC 8610                          CDDL                         June 2019
      CRLF = %x0A / %x0D.0A
 
 -}
+
+-- | Variant on 'NE.sepEndBy1' which doesn't consume the separator
+sepBy1' :: MonadParsec e s m => m a -> m sep -> m (NonEmpty a)
+sepBy1' p sep = NE.fromList <$> go
+  where
+    go = liftA2 (:) p (many (try $ sep *> p))

--- a/src/Codec/CBOR/Cuddle/Parser.hs
+++ b/src/Codec/CBOR/Cuddle/Parser.hs
@@ -1,0 +1,157 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Codec.CBOR.Cuddle.Parser where
+
+import Codec.CBOR.Cuddle.CDDL
+import Control.Applicative.Combinators.NonEmpty qualified as NE
+import Data.Functor (($>))
+import Data.Maybe (fromMaybe)
+import Data.Text (Text)
+import Data.Text qualified as T
+import Data.Void (Void)
+import Text.Megaparsec
+import Text.Megaparsec.Char
+import Text.Megaparsec.Char.Lexer qualified as L
+
+type Parser = Parsec Void Text
+
+pName :: Parser Name
+pName = do
+  fc <- firstChar
+  rest <- optional (mappend <$> many midChar <*> fmap (: []) lastChar)
+  pure $ Name . T.pack $ (fc : fromMaybe mempty rest)
+  where
+    firstChar = letterChar <|> char '@' <|> char '_' <|> char '$'
+    midChar = alphaNumChar <|> char '-' <|> char '_' <|> char '@' <|> char '.' <|> char '$'
+    lastChar = alphaNumChar <|> char '@' <|> char '_' <|> char '$'
+
+pAssignT :: Parser Assign
+pAssignT =
+  choice
+    [ AssignEq <$ char '=',
+      AssignExt <$ string "/="
+    ]
+
+pAssignG :: Parser Assign
+pAssignG =
+  choice
+    [ AssignEq <$ char '=',
+      AssignExt <$ string "//="
+    ]
+
+pGenericParam :: Parser GenericParam
+pGenericParam =
+  GenericParam
+    <$> between
+      (char '<')
+      (char '>')
+      (NE.sepBy1 pName (space <* char ',' <* space))
+
+pGenericArg :: Parser GenericArg
+pGenericArg =
+  GenericArg
+    <$> between
+      (char '<')
+      (char '>')
+      (NE.sepBy1 pType1 (space <* char ',' <* space))
+
+pType0 :: Parser Type0
+pType0 = Type0 <$> NE.sepBy1 pType1 (space <* char ',' <* space)
+
+pType1 :: Parser Type1
+pType1 = Type1 <$> pType2 <*> optional ((,) <$> pTyOp <*> pType2)
+
+pType2 :: Parser Type2
+pType2 =
+  choice
+    [ T2Value <$> pValue,
+      T2Name <$> pName <*> optional pGenericArg,
+      T2Group <$> pType0,
+      T2Map <$> pGroup
+    ]
+
+pGroup :: Parser Group
+pGroup = Group <$> NE.sepBy1 pGrpChoice (space <* string "//" *> space)
+
+pGrpChoice :: Parser GrpChoice
+pGrpChoice = many (pGrpEntry <* optional (space *> char ',' *> space))
+
+pGrpEntry :: Parser GroupEntry
+pGrpEntry =
+  choice
+    [ GEType <$> optional pOccur <*> optional pMemberKey <*> pType0,
+      GERef <$> optional pOccur <*> pName <*> optional pGenericArg,
+      GEGroup <$> optional pOccur <*> pGroup
+    ]
+
+pMemberKey :: Parser MemberKey
+pMemberKey =
+  choice
+    [ MKType <$> pType1,
+      MKBareword <$> pName,
+      MKValue <$> pValue
+    ]
+
+pTyOp :: Parser TyOp
+pTyOp =
+  choice
+    [ RangeOp <$> pRangeBound,
+      CtrlOp <$> (char '.' *> pName)
+    ]
+  where
+    pRangeBound :: Parser RangeBound
+    pRangeBound = (string ".." $> Closed) <|> (string ".." $> ClOpen)
+
+pOccur :: Parser OccurrenceIndicator
+pOccur =
+  choice
+    [ char '+' $> OIOneOrMore,
+      char '?' $> OIOptional,
+      mkBounded <$> optional L.decimal <*> (char '*' *> optional L.decimal)
+    ]
+  where
+    mkBounded mlb mub = case (mlb, mub) of
+      (Nothing, Nothing) -> OIZeroOrMore
+      (x, y) -> OIBounded x y
+
+pValue :: Parser Value
+pValue =
+  choice
+    [ pNumber,
+      pText,
+      pBytes
+    ]
+  where
+    pNumber = VNum <$> L.decimal
+    pText = VText <$> (char '"' *> pSChar <* char '"')
+    -- Currently this doesn't allow string escaping
+    pSChar :: Parser Text
+    pSChar =
+      T.pack
+        <$> many
+          ( satisfy
+              ( charInRange '\x20' '\x21'
+                  ||| charInRange '\x23' '\x5b'
+                  ||| charInRange '\x5d' '\x7e'
+                  ||| charInRange '\x80' '\x10fffd'
+              )
+          )
+    pBytes = VBytes <$> (optional (string "h" <|> string "b64") $> mempty)
+
+-- pBChar :: Parser B.ByteString
+-- pBChar =
+--   B.pack
+--     <$> many
+--       ( satisfy
+--           ( charInRange '\x20' '\x26'
+--               ||| charInRange '\x28' '\x5b'
+--               ||| charInRange '\x5d' '\x10fffd'
+--           )
+--           <|> crlf
+--       )
+
+charInRange :: Char -> Char -> Char -> Bool
+charInRange lb ub x = lb <= x && x <= ub
+
+(|||) :: (a -> Bool) -> (a -> Bool) -> (a -> Bool)
+(x ||| y) a = x a || y a

--- a/src/Codec/CBOR/Cuddle/Parser.hs
+++ b/src/Codec/CBOR/Cuddle/Parser.hs
@@ -83,10 +83,10 @@ pGenericArg =
       (NE.sepBy1 (space *> pType1 <* space) (char ','))
 
 pType0 :: Parser Type0
-pType0 = Type0 <$> NE.sepBy1 (space *> pType1 <* space) (char '/')
+pType0 = Type0 <$> sepBy1' (space *> pType1 <* space) (char '/')
 
 pType1 :: Parser Type1
-pType1 = Type1 <$> pType2 <*> optcomp ((,) <$> pTyOp <*> pType2)
+pType1 = Type1 <$> pType2 <*> optcomp ((,) <$> (space *> pTyOp <* space) <*> pType2)
 
 pType2 :: Parser Type2
 pType2 =
@@ -137,7 +137,7 @@ pGrpEntry =
 pMemberKey :: Parser MemberKey
 pMemberKey =
   choice
-    [ try $ MKType <$> pType1 <* space <* optional (char '^' <* space) <* string "=>",
+    [ try $ MKType <$> pType1 <* space <* optcomp (char '^' <* space) <* string "=>",
       try $ MKBareword <$> pName <* space <* char ':' <* space,
       MKValue <$> pValue <* space <* char ':' <* space
     ]

--- a/src/Codec/CBOR/Cuddle/Parser.hs
+++ b/src/Codec/CBOR/Cuddle/Parser.hs
@@ -121,10 +121,10 @@ pGrpChoice = many ((space *> pGrpEntry <* space) <* optional (char ','))
 pGrpEntry :: Parser GroupEntry
 pGrpEntry =
   choice
-    [ try $ GEType <$> optcomp pOccur <*> optcomp pMemberKey <*> pType0,
-      try $ GERef <$> optcomp pOccur <*> pName <*> optcomp pGenericArg,
+    [ try $ GEType <$> optcomp (pOccur <* space) <*> optcomp (pMemberKey <* space) <*> pType0,
+      try $ GERef <$> optcomp (pOccur <* space) <*> pName <*> optcomp pGenericArg,
       GEGroup
-        <$> optcomp pOccur
+        <$> optcomp (pOccur <* space)
         <*> between
           (char '(')
           (char ')')

--- a/src/Codec/CBOR/Cuddle/Parser.hs
+++ b/src/Codec/CBOR/Cuddle/Parser.hs
@@ -15,6 +15,21 @@ import Text.Megaparsec.Char.Lexer qualified as L
 
 type Parser = Parsec Void Text
 
+pRule :: Parser Rule
+pRule =
+  choice
+    [ Rule
+        <$> pName
+        <*> optional pGenericParam
+        <*> pAssignG
+        <*> (TOGGroup <$> pGroup),
+      Rule
+        <$> pName
+        <*> optional pGenericParam
+        <*> pAssignT
+        <*> (TOGType <$> pType0)
+    ]
+
 pName :: Parser Name
 pName = do
   fc <- firstChar

--- a/src/Codec/CBOR/Cuddle/Parser.hs
+++ b/src/Codec/CBOR/Cuddle/Parser.hs
@@ -4,41 +4,50 @@ module Codec.CBOR.Cuddle.Parser where
 
 import Codec.CBOR.Cuddle.CDDL
 import Control.Applicative.Combinators.NonEmpty qualified as NE
-import Data.Functor (($>))
-import Data.Maybe (fromMaybe)
+import Data.Functor (void, ($>))
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Void (Void)
 import Text.Megaparsec
-import Text.Megaparsec.Char
+import Text.Megaparsec.Char hiding (space)
 import Text.Megaparsec.Char.Lexer qualified as L
 
 type Parser = Parsec Void Text
 
+pCDDL :: Parser CDDL
+pCDDL = space *> NE.some (pRule <* space) <* eof
+
 pRule :: Parser Rule
 pRule =
   choice
-    [ Rule
-        <$> pName
-        <*> optional pGenericParam
-        <*> pAssignG
-        <*> (TOGGroup <$> pGroup),
+    [ try $
+        Rule
+          <$> pName
+          <*> optcomp pGenericParam
+          <*> (space *> pAssignT <* space)
+          <*> (TOGType <$> pType0),
       Rule
         <$> pName
-        <*> optional pGenericParam
-        <*> pAssignT
-        <*> (TOGType <$> pType0)
+        <*> optcomp pGenericParam
+        <*> (space *> pAssignG <* space)
+        <*> (TOGGroup <$> pGrpEntry)
     ]
 
 pName :: Parser Name
 pName = do
   fc <- firstChar
-  rest <- optional (mappend <$> many midChar <*> fmap (: []) lastChar)
-  pure $ Name . T.pack $ (fc : fromMaybe mempty rest)
+  rest <- many midChar
+  pure $ Name . T.pack $ (fc : rest)
   where
     firstChar = letterChar <|> char '@' <|> char '_' <|> char '$'
-    midChar = alphaNumChar <|> char '-' <|> char '_' <|> char '@' <|> char '.' <|> char '$'
-    lastChar = alphaNumChar <|> char '@' <|> char '_' <|> char '$'
+    midChar =
+      alphaNumChar
+        <|> char '@'
+        <|> char '_'
+        <|> char '$'
+        <|> ( (char '.' <|> char '-')
+                <* notFollowedBy (space1 <|> eof <|> void eol)
+            )
 
 pAssignT :: Parser Assign
 pAssignT =
@@ -60,73 +69,80 @@ pGenericParam =
     <$> between
       (char '<')
       (char '>')
-      (NE.sepBy1 pName (space <* char ',' <* space))
+      (NE.sepBy1 (space *> pName <* space) (char ','))
 
 pGenericArg :: Parser GenericArg
 pGenericArg =
   GenericArg
     <$> between
-      (space *> char '<')
-      (char '>' <* space)
-      (NE.sepBy1 pType1 (space <* char ',' <* space))
+      (char '<')
+      (char '>')
+      (NE.sepBy1 (space *> pType1 <* space) (char ','))
 
 pType0 :: Parser Type0
-pType0 = Type0 <$> NE.sepBy1 pType1 (space <* char ',' <* space)
+pType0 = Type0 <$> NE.sepBy1 (space *> pType1 <* space) (char ',')
 
 pType1 :: Parser Type1
-pType1 = Type1 <$> pType2 <*> optional ((,) <$> pTyOp <*> pType2)
+pType1 = Type1 <$> pType2 <*> optcomp ((,) <$> pTyOp <*> pType2)
 
 pType2 :: Parser Type2
 pType2 =
   choice
-    [ T2Value <$> pValue,
-      T2Name <$> pName <*> optional pGenericArg,
-      T2Group <$> between (char '(') (char ')') (space *> pType0 <* space),
-      T2Map <$> between (char '{') (char '}') (space *> pGroup <* space),
-      T2Array <$> between (char '[') (char ']') (space *> pGroup <* space),
-      T2Unwrapped <$> (char '~' *> space *> pName) <*> optional pGenericArg,
-      T2Enum
-        <$> ( char '&'
-                *> space
-                *> between
-                  (char '(')
-                  (char ')')
-                  (space *> pGroup <* space)
-            ),
-      T2EnumRef <$> (char '&' *> space *> pName) <*> optional pGenericArg,
-      T2Tag
-        <$> (string "#6" *> optional (char '.' *> L.decimal))
-        <*> between (char '(') (char ')') (space *> pType0 <* space),
-      T2DataItem <$> (char '#' *> L.decimal) <*> optional (char '.' *> L.decimal),
+    [ try $ T2Value <$> pValue,
+      try $ T2Name <$> pName <*> optcomp pGenericArg,
+      try $ T2Group <$> between (char '(') (char ')') (space *> pType0 <* space),
+      try $ T2Map <$> between (char '{') (char '}') (space *> pGroup <* space),
+      try $ T2Array <$> between (char '[') (char ']') (space *> pGroup <* space),
+      try $ T2Unwrapped <$> (char '~' *> space *> pName) <*> optcomp pGenericArg,
+      try $
+        T2Enum
+          <$> ( char '&'
+                  *> space
+                  *> between
+                    (char '(')
+                    (char ')')
+                    (space *> pGroup <* space)
+              ),
+      try $ T2EnumRef <$> (char '&' *> space *> pName) <*> optcomp pGenericArg,
+      try $
+        T2Tag
+          <$> (string "#6" *> optcomp (char '.' *> L.decimal))
+          <*> between (char '(') (char ')') (space *> pType0 <* space),
+      try $ T2DataItem <$> (char '#' *> L.decimal) <*> optcomp (char '.' *> L.decimal),
       T2Any <$ char '#'
     ]
 
 pGroup :: Parser Group
-pGroup = Group <$> NE.sepBy1 pGrpChoice (space <* string "//" *> space)
+pGroup = Group <$> NE.sepBy1 (space *> pGrpChoice <* space) (string "//")
 
 pGrpChoice :: Parser GrpChoice
-pGrpChoice = many (pGrpEntry <* optional (space *> char ',' *> space))
+pGrpChoice = many ((space *> pGrpEntry <* space) <* optional (char ','))
 
 pGrpEntry :: Parser GroupEntry
 pGrpEntry =
   choice
-    [ GEType <$> optional pOccur <*> optional pMemberKey <*> pType0,
-      GERef <$> optional pOccur <*> pName <*> optional pGenericArg,
-      GEGroup <$> optional pOccur <*> pGroup
+    [ try $ GEType <$> optcomp pOccur <*> optcomp pMemberKey <*> pType0,
+      try $ GERef <$> optcomp pOccur <*> pName <*> optcomp pGenericArg,
+      GEGroup
+        <$> optcomp pOccur
+        <*> between
+          (char '(')
+          (char ')')
+          (space *> pGroup <* space)
     ]
 
 pMemberKey :: Parser MemberKey
 pMemberKey =
   choice
-    [ MKType <$> pType1,
-      MKBareword <$> pName,
-      MKValue <$> pValue
+    [ try $ MKType <$> pType1 <* space <* optional (char '^' <* space) <* string "=>",
+      try $ MKBareword <$> pName <* space <* char ':' <* space,
+      MKValue <$> pValue <* space <* char ':' <* space
     ]
 
 pTyOp :: Parser TyOp
 pTyOp =
   choice
-    [ RangeOp <$> pRangeBound,
+    [ try $ RangeOp <$> pRangeBound,
       CtrlOp <$> (char '.' *> pName)
     ]
   where
@@ -149,8 +165,7 @@ pValue :: Parser Value
 pValue =
   choice
     [ pNumber,
-      pText,
-      pBytes
+      pText
     ]
   where
     pNumber = VNum <$> L.decimal
@@ -167,7 +182,18 @@ pValue =
                   ||| charInRange '\x80' '\x10fffd'
               )
           )
-    pBytes = VBytes <$> (optional (string "h" <|> string "b64") $> mempty)
+
+-- pBytes = VBytes <$> (optional (string "h" <|> string "b64") $> mempty)
+
+space :: Parser ()
+space = L.space space1 (void pComment) (fail "No block comments")
+
+pComment :: Parser Comment
+pComment =
+  Comment . T.pack
+    <$> (char ';' *> many pChar <* eol)
+  where
+    pChar = satisfy (charInRange '\x20' '\x7e' ||| charInRange '\x80' '\x10fffd')
 
 -- pBChar :: Parser B.ByteString
 -- pBChar =
@@ -186,3 +212,121 @@ charInRange lb ub x = lb <= x && x <= ub
 
 (|||) :: (a -> Bool) -> (a -> Bool) -> (a -> Bool)
 (x ||| y) a = x a || y a
+
+-- | A variant of 'optional' for composite parsers, which will consume no input
+-- if it fails.
+optcomp :: MonadParsec e s f => f a -> f (Maybe a)
+optcomp = optional . try
+
+{-
+Appendix B.  ABNF Grammar
+
+   This appendix is normative.
+
+   The following is a formal definition of the CDDL syntax in ABNF
+   [RFC5234].  Note that, as is defined in ABNF, the quote-delimited
+   strings below are case insensitive (while string values and names are
+   case sensitive in CDDL).
+
+     cddl = S 1*(rule S)
+     rule = typename [genericparm] S assignt S type
+          / groupname [genericparm] S assigng S grpent
+
+     typename = id
+     groupname = id
+
+     assignt = "=" / "/="
+     assigng = "=" / "//="
+
+     genericparm = "<" S id S *("," S id S ) ">"
+     genericarg = "<" S type1 S *("," S type1 S ) ">"
+
+     type = type1 *(S "/" S type1)
+
+     type1 = type2 [S (rangeop / ctlop) S type2]
+     ; space may be needed before the operator if type2 ends in a name
+
+     type2 = value
+           / typename [genericarg]
+           / "(" S type S ")"
+           / "{" S group S "}"
+           / "[" S group S "]"
+           / "~" S typename [genericarg]
+           / "&" S "(" S group S ")"
+           / "&" S groupname [genericarg]
+           / "#" "6" ["." uint] "(" S type S ")"
+           / "#" DIGIT ["." uint]                ; major/ai
+           / "#"                                 ; any
+
+     rangeop = "..." / ".."
+
+     ctlop = "." id
+
+     group = grpchoice *(S "//" S grpchoice)
+
+     grpchoice = *(grpent optcom)
+
+Birkholz, et al.             Standards Track                   [Page 45]
+RFC 8610                          CDDL                         June 2019
+
+     grpent = [occur S] [memberkey S] type
+            / [occur S] groupname [genericarg]  ; preempted by above
+            / [occur S] "(" S group S ")"
+
+     memberkey = type1 S ["^" S] "=>"
+               / bareword S ":"
+               / value S ":"
+
+     bareword = id
+
+     optcom = S ["," S]
+
+     occur = [uint] "*" [uint]
+           / "+"
+           / "?"
+
+     uint = DIGIT1 *DIGIT
+          / "0x" 1*HEXDIG
+          / "0b" 1*BINDIG
+          / "0"
+
+     value = number
+           / text
+           / bytes
+
+     int = ["-"] uint
+
+     ; This is a float if it has fraction or exponent; int otherwise
+     number = hexfloat / (int ["." fraction] ["e" exponent ])
+     hexfloat = ["-"] "0x" 1*HEXDIG ["." 1*HEXDIG] "p" exponent
+     fraction = 1*DIGIT
+     exponent = ["+"/"-"] 1*DIGIT
+
+     text = %x22 *SCHAR %x22
+     SCHAR = %x20-21 / %x23-5B / %x5D-7E / %x80-10FFFD / SESC
+     SESC = "\" (%x20-7E / %x80-10FFFD)
+
+     bytes = [bsqual] %x27 *BCHAR %x27
+     BCHAR = %x20-26 / %x28-5B / %x5D-10FFFD / SESC / CRLF
+     bsqual = "h" / "b64"
+
+Birkholz, et al.             Standards Track                   [Page 46]
+RFC 8610                          CDDL                         June 2019
+
+     id = EALPHA *(*("-" / ".") (EALPHA / DIGIT))
+     ALPHA = %x41-5A / %x61-7A
+     EALPHA = ALPHA / "@" / "_" / "$"
+     DIGIT = %x30-39
+     DIGIT1 = %x31-39
+     HEXDIG = DIGIT / "A" / "B" / "C" / "D" / "E" / "F"
+     BINDIG = %x30-31
+
+     S = *WS
+     WS = SP / NL
+     SP = %x20
+     NL = COMMENT / CRLF
+     COMMENT = ";" *PCHAR CRLF
+     PCHAR = %x20-7E / %x80-10FFFD
+     CRLF = %x0A / %x0D.0A
+
+-}

--- a/src/Codec/CBOR/Cuddle/Parser.hs
+++ b/src/Codec/CBOR/Cuddle/Parser.hs
@@ -18,7 +18,7 @@ import Text.Megaparsec.Char.Lexer qualified as L
 type Parser = Parsec Void Text
 
 pCDDL :: Parser CDDL
-pCDDL = space *> NE.some (pRule <* space) <* eof
+pCDDL = CDDL <$> (space *> NE.some (pRule <* space) <* eof)
 
 pRule :: Parser Rule
 pRule =

--- a/src/Codec/CBOR/Cuddle/Postlude.hs
+++ b/src/Codec/CBOR/Cuddle/Postlude.hs
@@ -1,8 +1,5 @@
 module Codec.CBOR.Cuddle.Postlude where
 
-import Data.ByteString (ByteString)
-import Data.Text qualified as T
-
 -- |
 --
 --  CDDL predefines a number of names.  This subsection summarizes these
@@ -38,13 +35,13 @@ import Data.Text qualified as T
 --  (Note that there are no predefined names for arrays or maps; these
 --  are defined with the syntax given below.)
 data PTerm
-  = PTBool !Bool
-  | PTUInt !Int
-  | PTNInt !Int
-  | PTInt !Int
-  | PTHalf !Float
-  | PTFloat !Float
-  | PTDboule !Double
-  | PTBytes !ByteString
-  | PTText !T.Text
+  = PTBool
+  | PTUInt
+  | PTNInt
+  | PTInt
+  | PTHalf
+  | PTFloat
+  | PTDboule
+  | PTBytes
+  | PTText
   | PTAny

--- a/src/Codec/CBOR/Cuddle/Pretty.hs
+++ b/src/Codec/CBOR/Cuddle/Pretty.hs
@@ -70,7 +70,9 @@ instance Pretty Group where
     encloseSep mempty mempty " // " $ fmap pretty xs
 
 instance Pretty GroupEntry where
-  pretty (GroupEntry moi mmk t) = pretty moi <+> pretty mmk <+> pretty t
+  pretty (GEType moi mmk t) = pretty moi <+> pretty mmk <+> pretty t
+  pretty (GERef moi n mga) = pretty moi <+> pretty n <+> pretty mga
+  pretty (GEGroup moi g) = pretty moi <+> enclose "(" ")" (pretty g)
 
 instance Pretty MemberKey where
   pretty (MKType t1) = pretty t1 <+> "=>"

--- a/src/Codec/CBOR/Cuddle/Pretty.hs
+++ b/src/Codec/CBOR/Cuddle/Pretty.hs
@@ -51,7 +51,8 @@ instance Pretty Type2 where
   pretty (T2Map g) = enclose "{" "}" $ pretty g
   pretty (T2Array g) = enclose "[" "]" $ pretty g
   pretty (T2Unwrapped n mg) = "~" <+> pretty n <> pretty mg
-  pretty (T2Enum g mg) = "&" <+> pretty g <> pretty mg
+  pretty (T2Enum g) = "&" <+> enclose "(" ")" (pretty g)
+  pretty (T2EnumRef g mg) = "&" <+> pretty g <+> pretty mg
   pretty (T2Tag minor t) = "#6." <> pretty minor <+> enclose "(" ")" (pretty t)
   pretty (T2DataItem major mminor) =
     "#" <> pretty major <> case mminor of

--- a/src/Codec/CBOR/Cuddle/Pretty.hs
+++ b/src/Codec/CBOR/Cuddle/Pretty.hs
@@ -9,6 +9,9 @@ import Codec.CBOR.Cuddle.CDDL
 import Data.List.NonEmpty qualified as NE
 import Prettyprinter
 
+instance Pretty CDDL where
+  pretty (CDDL (NE.toList -> xs)) = vsep . punctuate hardline $ fmap pretty xs
+
 deriving newtype instance Pretty Name
 
 instance Pretty Rule where
@@ -31,7 +34,7 @@ instance Pretty GenericParam where
   pretty (GenericParam (NE.toList -> l)) = encloseSep "<" ">" ", " $ fmap pretty l
 
 instance Pretty Type0 where
-  pretty (Type0 (NE.toList -> l)) = encloseSep mempty mempty " / " $ fmap pretty l
+  pretty (Type0 (NE.toList -> l)) = align . encloseSep mempty mempty " / " $ fmap pretty l
 
 instance Pretty Type1 where
   pretty (Type1 t2 Nothing) = pretty t2
@@ -68,7 +71,9 @@ instance Pretty OccurrenceIndicator where
 
 instance Pretty Group where
   pretty (Group (NE.toList -> xs)) =
-    encloseSep mempty mempty " // " $ fmap pretty xs
+    align . encloseSep mempty mempty " // " $ fmap prettyGrpChoice xs
+    where
+      prettyGrpChoice = align . vsep . punctuate "," . fmap pretty
 
 instance Pretty GroupEntry where
   pretty (GEType moi mmk t) = pretty moi <+> pretty mmk <+> pretty t

--- a/src/Codec/CBOR/Cuddle/Pretty.hs
+++ b/src/Codec/CBOR/Cuddle/Pretty.hs
@@ -6,7 +6,9 @@
 module Codec.CBOR.Cuddle.Pretty where
 
 import Codec.CBOR.Cuddle.CDDL
+import Codec.CBOR.Cuddle.CDDL.CtlOp (CtlOp)
 import Data.List.NonEmpty qualified as NE
+import Data.Text qualified as T
 import Prettyprinter
 
 instance Pretty CDDL where
@@ -36,6 +38,9 @@ instance Pretty GenericParam where
 instance Pretty Type0 where
   pretty (Type0 (NE.toList -> l)) = align . encloseSep mempty mempty " / " $ fmap pretty l
 
+instance Pretty CtlOp where
+  pretty = pretty . T.toLower . T.pack . show
+
 instance Pretty Type1 where
   pretty (Type1 t2 Nothing) = pretty t2
   pretty (Type1 t2 (Just (tyop, t2'))) =
@@ -43,7 +48,7 @@ instance Pretty Type1 where
       <+> ( case tyop of
               RangeOp ClOpen -> "..."
               RangeOp Closed -> ".."
-              CtrlOp n -> "." <+> pretty n
+              CtrlOp n -> "." <> pretty n
           )
       <+> pretty t2'
 

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -12,26 +12,33 @@ import Text.Megaparsec
 main :: IO ()
 main = hspec $
   describe "cddlParser" $ do
-    describe "pValue" $ do
-      it "Parses integer" $
-        parse pValue "" "123" `shouldParse` VNum 123
-      it "Parses text" $
-        parse pValue "" "\"Hello World\"" `shouldParse` VText "Hello World"
-    describe "pOccur" $ do
-      it "Parses OneOrMore" $
-        parse pOccur "" "+" `shouldParse` OIOneOrMore
-      it "Parses ZeroOrMore" $
-        parse pOccur "" "*" `shouldParse` OIZeroOrMore
-      it "Parses Optional" $
-        parse pOccur "" "?" `shouldParse` OIOptional
-      it "Parses Lower Bounded" $
-        parse pOccur "" "3*" `shouldParse` OIBounded (Just 3) Nothing
-      it "Parses Upper Bounded" $
-        parse pOccur "" "*9" `shouldParse` OIBounded Nothing (Just 9)
-      it "Parses bounded on both sides" $
-        parse pOccur "" "3*9" `shouldParse` OIBounded (Just 3) (Just 9)
+    valueSpec
+    occurSpec
     nameSpec
     type2Spec
+    grpEntrySpec
+
+valueSpec :: Spec
+valueSpec = describe "pValue" $ do
+  it "Parses integer" $
+    parse pValue "" "123" `shouldParse` VNum 123
+  it "Parses text" $
+    parse pValue "" "\"Hello World\"" `shouldParse` VText "Hello World"
+
+occurSpec :: Spec
+occurSpec = describe "pOccur" $ do
+  it "Parses OneOrMore" $
+    parse pOccur "" "+" `shouldParse` OIOneOrMore
+  it "Parses ZeroOrMore" $
+    parse pOccur "" "*" `shouldParse` OIZeroOrMore
+  it "Parses Optional" $
+    parse pOccur "" "?" `shouldParse` OIOptional
+  it "Parses Lower Bounded" $
+    parse pOccur "" "3*" `shouldParse` OIBounded (Just 3) Nothing
+  it "Parses Upper Bounded" $
+    parse pOccur "" "*9" `shouldParse` OIBounded Nothing (Just 9)
+  it "Parses bounded on both sides" $
+    parse pOccur "" "3*9" `shouldParse` OIBounded (Just 3) (Just 9)
 
 -- it "result of parsing satisfies what it should" $
 --   parse myParser "" "aaaa" `parseSatisfies` ((== 4) . length)
@@ -77,3 +84,66 @@ type2Spec = describe "type2" $ do
                   ]
               )
           )
+  describe "Array" $ do
+    it "Parses an array with an alternative" $
+      parse pType2 "" "[int // string]"
+        `shouldParse` T2Array
+          ( Group
+              ( [ GEType
+                    Nothing
+                    Nothing
+                    ( Type0
+                        ( Type1
+                            (T2Name (Name "int") Nothing)
+                            Nothing
+                            NE.:| []
+                        )
+                    )
+                ]
+                  NE.:| [ [ GEType
+                              Nothing
+                              Nothing
+                              ( Type0
+                                  ( Type1
+                                      (T2Name (Name "string") Nothing)
+                                      Nothing
+                                      NE.:| []
+                                  )
+                              )
+                          ]
+                        ]
+              )
+          )
+
+    it "Parses an array with a value alternative" $
+      parse pType2 "" "[0 // 1]"
+        `shouldParse` T2Array
+          ( Group
+              ( [ GEType
+                    Nothing
+                    Nothing
+                    (Type0 (NE.singleton (Type1 (T2Value (VNum 0)) Nothing)))
+                ]
+                  NE.:| [ [ GEType
+                              Nothing
+                              Nothing
+                              (Type0 (NE.singleton (Type1 (T2Value (VNum 0)) Nothing)))
+                          ]
+                        ]
+              )
+          )
+
+grpEntrySpec :: SpecWith ()
+grpEntrySpec = describe "GroupEntry" $ do
+  it "Prefers GEType over GERef for names" $
+    parse pGrpEntry "" "int"
+      `shouldParse` GEType
+        Nothing
+        Nothing
+        ( Type0
+            ( Type1
+                (T2Name (Name "int") Nothing)
+                Nothing
+                NE.:| []
+            )
+        )

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -15,6 +15,7 @@ main = hspec $
     valueSpec
     occurSpec
     nameSpec
+    type1Spec
     type2Spec
     grpEntrySpec
     grpChoiceSpec
@@ -176,3 +177,12 @@ grpChoiceSpec = describe "GroupChoice" $ do
                             )
                         )
                     ]
+
+type1Spec :: Spec
+type1Spec = describe "Type1" $ do
+  describe "CtlOp" $ do
+    it "Should parse a basic control operator" $
+      parse pType1 "" "uint .size 3"
+        `shouldParse` Type1
+          (T2Name (Name "uint") Nothing)
+          (Just (CtrlOp (Name "size"), T2Value (VNum 3)))

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -4,13 +4,10 @@ module Main (main) where
 
 import Codec.CBOR.Cuddle.CDDL
 import Codec.CBOR.Cuddle.Parser
-import Control.Applicative hiding (some)
-import Data.Text (Text)
-import Data.Void
+import Data.List.NonEmpty qualified as NE
 import Test.Hspec
 import Test.Hspec.Megaparsec
 import Text.Megaparsec
-import Text.Megaparsec.Char
 
 main :: IO ()
 main = hspec $
@@ -33,6 +30,50 @@ main = hspec $
         parse pOccur "" "*9" `shouldParse` OIBounded Nothing (Just 9)
       it "Parses bounded on both sides" $
         parse pOccur "" "3*9" `shouldParse` OIBounded (Just 3) (Just 9)
+    nameSpec
+    type2Spec
 
 -- it "result of parsing satisfies what it should" $
 --   parse myParser "" "aaaa" `parseSatisfies` ((== 4) . length)
+
+nameSpec :: SpecWith ()
+nameSpec = describe "pName" $ do
+  it "Parses a boring name" $
+    parse pName "" "coin" `shouldParse` Name "coin"
+  it "Allows . in the middle" $
+    parse pName "" "coin.me" `shouldParse` Name "coin.me"
+  it "Allows $ as the last character" $
+    parse pName "" "coin.me$" `shouldParse` Name "coin.me$"
+  it "Doesn't allow . as a last character" $
+    parse pName "" "coin." `shouldFailWith` err 5 ueof
+
+type2Spec :: SpecWith ()
+type2Spec = describe "type2" $ do
+  describe "Value" $ do
+    it "Parses a value" $
+      parse pType2 "" "123" `shouldParse` T2Value (VNum 123)
+  describe "Map" $ do
+    it "Parses a basic group" $
+      parse pType2 "" "{ int => string }"
+        `shouldParse` T2Map
+          ( Group
+              ( NE.singleton
+                  [ GEType
+                      Nothing
+                      (Just (MKType (Type1 (T2Name (Name "int") Nothing) Nothing)))
+                      (Type0 (NE.singleton (Type1 (T2Name (Name "string") Nothing) Nothing)))
+                  ]
+              )
+          )
+    it "Parses a table" $
+      parse pType2 "" "{ * int => string }"
+        `shouldParse` T2Map
+          ( Group
+              ( NE.singleton
+                  [ GEType
+                      (Just OIZeroOrMore)
+                      (Just (MKType (Type1 (T2Name (Name "int") Nothing) Nothing)))
+                      (Type0 (NE.singleton (Type1 (T2Name (Name "string") Nothing) Nothing)))
+                  ]
+              )
+          )

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,4 +1,38 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 module Main (main) where
 
+import Codec.CBOR.Cuddle.CDDL
+import Codec.CBOR.Cuddle.Parser
+import Control.Applicative hiding (some)
+import Data.Text (Text)
+import Data.Void
+import Test.Hspec
+import Test.Hspec.Megaparsec
+import Text.Megaparsec
+import Text.Megaparsec.Char
+
 main :: IO ()
-main = putStrLn "Tests are yet to be implemented"
+main = hspec $
+  describe "cddlParser" $ do
+    describe "pValue" $ do
+      it "Parses integer" $
+        parse pValue "" "123" `shouldParse` VNum 123
+      it "Parses text" $
+        parse pValue "" "\"Hello World\"" `shouldParse` VText "Hello World"
+    describe "pOccur" $ do
+      it "Parses OneOrMore" $
+        parse pOccur "" "+" `shouldParse` OIOneOrMore
+      it "Parses ZeroOrMore" $
+        parse pOccur "" "*" `shouldParse` OIZeroOrMore
+      it "Parses Optional" $
+        parse pOccur "" "?" `shouldParse` OIOptional
+      it "Parses Lower Bounded" $
+        parse pOccur "" "3*" `shouldParse` OIBounded (Just 3) Nothing
+      it "Parses Upper Bounded" $
+        parse pOccur "" "*9" `shouldParse` OIBounded Nothing (Just 9)
+      it "Parses bounded on both sides" $
+        parse pOccur "" "3*9" `shouldParse` OIBounded (Just 3) (Just 9)
+
+-- it "result of parsing satisfies what it should" $
+--   parse myParser "" "aaaa" `parseSatisfies` ((== 4) . length)

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -17,6 +17,7 @@ main = hspec $
     nameSpec
     type2Spec
     grpEntrySpec
+    grpChoiceSpec
 
 valueSpec :: Spec
 valueSpec = describe "pValue" $ do
@@ -127,7 +128,7 @@ type2Spec = describe "type2" $ do
                   NE.:| [ [ GEType
                               Nothing
                               Nothing
-                              (Type0 (NE.singleton (Type1 (T2Value (VNum 0)) Nothing)))
+                              (Type0 (NE.singleton (Type1 (T2Value (VNum 1)) Nothing)))
                           ]
                         ]
               )
@@ -147,3 +148,31 @@ grpEntrySpec = describe "GroupEntry" $ do
                 NE.:| []
             )
         )
+  it "Should parse part of a group alternative" $
+    parse pGrpEntry "" "int // notConsideredHere"
+      `shouldParse` GEType
+        Nothing
+        Nothing
+        ( Type0
+            ( Type1
+                (T2Name (Name "int") Nothing)
+                Nothing
+                NE.:| []
+            )
+        )
+
+grpChoiceSpec :: SpecWith ()
+grpChoiceSpec = describe "GroupChoice" $ do
+  it "Should parse part of a group alternative" $
+    parse pGrpChoice "" "int // string"
+      `shouldParse` [ GEType
+                        Nothing
+                        Nothing
+                        ( Type0
+                            ( Type1
+                                (T2Name (Name "int") Nothing)
+                                Nothing
+                                NE.:| []
+                            )
+                        )
+                    ]


### PR DESCRIPTION
This PR adds a full CDDL Parser and pretty-printer. A test suite is included to cover various cases, though could still be expanded.

The pretty-printer could be made prettier!

The CtlOp code isn't yet used, but will be needed in order to define validation and then generation based on the CDDL.