### PR TITLE
Support comments in Huddle.

### DIFF
--- a/example/Conway.hs
+++ b/example/Conway.hs
@@ -546,7 +546,14 @@ transaction_witness_set =
 -- we need to hack around for tests in order to avoid generating duplicates,
 -- since the cddl tool we use for roundtrip testing doesn't generate distinct collections.
 plutus_v1_script :: Rule
-plutus_v1_script = "plutus_v1_script" =:= distinct VBytes
+plutus_v1_script =
+  comment
+    ( "The real type of  plutus_v1_script, plutus_v2_script and plutus_v3_script is bytes.\n"
+        <> "However, because we enforce uniqueness when many scripts are supplied,\n"
+        <> "we need to hack around for tests in order to avoid generating duplicates,\n"
+        <> "since the cddl tool we use for roundtrip testing doesn't generate distinct collections.\n"
+    )
+    $ "plutus_v1_script" =:= distinct VBytes
 
 plutus_v2_script :: Rule
 plutus_v2_script = "plutus_v2_script" =:= distinct VBytes
@@ -641,13 +648,14 @@ potential_languages = "potential_languages" =:= 0 ... 255
 --
 costmdls :: Rule
 costmdls =
-  "costmdls"
-    =:= mp
-      [ opt $ idx 0 ==> arr [166 <+ a VInt], -- Plutus v1, only 166 integers are used, but more are accepted (and ignored)
-        opt $ idx 1 ==> arr [175 <+ a VInt], -- Plutus v2, only 175 integers are used, but more are accepted (and ignored)
-        opt $ idx 2 ==> arr [223 <+ a VInt], -- Plutus v3, only 223 integers are used, but more are accepted (and ignored)
-        opt $ idx 3 ==> arr [a VInt] -- Any 8-bit unsigned number can be used as a key.
-      ]
+  comment "The format for costmdls is flexible enough to allow adding Plutus\n built-ins and language versions in the future." $
+    "costmdls"
+      =:= mp
+        [ opt $ idx 0 ==> arr [166 <+ a VInt], -- Plutus v1, only 166 integers are used, but more are accepted (and ignored)
+          opt $ idx 1 ==> arr [175 <+ a VInt], -- Plutus v2, only 175 integers are used, but more are accepted (and ignored)
+          opt $ idx 2 ==> arr [223 <+ a VInt], -- Plutus v3, only 223 integers are used, but more are accepted (and ignored)
+          opt $ idx 3 ==> arr [a VInt] -- Any 8-bit unsigned number can be used as a key.
+        ]
 
 transaction_metadatum :: Rule
 transaction_metadatum =
@@ -801,7 +809,18 @@ pool_metadata_hash = "pool_metadata_hash" =:= hash32
 --   "\x02" for Plutus V2 scripts
 --   "\x03" for Plutus V3 scripts
 scripthash :: Rule
-scripthash = "scripthash" =:= hash28
+scripthash =
+  comment
+    ( "To compute a script hash, note that you must prepend\n"
+        <> "a tag to the bytes of the script before hashing.\n"
+        <> "The tag is determined by the language.\n"
+        <> "The tags in the Conway era are:\n"
+        <> "\"\x00\" for multisig scripts\n"
+        <> "\"\x01\" for Plutus V1 scripts\n"
+        <> "\"\x02\" for Plutus V2 scripts\n"
+        <> "\"\x03\" for Plutus V3 scripts\n"
+    )
+    $ "scripthash" =:= hash28
 
 datum_hash :: Rule
 datum_hash = "datum_hash" =:= hash32

--- a/src/Codec/CBOR/Cuddle/CDDL.hs
+++ b/src/Codec/CBOR/Cuddle/CDDL.hs
@@ -9,8 +9,17 @@ import Data.List.NonEmpty qualified as NE
 import Data.Text qualified as T
 import GHC.Generics (Generic)
 
-newtype CDDL = CDDL (NE.NonEmpty Rule)
+newtype CDDL = CDDL (NE.NonEmpty (WithComments Rule))
   deriving (Eq, Generic, Show)
+
+data WithComments a = WithComments a (Maybe Comment)
+  deriving (Eq, Show, Generic)
+
+stripComment :: WithComments a -> a
+stripComment (WithComments a _) = a
+
+noComment :: a -> WithComments a
+noComment a = WithComments a Nothing
 
 -- |
 --  A name can consist of any of the characters from the set {"A" to

--- a/src/Codec/CBOR/Cuddle/CDDL/Resolve.hs
+++ b/src/Codec/CBOR/Cuddle/CDDL/Resolve.hs
@@ -81,7 +81,7 @@ parameters (Unparametrised _) = mempty
 parameters (Parametrised _ ps) = ps
 
 asMap :: CDDL -> CDDLMap
-asMap (CDDL rules) = foldl' assignOrExtend Map.empty rules
+asMap (CDDL rules) = foldl' assignOrExtend Map.empty (stripComment <$> rules)
   where
     assignOrExtend :: CDDLMap -> Rule -> CDDLMap
     assignOrExtend m (Rule n gps assign tog) = case assign of

--- a/src/Codec/CBOR/Cuddle/Parser.hs
+++ b/src/Codec/CBOR/Cuddle/Parser.hs
@@ -19,7 +19,7 @@ import Text.Megaparsec.Char.Lexer qualified as L
 type Parser = Parsec Void Text
 
 pCDDL :: Parser CDDL
-pCDDL = CDDL <$> (space *> NE.some (pRule <* space) <* eof)
+pCDDL = CDDL . fmap noComment <$> (space *> NE.some (pRule <* space) <* eof)
 
 pRule :: Parser Rule
 pRule =

--- a/src/Codec/CBOR/Cuddle/Pretty.hs
+++ b/src/Codec/CBOR/Cuddle/Pretty.hs
@@ -19,6 +19,15 @@ instance Pretty CDDL where
 
 deriving newtype instance Pretty Name
 
+instance (Pretty a) => Pretty (WithComments a) where
+  pretty (WithComments a Nothing) = pretty a
+  pretty (WithComments a (Just cmt)) = pretty cmt <> hardline <> pretty a
+
+instance Pretty Comment where
+  pretty (Comment t) =
+    let clines = T.splitOn "\n" t
+     in vsep $ fmap (("; " <>) . pretty) clines
+
 instance Pretty Rule where
   pretty (Rule n mgen assign tog) =
     pretty n <> pretty mgen <+> case tog of

--- a/test/Test/Codec/CBOR/Cuddle/CDDL/Gen.hs
+++ b/test/Test/Codec/CBOR/Cuddle/CDDL/Gen.hs
@@ -15,7 +15,7 @@ import Hedgehog.Gen qualified as Gen
 import Hedgehog.Range qualified as Range
 
 genCDDL :: (MonadGen m) => m CDDL
-genCDDL = CDDL <$> Gen.nonEmpty (Range.linear 1 15) genRule
+genCDDL = CDDL . fmap noComment <$> Gen.nonEmpty (Range.linear 1 15) genRule
 
 -- TODO Expand the range of names generated
 genName :: (MonadGen m) => m Name


### PR DESCRIPTION
This allows comments on top-level named entities,
using the `comment` combinator. We attempt to
render these nicely on multiple lines following
the line breaks added in the Haskell code.

Currently the parser does not support attaching
comments, so we do not test comment
round-tripping.

Addresses #19 