### PR TITLE
Add upper bound for `random`

### DIFF
--- a/cuddle.cabal
+++ b/cuddle.cabal
@@ -75,7 +75,7 @@ library
     , ordered-containers
     , parser-combinators
     , prettyprinter
-    , random
+    , random              <1.3
     , text
 
   hs-source-dirs:   src


### PR DESCRIPTION
The project fails to build with `random 1.3.0` which will be selected by `cabal` unless we have this bound.