### PR TITLE
Markdown fixes and removed warning

### DIFF
--- a/cuddle.cabal
+++ b/cuddle.cabal
@@ -75,7 +75,7 @@ library
     , ordered-containers
     , parser-combinators
     , prettyprinter
-    , random
+    , random              <1.3
     , text
 
   hs-source-dirs:   src

--- a/docs/huddle.md
+++ b/docs/huddle.md
@@ -7,12 +7,12 @@ defining CDDL in Huddle.
 
 ## Core Types
 Huddle utilizes several core types to represent CDDL constructs:
-● Huddle: The top-level type representing a collection of rules.
-● HuddleItem: Represents individual items within a Huddle, such as rules, groups, or generic rules.
-● Rule: A named type definition.
-● Named: A type wrapper for associating a name, value, and optional description with an item.
-● Value: A type representing primitive CBOR values.
-● Group: Represents a collection of entries within a map or array.
+- Huddle: The top-level type representing a collection of rules.
+- HuddleItem: Represents individual items within a Huddle, such as rules, groups, or generic rules.
+- Rule: A named type definition.
+- Named: A type wrapper for associating a name, value, and optional description with an item.
+- Value: A type representing primitive CBOR values.
+- Group: Represents a collection of entries within a map or array.
 
 ## Language Extensions
 
@@ -96,9 +96,9 @@ choice =:= optionA / optionB
 ## Quantifiers
 Huddle provides functions to specify occurrence quantifiers for group entries
 and array elements:
-● <+: Lower bound
-● +>: Upper bound
-● opt: Optional (0 or 1 occurrences)
+- <+: Lower bound
+- +>: Upper bound
+- opt: Optional (0 or 1 occurrences)
 
 ### Example:
 ```haskell

--- a/docs/huddle.md
+++ b/docs/huddle.md
@@ -39,16 +39,18 @@ In addition, if using hlint, we suggest disabling the following hints:
 Rules are defined using the =:= operator. The left-hand side of the operator is
 the rule name (a T.Text value), and the right-hand side is the type definition.
 
-ruleName =:= typeDefinition
+`ruleName =:= typeDefinition`
 
 ### Example:
-`age =:= VUInt`
+```haskell
+age =:= VUInt
+```
 
 ## Maps
 Maps are defined using the mp function and the ==> operator to specify key-value
 pairs.
 
-mapName =:= mp [ key1 ==> value1, key2 ==> value2 ]
+`mapName =:= mp [ key1 ==> value1, key2 ==> value2 ]`
 
 ### Example:
 ```haskell
@@ -61,15 +63,19 @@ location =:= mp [
 ## Arrays
 Arrays are defined using the arr function and the a function to indicate array elements.
 
-arrayName =:= arr [ a element1, a element2 ]
+`arrayName =:= arr [ a element1, a element2 ]`
 
 ### Example:
+```haskell
 point =:= arr [ a int, a int ]
+```
+
 ## Groups
 Groups are collections of entries within maps or arrays. They can be named using
 the =:~ operator.
 
-groupName =:~ grp [ entry1, entry2 ]
+`groupName =:~ grp [ entry1, entry2 ]`
+
 ### Example:
 ```haskell
 personalinfo =:~ grp [
@@ -77,10 +83,15 @@ personalinfo =:~ grp [
   "age" ==> uint
 ]
 ```
+
 ## Choices
+
 Huddle represents choices between types using the / operator.
+
 ### Example:
+```haskell
 value =:= int / tstr
+```
 
 Huddle does not have a direct equivalent for the CDDL // operator (group
 choice). Instead, choices within arrays are represented by creating separate
@@ -96,9 +107,9 @@ choice =:= optionA / optionB
 ## Quantifiers
 Huddle provides functions to specify occurrence quantifiers for group entries
 and array elements:
-- <+: Lower bound
-- +>: Upper bound
-- opt: Optional (0 or 1 occurrences)
+- `<+`: Lower bound
+- `+>`: Upper bound
+- `opt`: Optional (0 or 1 occurrences)
 
 ### Example:
 ```haskell
@@ -112,7 +123,7 @@ which will be included as comments in the generated CDDL.
 ### Example:
 ```haskell
 person =:= comment "Represents a person" $ mp [
-  comment "Person's name" $ "name" ==> VBytes,
+  "name" ==> VBytes & comment "Person's name",
   "age" ==> VUIntf
 ]
 ```
@@ -129,11 +140,11 @@ message = binding $ \t -> "message" =:= {
 ```
   
 ## Converting to CDDL
-The toCDDL and toCDDLNoRoot functions convert a Huddle definition to CDDL.
-toCDDL generates a top-level root element, while toCDDLNoRoot skips the root
+The `toCDDL` and `toCDDLNoRoot` functions convert a Huddle definition to CDDL.
+`toCDDL` generates a top-level root element, while `toCDDLNoRoot` skips the root
 element.
 
 ## Example File (Conway.hs)
-The Conway.hs example file showcases a practical application of Huddle to define
-the CDDL for a specific data structure. The file defines numerous rules and
-groups using the Huddle syntax and functions described above.
+The `Conway.hs` example file showcases a practical application of Huddle to
+define the CDDL for a specific data structure. The file defines numerous rules
+and groups using the Huddle syntax and functions described above.

--- a/src/Codec/CBOR/Cuddle/CBOR/Gen.hs
+++ b/src/Codec/CBOR/Cuddle/CBOR/Gen.hs
@@ -123,7 +123,7 @@ instance (RandomGen r) => RandomGenM (CapGenM r) r (M r) where
   applyRandomGenM f _ = state @"randomSeed" f
 
 runGen :: M g a -> GenEnv g -> GenState g -> (a, GenState g)
-runGen (M m) env st = runReader (runStateT m st) env
+runGen m env st = runReader (runStateT (runM m) st) env
 
 evalGen :: M g a -> GenEnv g -> GenState g -> a
 evalGen m env = fst . runGen m env
@@ -165,19 +165,6 @@ genBytes n = asksM @"fakeSeed" $ uniformByteStringM n
 
 genText :: forall g. (RandomGen g) => Int -> M g Text
 genText n = pure $ T.pack . take n . join $ repeat ['a' .. 'z']
-
---------------------------------------------------------------------------------
--- Combinators
---------------------------------------------------------------------------------
-
-choose :: (RandomGen g) => [a] -> M g a
-choose xs = genUniformRM (0, length xs) >>= \i -> pure $ xs !! i
-
-oneOf :: (RandomGen g) => [M g a] -> M g a
-oneOf xs = genUniformRM (0, length xs) >>= \i -> xs !! i
-
-oneOfGenerated :: (RandomGen g) => M g [a] -> M g a
-oneOfGenerated genXs = genXs >>= choose
 
 --------------------------------------------------------------------------------
 -- Postlude


### PR DESCRIPTION
Small changes to the markup in `docs/huddle.md` as I was reading through it, along with fixes to the build (see also #51) and warnings removed.