### PR TITLE
Support compilation under GHC8.10

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,2 @@
-use flake . --impure
+watch_file project.ncl
+use flake

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ["9.2.8", "9.6.3", "9.8.1"]
+        ghc: ["8.10.7", "9.2.8", "9.6.4", "9.8.1"]
         os: [ubuntu-latest]
     steps:
     - uses: actions/checkout@v3

--- a/bin/Main.hs
+++ b/bin/Main.hs
@@ -1,6 +1,4 @@
 {-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE OverloadedRecordDot #-}
-{-# LANGUAGE NoFieldSelectors #-}
 
 module Main (main) where
 
@@ -131,8 +129,8 @@ run (Opts cmd cddlFile) = do
         Left err -> putStrLnErr (show err) >> exitFailure
         Right mt -> do
           stdGen <- getStdGen
-          let term = generateCBORTerm mt (Name x.itemName) stdGen
-           in case x.outputFormat of
+          let term = generateCBORTerm mt (Name $ itemName x) stdGen
+           in case outputFormat x of
                 AsTerm -> print term
                 AsFlatTerm -> print $ toFlatTerm (encodeTerm term)
                 AsCBOR -> print . toStrictByteString $ encodeTerm term

--- a/cuddle.cabal
+++ b/cuddle.cabal
@@ -19,8 +19,29 @@ extra-doc-files: CHANGELOG.md
 common warnings
     ghc-options: -Wall
 
+common ghc2021
+    -- These options are all on by default in GHC2021, so once we drop GHC8 we
+    -- can remove this section.
+    default-extensions:
+        DataKinds
+        DeriveGeneric
+        DeriveTraversable
+        FlexibleContexts
+        FlexibleInstances
+        GeneralizedNewtypeDeriving
+        ImportQualifiedPost
+        InstanceSigs
+        MultiParamTypeClasses
+        NamedFieldPuns
+        PolyKinds
+        RankNTypes
+        ScopedTypeVariables
+        StandaloneDeriving
+        TypeApplications
+        TypeSynonymInstances
+
 library
-    import:           warnings
+    import:           warnings, ghc2021
     exposed-modules:
         Codec.CBOR.Cuddle.CBOR.Gen
         Codec.CBOR.Cuddle.CDDL
@@ -36,7 +57,7 @@ library
 
     -- other-extensions:
     build-depends:
-        , base                ^>=4.16.3.0 || ^>=4.18.1.0 || ^>=4.19.0.0
+        , base                ^>=4.14.3.0 || ^>=4.16.3.0 || ^>=4.18.1.0 || ^>=4.19.0.0
         , bytestring
         , capability
         , cborg
@@ -54,18 +75,18 @@ library
         , text
 
     hs-source-dirs:   src
-    default-language: GHC2021
+    default-language: Haskell2010
 
 executable example
-    import:           warnings
-    default-language: GHC2021
+    import:           warnings, ghc2021
+    default-language: Haskell2010
     other-modules:    Conway
 
     -- other-extensions:
     hs-source-dirs:   example
     main-is:          Main.hs
     build-depends:
-        , base           ^>=4.16.3.0 || ^>=4.18.1.0 || ^>=4.19.0.0
+        , base           ^>=4.14.3.0 || ^>=4.16.3.0 || ^>=4.18.1.0 || ^>=4.19.0.0
         , cuddle
         , megaparsec
         , prettyprinter
@@ -73,12 +94,12 @@ executable example
         , text
 
 executable cuddle
-    import:           warnings
-    default-language: GHC2021
+    import:           warnings, ghc2021
+    default-language: Haskell2010
     hs-source-dirs:   ./bin/
     main-is:          Main.hs
     build-depends:
-        , base                  ^>=4.16.3.0 || ^>=4.18.1.0 || ^>=4.19.0.0
+        , base                  ^>=4.14.3.0 || ^>=4.16.3.0 || ^>=4.18.1.0 || ^>=4.19.0.0
         , cborg
         , cuddle
         , megaparsec
@@ -88,8 +109,8 @@ executable cuddle
         , text
 
 test-suite cuddle-test
-    import:           warnings
-    default-language: GHC2021
+    import:           warnings, ghc2021
+    default-language: Haskell2010
     other-modules:
         Test.Codec.CBOR.Cuddle.CDDL.Gen
         Test.Codec.CBOR.Cuddle.CDDL.Parser
@@ -100,7 +121,7 @@ test-suite cuddle-test
     hs-source-dirs:   test
     main-is:          Main.hs
     build-depends:
-        , base              ^>=4.16.3.0 || ^>=4.18.1.0 || ^>=4.19.0.0
+        , base              ^>=4.14.3.0 || ^>=4.16.3.0 || ^>=4.18.1.0 || ^>=4.19.0.0
         , cuddle
         , hspec
         , hspec-megaparsec

--- a/flake.lock
+++ b/flake.lock
@@ -1,34 +1,31 @@
 {
   "nodes": {
-    "devenv": {
+    "fenix": {
       "inputs": {
-        "flake-compat": "flake-compat",
-        "nix": "nix",
         "nixpkgs": "nixpkgs",
-        "pre-commit-hooks": "pre-commit-hooks"
+        "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1703939110,
-        "narHash": "sha256-GgjYWkkHQ8pUBwXX++ah+4d07DqOeCDaaQL6Ab86C50=",
-        "owner": "cachix",
-        "repo": "devenv",
-        "rev": "7354096fc026f79645fdac73e9aeea71a09412c3",
+        "lastModified": 1713421495,
+        "narHash": "sha256-5vVF9W1tJT+WdfpWAEG76KywktKDAW/71mVmNHEHjac=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "fd47b1f9404fae02a4f38bd9f4b12bad7833c96b",
         "type": "github"
       },
       "original": {
-        "owner": "cachix",
-        "repo": "devenv",
+        "owner": "nix-community",
+        "repo": "fenix",
         "type": "github"
       }
     },
     "flake-compat": {
-      "flake": false,
       "locked": {
-        "lastModified": 1673956053,
-        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
         "type": "github"
       },
       "original": {
@@ -42,11 +39,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1685518550,
-        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
         "type": "github"
       },
       "original": {
@@ -55,183 +52,114 @@
         "type": "github"
       }
     },
-    "gitignore": {
-      "inputs": {
-        "nixpkgs": [
-          "devenv",
-          "pre-commit-hooks",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1660459072,
-        "narHash": "sha256-8DFJjXG8zqoONA1vXtgeKXy68KdJL5UaXR8NtVMUbx8=",
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "a20de23b925fd8264fd7fad6454652e142fd7f73",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "type": "github"
-      }
-    },
-    "lowdown-src": {
+    "nickel_src": {
       "flake": false,
       "locked": {
-        "lastModified": 1633514407,
-        "narHash": "sha256-Dw32tiMjdK9t3ETl5fzGrutQTzh2rufgZV4A/BbxuD4=",
-        "owner": "kristapsdz",
-        "repo": "lowdown",
-        "rev": "d2c2b44ff6c27b936ec27358a2653caaef8f73b8",
+        "lastModified": 1698331902,
+        "narHash": "sha256-BEqUDYIy9YCgdz0WPg6BTf88hRzW/hq9K7iqogQBpbs=",
+        "owner": "tweag",
+        "repo": "nickel",
+        "rev": "1921c316ad81bca8100c3a0c6ae2e3da974cdd51",
         "type": "github"
       },
       "original": {
-        "owner": "kristapsdz",
-        "repo": "lowdown",
-        "type": "github"
-      }
-    },
-    "nix": {
-      "inputs": {
-        "lowdown-src": "lowdown-src",
-        "nixpkgs": [
-          "devenv",
-          "nixpkgs"
-        ],
-        "nixpkgs-regression": "nixpkgs-regression"
-      },
-      "locked": {
-        "lastModified": 1676545802,
-        "narHash": "sha256-EK4rZ+Hd5hsvXnzSzk2ikhStJnD63odF7SzsQ8CuSPU=",
-        "owner": "domenkozar",
-        "repo": "nix",
-        "rev": "7c91803598ffbcfe4a55c44ac6d49b2cf07a527f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "domenkozar",
-        "ref": "relaxed-flakes",
-        "repo": "nix",
+        "owner": "tweag",
+        "repo": "nickel",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1678875422,
-        "narHash": "sha256-T3o6NcQPwXjxJMn2shz86Chch4ljXgZn746c2caGxd8=",
-        "owner": "NixOS",
+        "lastModified": 1713248628,
+        "narHash": "sha256-NLznXB5AOnniUtZsyy/aPWOk8ussTuePp2acb9U+ISA=",
+        "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "126f49a01de5b7e35a43fd43f891ecf6d3a51459",
+        "rev": "5672bc9dbf9d88246ddab5ac454e82318d094bb8",
         "type": "github"
       },
       "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-regression": {
-      "locked": {
-        "lastModified": 1643052045,
-        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
-        "type": "github"
-      }
-    },
-    "nixpkgs-stable": {
-      "locked": {
-        "lastModified": 1685801374,
-        "narHash": "sha256-otaSUoFEMM+LjBI1XL/xGB5ao6IwnZOXc47qhIgJe8U=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "c37ca420157f4abc31e26f436c1145f8951ff373",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-23.05",
+        "owner": "nixos",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1703992652,
-        "narHash": "sha256-C0o8AUyu8xYgJ36kOxJfXIroy9if/G6aJbNOpA5W0+M=",
+        "lastModified": 1713248628,
+        "narHash": "sha256-NLznXB5AOnniUtZsyy/aPWOk8ussTuePp2acb9U+ISA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "32f63574c85fbc80e4ba1fbb932cde9619bad25e",
+        "rev": "5672bc9dbf9d88246ddab5ac454e82318d094bb8",
         "type": "github"
       },
       "original": {
-        "owner": "NixOS",
-        "ref": "nixos-23.11",
-        "repo": "nixpkgs",
-        "type": "github"
+        "id": "nixpkgs",
+        "ref": "nixos-unstable",
+        "type": "indirect"
       }
     },
-    "pre-commit-hooks": {
-      "inputs": {
-        "flake-compat": [
-          "devenv",
-          "flake-compat"
-        ],
-        "flake-utils": "flake-utils",
-        "gitignore": "gitignore",
-        "nixpkgs": [
-          "devenv",
-          "nixpkgs"
-        ],
-        "nixpkgs-stable": "nixpkgs-stable"
-      },
+    "nixpkgs_3": {
       "locked": {
-        "lastModified": 1688056373,
-        "narHash": "sha256-2+SDlNRTKsgo3LBRiMUcoEUb6sDViRNQhzJquZ4koOI=",
-        "owner": "cachix",
-        "repo": "pre-commit-hooks.nix",
-        "rev": "5843cf069272d92b60c3ed9e55b7a8989c01d4c7",
+        "lastModified": 1698318101,
+        "narHash": "sha256-gUihHt3yPD7bVqg+k/UVHgngyaJ3DMEBchbymBMvK1E=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "63678e9f3d3afecfeafa0acead6239cdb447574c",
         "type": "github"
       },
       "original": {
-        "owner": "cachix",
-        "repo": "pre-commit-hooks.nix",
+        "id": "nixpkgs",
+        "ref": "nixos-unstable",
+        "type": "indirect"
+      }
+    },
+    "organist": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
+        "nickel_src": "nickel_src",
+        "nixpkgs": "nixpkgs_3"
+      },
+      "locked": {
+        "lastModified": 1711376357,
+        "narHash": "sha256-ZEKfiPM3Z59xp5lsQl+YdvxGUIs9QRKol+45I8k8wVc=",
+        "owner": "nickel-lang",
+        "repo": "organist",
+        "rev": "d69c758780974ed8729bb32e1f8642f61891b7a9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nickel-lang",
+        "repo": "organist",
         "type": "github"
       }
     },
     "root": {
       "inputs": {
-        "devenv": "devenv",
+        "fenix": "fenix",
         "nixpkgs": "nixpkgs_2",
-        "systems": "systems_2"
+        "organist": "organist"
       }
     },
-    "systems": {
+    "rust-analyzer-src": {
+      "flake": false,
       "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "lastModified": 1713373173,
+        "narHash": "sha256-octd9BFY9G/Gbr4KfwK4itZp4Lx+qvJeRRcYnN+dEH8=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "46702ffc1a02a2ac153f1d1ce619ec917af8f3a6",
         "type": "github"
       },
       "original": {
-        "owner": "nix-systems",
-        "repo": "default",
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
         "type": "github"
       }
     },
-    "systems_2": {
+    "systems": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -1,46 +1,13 @@
 {
-  inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.11";
-    systems.url = "github:nix-systems/default";
-    devenv.url = "github:cachix/devenv";
-  };
+  inputs.nixpkgs.url = "nixpkgs/nixos-unstable";
+  inputs.fenix.url = "github:nix-community/fenix";
+  inputs.organist.url = "github:nickel-lang/organist";
 
   nixConfig = {
-    extra-trusted-public-keys = "devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw=";
-    extra-substituters = "https://devenv.cachix.org";
+    extra-substituters = ["https://organist.cachix.org" "https://nix-community.cachix.org"];
+    extra-trusted-public-keys = ["organist.cachix.org-1:GB9gOx3rbGl7YEh6DwOscD1+E/Gc5ZCnzqwObNH2Faw=" "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="];
   };
 
-  outputs = { self, nixpkgs, devenv, systems, ... } @ inputs:
-    let
-      forEachSystem = nixpkgs.lib.genAttrs (import systems);
-    in
-    {
-      devShells = forEachSystem
-        (system:
-          let
-            pkgs = nixpkgs.legacyPackages.${system};
-            ghcver = "ghc963";
-          in
-          {
-            default = devenv.lib.mkShell {
-              inherit inputs pkgs;
-              modules = [
-                {
-                  # https://devenv.sh/reference/options/
-                  packages = with pkgs.haskell.packages.${ghcver};
-                    [ haskell-language-server
-                      ormolu
-                      pkgs.haskell.compiler.${ghcver}
-                      cabal-install
-                      cabal-fmt
-                      pkgs.cddl
-                    ];
-
-                  enterShell = ''
-                  '';
-                }
-              ];
-            };
-          });
-    };
+  outputs = {organist, ...} @ inputs:
+    organist.flake.outputsFromNickel ./. inputs {};
 }

--- a/nickel.lock.ncl
+++ b/nickel.lock.ncl
@@ -1,0 +1,3 @@
+{
+  organist = import "/nix/store/2r3m9zdvydnrlmh3mvk15m3xddxschgy-source/lib/organist.ncl",
+}

--- a/project.ncl
+++ b/project.ncl
@@ -1,0 +1,29 @@
+let inputs = import "./nickel.lock.ncl" in
+let organist = inputs.organist in
+
+let import_hs = fun ghcver pkgname =>
+  organist.import_nix "nixpkgs#haskell.packages.%{ghcver}.%{pkgname}"
+in
+let shellFor = fun ghcver =>
+  let hspkg = import_hs ghcver in {
+    packages = {
+      haskell-language-server = hspkg "haskell-language-server",
+      ormolu = hspkg "ormolu",
+      ghc = organist.import_nix "nixpkgs#haskell.compiler.%{ghcver}",
+      cabal-install = hspkg "cabal-install",
+      cabal-fmt = hspkg "cabal-fmt",
+      cddl = organist.import_nix "nixpkgs#cddl",
+    },
+  } in
+
+{
+  shells = organist.shells.Bash,
+
+  shells.build = {
+    packages = {},
+  },
+
+  shells.dev = shellFor "ghc964",
+
+}
+  | organist.OrganistExpression

--- a/src/Codec/CBOR/Cuddle/CBOR/Gen.hs
+++ b/src/Codec/CBOR/Cuddle/CBOR/Gen.hs
@@ -8,7 +8,6 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE ViewPatterns #-}
-{-# LANGUAGE NoFieldSelectors #-}
 {-# OPTIONS_GHC -Wno-unticked-promoted-constructors #-}
 
 -- | Generate example CBOR given a CDDL specification

--- a/src/Codec/CBOR/Cuddle/CDDL/CTree.hs
+++ b/src/Codec/CBOR/Cuddle/CDDL/CTree.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE NoFieldSelectors #-}
 
 module Codec.CBOR.Cuddle.CDDL.CTree where
 
@@ -53,19 +52,19 @@ traverseCTree atNode (Map xs) = Map <$> traverse atNode xs
 traverseCTree atNode (Array xs) = Array <$> traverse atNode xs
 traverseCTree atNode (Group xs) = Group <$> traverse atNode xs
 traverseCTree atNode (Choice xs) = Choice <$> traverse atNode xs
-traverseCTree atNode (KV k v cut) = do
+traverseCTree atNode (KV k v c) = do
   k' <- atNode k
   v' <- atNode v
-  pure $ KV k' v' cut
+  pure $ KV k' v' c
 traverseCTree atNode (Occur i occ) = flip Occur occ <$> atNode i
 traverseCTree atNode (Range f t inc) = do
   f' <- atNode f
   t' <- atNode t
   pure $ Range f' t' inc
-traverseCTree atNode (Control op t c) = do
+traverseCTree atNode (Control o t c) = do
   t' <- atNode t
   c' <- atNode c
-  pure $ Control op t' c'
+  pure $ Control o t' c'
 traverseCTree atNode (Enum ref) = Enum <$> atNode ref
 traverseCTree atNode (Unwrap ref) = Unwrap <$> atNode ref
 

--- a/test/Test/Codec/CBOR/Cuddle/CDDL/Parser.hs
+++ b/test/Test/Codec/CBOR/Cuddle/CDDL/Parser.hs
@@ -160,11 +160,11 @@ type2Spec = describe "type2" $ do
       parse pType2 "" "{ int => string }"
         `shouldParse` T2Map
           ( Group
-              ( NE.singleton
+              ( (NE.:| [])
                   [ GEType
                       Nothing
                       (Just (MKType (Type1 (T2Name (Name "int") Nothing) Nothing)))
-                      (Type0 (NE.singleton (Type1 (T2Name (Name "string") Nothing) Nothing)))
+                      (Type0 ((NE.:| []) (Type1 (T2Name (Name "string") Nothing) Nothing)))
                   ]
               )
           )
@@ -172,11 +172,11 @@ type2Spec = describe "type2" $ do
       parse pType2 "" "{ * int => string }"
         `shouldParse` T2Map
           ( Group
-              ( NE.singleton
+              ( (NE.:| [])
                   [ GEType
                       (Just OIZeroOrMore)
                       (Just (MKType (Type1 (T2Name (Name "int") Nothing) Nothing)))
-                      (Type0 (NE.singleton (Type1 (T2Name (Name "string") Nothing) Nothing)))
+                      (Type0 ((NE.:| []) (Type1 (T2Name (Name "string") Nothing) Nothing)))
                   ]
               )
           )
@@ -218,12 +218,12 @@ type2Spec = describe "type2" $ do
               ( [ GEType
                     Nothing
                     Nothing
-                    (Type0 (NE.singleton (Type1 (T2Value (VUInt 0)) Nothing)))
+                    (Type0 ((NE.:| []) (Type1 (T2Value (VUInt 0)) Nothing)))
                 ]
                   NE.:| [ [ GEType
                               Nothing
                               Nothing
-                              (Type0 (NE.singleton (Type1 (T2Value (VUInt 1)) Nothing)))
+                              (Type0 ((NE.:| []) (Type1 (T2Value (VUInt 1)) Nothing)))
                           ]
                         ]
               )


### PR DESCRIPTION
We also switch to organist, though it was unrelated in the end. Means we can avoid an extra nixpkgs pin, though.

Main change for GHC8 is that we can't use record field dot.