### PR TITLE
Huddle 'collectFrom' should traverse generics.

### DIFF
--- a/cuddle.cabal
+++ b/cuddle.cabal
@@ -1,6 +1,6 @@
 cabal-version:   3.4
 name:            cuddle
-version:         0.1.0.0
+version:         0.1.2.0
 synopsis:        CDDL Generator and test utilities
 
 -- description:

--- a/src/Codec/CBOR/Cuddle/Huddle.hs
+++ b/src/Codec/CBOR/Cuddle/Huddle.hs
@@ -814,6 +814,7 @@ collectFrom topR =
       when (HaskMap.notMember n gRules) $ do
         modify (over _3 $ HaskMap.insert n (fmap callToDef r))
         goT0 (body g)
+        mapM_ goT2 $ args g
     goT2 _ = pure ()
     goArrayEntry (ArrayEntry (Just k) t0 _) = goKey k >> goT0 t0
     goArrayEntry (ArrayEntry Nothing t0 _) = goT0 t0


### PR DESCRIPTION
Previously when calling 'collectFrom', rules which were referenced only as generic arguments to other rules were not being traversed.