### PR TITLE
Hex-encode the CBOR output

### DIFF
--- a/bin/Main.hs
+++ b/bin/Main.hs
@@ -14,6 +14,8 @@ import Codec.CBOR.FlatTerm (toFlatTerm)
 import Codec.CBOR.Pretty (prettyHexEnc)
 import Codec.CBOR.Term (encodeTerm)
 import Codec.CBOR.Write (toStrictByteString)
+import Data.ByteString.Base16 qualified as Base16
+import Data.ByteString.Char8 qualified as BSC
 import Data.Text qualified as T
 import Data.Text.IO qualified as T
 import Options.Applicative
@@ -153,7 +155,7 @@ run (Opts cmd cddlFile) = do
            in case outputFormat x of
                 AsTerm -> print term
                 AsFlatTerm -> print $ toFlatTerm (encodeTerm term)
-                AsCBOR -> print . toStrictByteString $ encodeTerm term
+                AsCBOR -> BSC.putStrLn . Base16.encode . toStrictByteString $ encodeTerm term
                 AsPrettyCBOR -> putStrLn . prettyHexEnc $ encodeTerm term
 
 putStrLnErr :: String -> IO ()

--- a/cuddle.cabal
+++ b/cuddle.cabal
@@ -47,8 +47,8 @@ library
     Codec.CBOR.Cuddle.CDDL
     Codec.CBOR.Cuddle.CDDL.CtlOp
     Codec.CBOR.Cuddle.CDDL.CTree
-    Codec.CBOR.Cuddle.CDDL.Prelude
     Codec.CBOR.Cuddle.CDDL.Postlude
+    Codec.CBOR.Cuddle.CDDL.Prelude
     Codec.CBOR.Cuddle.CDDL.Resolve
     Codec.CBOR.Cuddle.Huddle
     Codec.CBOR.Cuddle.Huddle.HuddleM
@@ -108,6 +108,8 @@ executable cuddle
   main-is:          Main.hs
   build-depends:
     , base                  >=4.14.0.0
+    , base16-bytestring
+    , bytestring
     , cborg
     , cuddle
     , megaparsec
@@ -120,9 +122,9 @@ test-suite cuddle-test
   import:           warnings, ghc2021
   default-language: Haskell2010
   other-modules:
+    Test.Codec.CBOR.Cuddle.CDDL.Examples
     Test.Codec.CBOR.Cuddle.CDDL.Gen
     Test.Codec.CBOR.Cuddle.CDDL.Parser
-    Test.Codec.CBOR.Cuddle.CDDL.Examples
     Test.Codec.CBOR.Cuddle.Huddle
 
   -- other-extensions:


### PR DESCRIPTION
The Haskell specific escaped show instance is less useful and using hex encoding is the most common way to share CBOR encoded bytes (at least in the Cardano ecosystem).

Before:
```
λ cabal exec cuddle -- gen -r msgResult foo.cddl
"\130\EOT\193\ESC~\220\200\203\246&b&"
```


After:

```
λ cabal exec cuddle -- gen -r msgResult foo.cddl          
8204c1fa3c4606c0
```