### PR TITLE
Added CDDL prelude, improved parser

### DIFF
--- a/cuddle.cabal
+++ b/cuddle.cabal
@@ -47,6 +47,7 @@ library
     Codec.CBOR.Cuddle.CDDL
     Codec.CBOR.Cuddle.CDDL.CtlOp
     Codec.CBOR.Cuddle.CDDL.CTree
+    Codec.CBOR.Cuddle.CDDL.Prelude
     Codec.CBOR.Cuddle.CDDL.Postlude
     Codec.CBOR.Cuddle.CDDL.Resolve
     Codec.CBOR.Cuddle.Huddle
@@ -76,6 +77,7 @@ library
     , parser-combinators
     , prettyprinter
     , random              <1.3
+    , scientific
     , text
 
   hs-source-dirs:   src
@@ -120,6 +122,7 @@ test-suite cuddle-test
   other-modules:
     Test.Codec.CBOR.Cuddle.CDDL.Gen
     Test.Codec.CBOR.Cuddle.CDDL.Parser
+    Test.Codec.CBOR.Cuddle.CDDL.Examples
     Test.Codec.CBOR.Cuddle.Huddle
 
   -- other-extensions:

--- a/example/cddl-files/byron.cddl
+++ b/example/cddl-files/byron.cddl
@@ -1,0 +1,209 @@
+; Cardano Byron blockchain CBOR schema
+
+block = [0, ebblock]
+      / [1, mainblock]
+
+mainblock = [ "header" : blockhead
+            , "body" : blockbody
+            , "extra" : [attributes]
+            ]
+
+ebblock = [ "header" : ebbhead
+          , "body" : [+ stakeholderid]
+          , extra : [attributes]
+          ]
+
+u8 = uint .lt 256
+u16 = uint .lt 65536
+u32 = uint
+u64 = uint
+
+; Basic Cardano Types
+
+blake2b-256 = bytes .size 32
+
+txid = blake2b-256
+blockid = blake2b-256
+updid = blake2b-256
+hash = blake2b-256
+
+blake2b-224 = bytes .size 28
+
+addressid = blake2b-224
+stakeholderid = blake2b-224
+
+epochid = u64
+slotid = [ epoch: epochid, slot : u64 ]
+
+pubkey = bytes
+signature = bytes
+
+; Attributes - at the moment we do not bother deserialising these, since they
+; don't contain anything
+
+attributes = {* any => any}
+
+; Addresses
+
+addrdistr = [1] / [0, stakeholderid]
+
+addrtype = &("PubKey" : 0, "Script" : 1, "Redeem" : 2) / (u64 .gt 2)
+addrattr = { ? 0 : addrdistr
+           , ? 1 : bytes}
+address = [ #6.24(bytes .cbor ([addressid, addrattr, addrtype])), u64 ]
+
+; Transactions
+
+txin = [0, #6.24(bytes .cbor ([txid, u32]))] / [u8 .ne 0, encoded-cbor]
+txout = [address, u64]
+
+tx = [[+ txin], [+ txout], attributes]
+
+txproof = [u32, hash, hash]
+
+twit = [0, #6.24(bytes .cbor ([pubkey, signature]))]
+     / [1, #6.24(bytes .cbor ([[u16, bytes], [u16, bytes]]))]
+     / [2, #6.24(bytes .cbor ([pubkey, signature]))]
+     / [u8 .gt 2, encoded-cbor]
+
+; Shared Seed Computation
+
+vsspubkey = bytes ; This is encoded using the 'Binary' instance
+                  ; for Scrape.PublicKey
+vsssec = bytes ; This is encoded using the 'Binary' instance
+               ; for Scrape.Secret.
+vssenc = [bytes] ; This is encoded using the 'Binary' instance
+                 ; for Scrape.EncryptedSi.
+                 ; TODO work out why this seems to be in a length 1 array
+vssdec = bytes ; This is encoded using the 'Binary' instance
+               ; for Scrape.DecryptedShare
+vssproof = [bytes, bytes, bytes, [* bytes]] ; This is encoded using the
+                                            ; 'Binary' instance for Scrape.Proof
+
+ssccomm = [pubkey, [{vsspubkey => vssenc},vssproof], signature]
+ssccomms = #6.258([* ssccomm])
+
+sscopens = {stakeholderid => vsssec}
+
+sscshares = {addressid => [addressid, [* vssdec]]}
+
+ssccert = [vsspubkey, pubkey, epochid, signature]
+ssccerts = #6.258([* ssccert])
+
+ssc = [0, ssccomms, ssccerts]
+    / [1, sscopens, ssccerts]
+    / [2, sscshares, ssccerts]
+    / [3, ssccerts]
+
+sscproof = [0, hash, hash]
+         / [1, hash, hash]
+         / [2, hash, hash]
+         / [3, hash]
+
+; Delegation
+
+dlg = [ epoch : epochid
+      , issuer : pubkey
+      , delegate : pubkey
+      , certificate : signature
+      ]
+
+dlgsig = [dlg, signature]
+
+lwdlg = [ epochRange : [epochid, epochid]
+        , issuer : pubkey
+        , delegate : pubkey
+        , certificate : signature
+        ]
+
+lwdlgsig = [lwdlg, signature]
+
+; Updates
+
+bver = [u16, u16, u8]
+
+txfeepol = [0, #6.24(bytes .cbor ([bigint, bigint]))]
+         / [u8 .gt 0, encoded-cbor]
+
+bvermod = [ scriptVersion : [? u16]
+          , slotDuration : [? bigint]
+          , maxBlockSize : [? bigint]
+          , maxHeaderSize  : [? bigint]
+          , maxTxSize : [? bigint]
+          , maxProposalSize : [? bigint]
+          , mpcThd : [? u64]
+          , heavyDelThd : [? u64]
+          , updateVoteThd : [? u64]
+          , updateProposalThd : [? u64]
+          , updateImplicit : [? u64]
+          , softForkRule : [? [u64, u64, u64]]
+          , txFeePolicy : [? txfeepol]
+          , unlockStakeEpoch : [? epochid]
+          ]
+
+updata = [ hash, hash, hash, hash ]
+
+upprop = [ "blockVersion" : bver
+         , "blockVersionMod" : bvermod
+         , "softwareVersion" : [ text, u32 ]
+         , "data" : #6.258([text, updata])
+         , "attributes" : attributes
+         , "from" : pubkey
+         , "signature" : signature
+         ]
+
+upvote = [ "voter" : pubkey
+         , "proposalId" : updid
+         , "vote" : bool
+         , "signature" : signature
+         ]
+
+up = [ "proposal" :  [? upprop]
+     , votes : [* upvote]
+     ]
+
+; Blocks
+
+difficulty = [u64]
+
+blocksig = [0, signature]
+         / [1, lwdlgsig]
+         / [2, dlgsig]
+
+blockcons = [slotid, pubkey, difficulty, blocksig]
+
+blockheadex = [ "blockVersion" : bver
+              , "softwareVersion" : [ text, u32 ]
+              , "attributes" : attributes
+              , "extraProof" : hash
+              ]
+
+blockproof = [ "txProof" : txproof
+             , "sscProof" : sscproof
+             , "dlgProof" : hash
+             , "updProof" : hash
+             ]
+
+blockhead = [ "protocolMagic" : u32
+            , "prevBlock" : blockid
+            , "bodyProof" : blockproof
+            , "consensusData" : blockcons
+            , "extraData" : blockheadex
+            ]
+
+blockbody = [ "txPayload" : [* [tx, [* twit]]]
+            , "sscPayload" : ssc
+            , "dlgPayload" : [* dlg]
+            , "updPayload" : up
+            ]
+
+; Epoch Boundary Blocks
+
+ebbcons = [ epochid, difficulty ]
+
+ebbhead = [ "protocolMagic" : u32
+          , "prevBlock" : blockid
+          , "bodyProof" : hash
+          , "consensusData" : ebbcons
+          , "extraData" : [attributes]
+          ]

--- a/example/cddl-files/conway.cddl
+++ b/example/cddl-files/conway.cddl
@@ -1,3 +1,83 @@
+; crypto.cddl
+$hash28 /= bytes .size 28
+$hash32 /= bytes .size 32
+
+$vkey /= bytes .size 32
+
+$vrf_vkey /= bytes .size 32
+$vrf_cert /= [bytes, bytes .size 80]
+
+$kes_vkey /= bytes .size 32
+$kes_signature /= bytes .size 448
+signkeyKES = bytes .size 64
+
+$signature /= bytes .size 64
+
+; extra.cddl
+; Conway era introduces an optional 258 tag for sets, which will become mandatory in the
+; second era after Conway. We recommend all the tooling to account for this future breaking
+; change sooner rather than later, in order to provide a smooth transition for their users.
+
+; This is an unordered set. Duplicate elements are not allowed and the order of elements is implementation specific.
+set<a> = #6.258([* a]) / [* a]
+
+; Just like `set`, but must contain at least one element.
+nonempty_set<a> = #6.258([+ a]) / [+ a]
+
+; This is a non-empty ordered set. Duplicate elements are not allowed and the order of elements will be preserved.
+nonempty_oset<a> = #6.258([+ a]) / [+ a]
+
+positive_int = 1 .. 18446744073709551615
+
+unit_interval = #6.30([1, 2])
+  ; unit_interval = #6.30([uint, uint])
+  ;
+  ; Comment above depicts the actual definition for `unit_interval`.
+  ;
+  ; Unit interval is a number in the range between 0 and 1, which
+  ; means there are two extra constraints:
+  ; * numerator <= denominator
+  ; * denominator > 0
+  ;
+  ; Relation between numerator and denominator cannot be expressed in CDDL, which
+  ; poses a problem for testing. We need to be able to generate random valid data
+  ; for testing implementation of our encoders/decoders. Which means we cannot use
+  ; the actual definition here and we hard code the value to 1/2
+
+
+nonnegative_interval = #6.30([uint, positive_int])
+
+
+address =
+  h'001000000000000000000000000000000000000000000000000000000011000000000000000000000000000000000000000000000000000000' /
+  h'102000000000000000000000000000000000000000000000000000000022000000000000000000000000000000000000000000000000000000' /
+  h'203000000000000000000000000000000000000000000000000000000033000000000000000000000000000000000000000000000000000000' /
+  h'304000000000000000000000000000000000000000000000000000000044000000000000000000000000000000000000000000000000000000' /
+  h'405000000000000000000000000000000000000000000000000000000087680203' /
+  h'506000000000000000000000000000000000000000000000000000000087680203' /
+  h'6070000000000000000000000000000000000000000000000000000000' /
+  h'7080000000000000000000000000000000000000000000000000000000'
+
+reward_account =
+  h'E090000000000000000000000000000000000000000000000000000000' /
+  h'F0A0000000000000000000000000000000000000000000000000000000'
+
+bounded_bytes = bytes .size (0..64)
+  ; the real bounded_bytes does not have this limit. it instead has a different
+  ; limit which cannot be expressed in CDDL.
+  ; The limit is as follows:
+  ;  - bytes with a definite-length encoding are limited to size 0..64
+  ;  - for bytes with an indefinite-length CBOR encoding, each chunk is
+  ;    limited to size 0..64
+  ;  ( reminder: in CBOR, the indefinite-length encoding of bytestrings
+  ;    consists of a token #2.31 followed by a sequence of definite-length
+  ;    encoded bytestrings and a stop code )
+
+; a type for distinct values.
+; The type parameter must support .size, for example: bytes or uint
+distinct<a> = a .size 8 / a .size 16 / a .size 20 / a .size 24 / a .size 30 / a .size 32
+
+; conway.cddl
 block =
   [ header
   , transaction_bodies         : [* transaction_body]
@@ -87,9 +167,9 @@ proposal_procedure =
   , anchor
   ]
 
-proposal_procedures = nonempty_oset<proposal_procedure>
+proposal_procedures = nonempty_set<proposal_procedure>
 
-certificates = nonempty_oset<certificate>
+certificates = nonempty_set<certificate>
 
 gov_action =
   [ parameter_change_action

--- a/src/Codec/CBOR/Cuddle/CDDL/Prelude.hs
+++ b/src/Codec/CBOR/Cuddle/CDDL/Prelude.hs
@@ -1,0 +1,63 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Codec.CBOR.Cuddle.CDDL.Prelude (prependPrelude) where
+
+import Codec.CBOR.Cuddle.CDDL (CDDL (..))
+import Codec.CBOR.Cuddle.Parser (pCDDL)
+import Text.Megaparsec (parse)
+
+-- TODO switch to quasiquotes
+cddlPrelude :: CDDL
+cddlPrelude =
+  either (error . show) id $
+    parse
+      pCDDL
+      "<HARDCODED>"
+      " any = # \
+      \ uint = #0 \
+      \ nint = #1 \
+      \ int = uint / nint \
+      \ \
+      \ bstr = #2 \
+      \ bytes = bstr \
+      \ tstr = #3 \
+      \ text = tstr \
+      \ \
+      \ tdate = #6.0(tstr) \
+      \ time = #6.1(number) \
+      \ number = int / float \
+      \ biguint = #6.2(bstr) \
+      \ bignint = #6.3(bstr) \
+      \ bigint = biguint / bignint \
+      \ integer = int / bigint \
+      \ unsigned = uint / biguint \
+      \ decfrac = #6.4([e10: int, m: integer]) \
+      \ bigfloat = #6.5([e2: int, m: integer]) \
+      \ eb64url = #6.21(any) \
+      \ eb64legacy = #6.22(any) \
+      \ eb16 = #6.23(any) \
+      \ encoded-cbor = #6.24(bstr) \
+      \ uri = #6.32(tstr) \
+      \ b64url = #6.33(tstr) \
+      \ b64legacy = #6.34(tstr) \
+      \ regexp = #6.35(tstr) \
+      \ mime-message = #6.36(tstr) \
+      \ cbor-any = #6.55799(any) \
+      \ float16 = #7.25 \
+      \ float32 = #7.26 \
+      \ float64 = #7.27 \
+      \ float16-32 = float16 / float32 \
+      \ float32-64 = float32 / float64 \
+      \ float = float16-32 / float64 \
+      \  \
+      \ false = #7.20 \
+      \ true = #7.21 \
+      \ bool = false / true \
+      \ nil = #7.22 \
+      \ null = nil \
+      \ undefined = #7.23"
+
+prependPrelude :: CDDL -> CDDL
+prependPrelude (CDDL rules) =
+  let CDDL preludeRules = cddlPrelude
+   in CDDL $ preludeRules <> rules

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,11 +1,20 @@
 module Main (main) where
 
+import Test.Codec.CBOR.Cuddle.CDDL.Examples qualified as Examples
 import Test.Codec.CBOR.Cuddle.CDDL.Parser (parserSpec)
 import Test.Codec.CBOR.Cuddle.Huddle (huddleSpec)
 import Test.Hspec
+import Test.Hspec.Runner
+
+hspecConfig :: Config
+hspecConfig =
+  defaultConfig
+    { configColorMode = ColorAlways
+    }
 
 main :: IO ()
 main =
-  hspec $ do
+  hspecWith hspecConfig $ do
     describe "cddlParser" parserSpec
     describe "Huddle" huddleSpec
+    describe "Examples" Examples.spec

--- a/test/Test/Codec/CBOR/Cuddle/CDDL/Examples.hs
+++ b/test/Test/Codec/CBOR/Cuddle/CDDL/Examples.hs
@@ -1,0 +1,27 @@
+module Test.Codec.CBOR.Cuddle.CDDL.Examples (spec) where
+
+import Codec.CBOR.Cuddle.CDDL.Prelude (prependPrelude)
+import Codec.CBOR.Cuddle.CDDL.Resolve (fullResolveCDDL)
+import Codec.CBOR.Cuddle.Parser (pCDDL)
+import Data.Either (isRight)
+import Data.Text.IO qualified as T
+import Test.Hspec
+import Text.Megaparsec (parse)
+import Text.Megaparsec.Error (errorBundlePretty)
+
+validateFile :: FilePath -> Spec
+validateFile filePath = it ("Successfully validates " <> filePath) $ do
+  contents <- T.readFile filePath
+  cddl <- case parse pCDDL "" contents of
+    Right x -> pure $ prependPrelude x
+    Left x -> fail $ "Failed to parse the file:\n" <> errorBundlePretty x
+  fullResolveCDDL cddl `shouldSatisfy` isRight
+
+spec :: Spec
+spec = do
+  validateFile "example/cddl-files/byron.cddl"
+  validateFile "example/cddl-files/conway.cddl"
+  validateFile "example/cddl-files/shelley.cddl"
+
+-- TODO this one does not seem to terminate
+-- validateFile "example/cddl-files/basic_assign.cddl"


### PR DESCRIPTION
This PR adds the CDDL prelude, which is now included automatically when verifying a CDDL file. The prelude can be omitted with the `--no-prelude` option in `cuddle`.

I added some tests and discovered a few problems with the parsers, which I also fixed in this PR. I also made lexing more efficient by replacing `many . satisfy` and `some . satisfy` with `takeWhileP` and `takeWhileP1` respectively. I also pushed `try`s deeper in a couple of places to reduce backtracking.

close #53