### PR TITLE
Allow comments on group entries

### DIFF
--- a/example/Monad.hs
+++ b/example/Monad.hs
@@ -42,9 +42,9 @@ spec2 =
           _transaction <-
             "transaction"
               =:= mp
-                [ idx 0 ==> set txIn,
-                  idx 1 ==> set txOut,
-                  idx 2 ==> metadata
+                [ comment "Transaction inputs" $ idx 0 ==> set txIn,
+                  comment "Transaction outputs" $ idx 1 ==> set txOut,
+                  comment "Metadata" $ idx 2 ==> metadata
                 ]
           metadata <- "metadata" =:= VBytes
           _value <- "value" =:= mp ["token" ==> VText, "quantity" ==> VUInt]

--- a/src/Codec/CBOR/Cuddle/CDDL.hs
+++ b/src/Codec/CBOR/Cuddle/CDDL.hs
@@ -274,7 +274,7 @@ instance Hashable OccurrenceIndicator
 newtype Group = Group (NE.NonEmpty GrpChoice)
   deriving (Eq, Generic, Show, Semigroup)
 
-type GrpChoice = [GroupEntry]
+type GrpChoice = [WithComments GroupEntry]
 
 -- |
 --  A group entry can be given by a value type, which needs to be matched

--- a/src/Codec/CBOR/Cuddle/CDDL/Resolve.hs
+++ b/src/Codec/CBOR/Cuddle/CDDL/Resolve.hs
@@ -193,6 +193,9 @@ buildRefCTree rules = CTreeRoot $ fmap toCTreeRule rules
       It $ CTree.Postlude PTAny
     toCTreeT2 T2Any = It $ CTree.Postlude PTAny
 
+    toCTreeGroupEntryNC :: WithComments GroupEntry -> CTree.Node OrRef
+    toCTreeGroupEntryNC = toCTreeGroupEntry . stripComment 
+    
     toCTreeGroupEntry :: GroupEntry -> CTree.Node OrRef
     toCTreeGroupEntry (GEType (Just occi) mmkey t0) =
       It $
@@ -223,18 +226,18 @@ buildRefCTree rules = CTreeRoot $ fmap toCTreeRule rules
     -- choice options
     toCTreeEnum :: Group -> CTree.Node OrRef
     toCTreeEnum (Group (a NE.:| [])) =
-      It . CTree.Enum . It . CTree.Group $ fmap toCTreeGroupEntry a
+      It . CTree.Enum . It . CTree.Group $ fmap toCTreeGroupEntryNC a
     toCTreeEnum (Group xs) =
       It . CTree.Choice $
-        fmap (It . CTree.Enum . It . CTree.Group . fmap toCTreeGroupEntry) xs
+        fmap (It . CTree.Enum . It . CTree.Group . fmap toCTreeGroupEntryNC) xs
 
     -- Embed a group in another group, again floating out the choice options
     groupToGroup :: Group -> CTree.Node OrRef
     groupToGroup (Group (a NE.:| [])) =
-      It . CTree.Group $ fmap toCTreeGroupEntry a
+      It . CTree.Group $ fmap toCTreeGroupEntryNC a
     groupToGroup (Group xs) =
       It . CTree.Choice $
-        fmap (It . CTree.Group . fmap toCTreeGroupEntry) xs
+        fmap (It . CTree.Group . fmap toCTreeGroupEntryNC) xs
 
     toKVPair :: Maybe MemberKey -> Type0 -> CTree.Node OrRef
     toKVPair Nothing t0 = toCTreeT0 t0
@@ -249,20 +252,20 @@ buildRefCTree rules = CTreeRoot $ fmap toCTreeRule rules
 
     -- Interpret a group as a map. Note that we float out the choice options
     toCTreeMap :: Group -> CTree.Node OrRef
-    toCTreeMap (Group (a NE.:| [])) = It . CTree.Map $ fmap toCTreeGroupEntry a
+    toCTreeMap (Group (a NE.:| [])) = It . CTree.Map $ fmap toCTreeGroupEntryNC a
     toCTreeMap (Group xs) =
       It
         . CTree.Choice
-        $ fmap (It . CTree.Map . fmap toCTreeGroupEntry) xs
+        $ fmap (It . CTree.Map . fmap toCTreeGroupEntryNC) xs
 
     -- Interpret a group as an array. Note that we float out the choice
     -- options
     toCTreeArray :: Group -> CTree.Node OrRef
     toCTreeArray (Group (a NE.:| [])) =
-      It . CTree.Array $ fmap toCTreeGroupEntry a
+      It . CTree.Array $ fmap toCTreeGroupEntryNC a
     toCTreeArray (Group xs) =
       It . CTree.Choice $
-        fmap (It . CTree.Array . fmap toCTreeGroupEntry) xs
+        fmap (It . CTree.Array . fmap toCTreeGroupEntryNC) xs
 
     toCTreeMemberKey :: MemberKey -> CTree.Node OrRef
     toCTreeMemberKey (MKValue v) = It $ CTree.Literal v

--- a/src/Codec/CBOR/Cuddle/Parser.hs
+++ b/src/Codec/CBOR/Cuddle/Parser.hs
@@ -122,7 +122,11 @@ pGroup :: Parser Group
 pGroup = Group <$> NE.sepBy1 (space *> pGrpChoice <* space) (string "//")
 
 pGrpChoice :: Parser GrpChoice
-pGrpChoice = many ((space *> pGrpEntry <* space) <* optional (char ','))
+pGrpChoice =
+  many
+    ( (space *> (noComment <$> pGrpEntry) <* space)
+        <* optional (char ',')
+    )
 
 pGrpEntry :: Parser GroupEntry
 pGrpEntry =

--- a/test/Test/Codec/CBOR/Cuddle/CDDL/Gen.hs
+++ b/test/Test/Codec/CBOR/Cuddle/CDDL/Gen.hs
@@ -167,7 +167,7 @@ instance Arbitrary Group where
   shrink (Group gr) = Group <$> shrinkNE gr
 
 genGrpChoice :: Gen GrpChoice
-genGrpChoice = listOf' genGroupEntry
+genGrpChoice = listOf' (noComment <$> genGroupEntry)
 
 genGroupEntry :: Gen GroupEntry
 genGroupEntry =
@@ -240,6 +240,11 @@ genCtlOp =
 instance Arbitrary CtlOp where
   arbitrary = genCtlOp
   shrink = genericShrink
+
+instance Arbitrary a => Arbitrary (WithComments a) where
+  arbitrary = noComment <$> arbitrary
+  shrink (WithComments x _) = noComment <$> shrink x 
+
 
 --------------------------------------------------------------------------------
 -- Utility

--- a/test/Test/Codec/CBOR/Cuddle/CDDL/Parser.hs
+++ b/test/Test/Codec/CBOR/Cuddle/CDDL/Parser.hs
@@ -161,10 +161,11 @@ type2Spec = describe "type2" $ do
         `shouldParse` T2Map
           ( Group
               ( (NE.:| [])
-                  [ GEType
-                      Nothing
-                      (Just (MKType (Type1 (T2Name (Name "int") Nothing) Nothing)))
-                      (Type0 ((NE.:| []) (Type1 (T2Name (Name "string") Nothing) Nothing)))
+                  [ noComment $
+                      GEType
+                        Nothing
+                        (Just (MKType (Type1 (T2Name (Name "int") Nothing) Nothing)))
+                        (Type0 ((NE.:| []) (Type1 (T2Name (Name "string") Nothing) Nothing)))
                   ]
               )
           )
@@ -173,10 +174,11 @@ type2Spec = describe "type2" $ do
         `shouldParse` T2Map
           ( Group
               ( (NE.:| [])
-                  [ GEType
-                      (Just OIZeroOrMore)
-                      (Just (MKType (Type1 (T2Name (Name "int") Nothing) Nothing)))
-                      (Type0 ((NE.:| []) (Type1 (T2Name (Name "string") Nothing) Nothing)))
+                  [ noComment $
+                      GEType
+                        (Just OIZeroOrMore)
+                        (Just (MKType (Type1 (T2Name (Name "int") Nothing) Nothing)))
+                        (Type0 ((NE.:| []) (Type1 (T2Name (Name "string") Nothing) Nothing)))
                   ]
               )
           )
@@ -185,27 +187,29 @@ type2Spec = describe "type2" $ do
       parse pType2 "" "[int // string]"
         `shouldParse` T2Array
           ( Group
-              ( [ GEType
-                    Nothing
-                    Nothing
-                    ( Type0
-                        ( Type1
-                            (T2Name (Name "int") Nothing)
-                            Nothing
-                            NE.:| []
-                        )
-                    )
+              ( [ noComment $
+                    GEType
+                      Nothing
+                      Nothing
+                      ( Type0
+                          ( Type1
+                              (T2Name (Name "int") Nothing)
+                              Nothing
+                              NE.:| []
+                          )
+                      )
                 ]
-                  NE.:| [ [ GEType
-                              Nothing
-                              Nothing
-                              ( Type0
-                                  ( Type1
-                                      (T2Name (Name "string") Nothing)
-                                      Nothing
-                                      NE.:| []
-                                  )
-                              )
+                  NE.:| [ [ noComment $
+                              GEType
+                                Nothing
+                                Nothing
+                                ( Type0
+                                    ( Type1
+                                        (T2Name (Name "string") Nothing)
+                                        Nothing
+                                        NE.:| []
+                                    )
+                                )
                           ]
                         ]
               )
@@ -215,15 +219,17 @@ type2Spec = describe "type2" $ do
       parse pType2 "" "[0 // 1]"
         `shouldParse` T2Array
           ( Group
-              ( [ GEType
-                    Nothing
-                    Nothing
-                    (Type0 ((NE.:| []) (Type1 (T2Value (VUInt 0)) Nothing)))
+              ( [ noComment $
+                    GEType
+                      Nothing
+                      Nothing
+                      (Type0 ((NE.:| []) (Type1 (T2Value (VUInt 0)) Nothing)))
                 ]
-                  NE.:| [ [ GEType
-                              Nothing
-                              Nothing
-                              (Type0 ((NE.:| []) (Type1 (T2Value (VUInt 1)) Nothing)))
+                  NE.:| [ [ noComment $
+                              GEType
+                                Nothing
+                                Nothing
+                                (Type0 ((NE.:| []) (Type1 (T2Value (VUInt 1)) Nothing)))
                           ]
                         ]
               )
@@ -293,16 +299,17 @@ grpChoiceSpec :: SpecWith ()
 grpChoiceSpec = describe "GroupChoice" $ do
   it "Should parse part of a group alternative" $
     parse pGrpChoice "" "int // string"
-      `shouldParse` [ GEType
-                        Nothing
-                        Nothing
-                        ( Type0
-                            ( Type1
-                                (T2Name (Name "int") Nothing)
-                                Nothing
-                                NE.:| []
-                            )
-                        )
+      `shouldParse` [ noComment $
+                        GEType
+                          Nothing
+                          Nothing
+                          ( Type0
+                              ( Type1
+                                  (T2Name (Name "int") Nothing)
+                                  Nothing
+                                  NE.:| []
+                              )
+                          )
                     ]
 
 type1Spec :: Spec


### PR DESCRIPTION
This addresses part of #36 - comments are still not supported _everywhere_, but they are allowed on group entries, which represent the area (other than top-level rules) where comments are the most useful.

The same "comment" syntax is used as with top-level rules.

Note that this does not (yet) work within groups - that will be addressed as part of #32.

As yet, the parser still does not deal with comments, or attribute them to any entity. The tests are likewise oblivious to comments. But this does allow Huddle to define comments and have them reflected in the generated CDDL, which was the principal outcome.