### PR TITLE
Improved pretty printing

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,4 @@
+packages:
+  .
+
+test-show-details: streaming

--- a/cuddle.cabal
+++ b/cuddle.cabal
@@ -17,7 +17,7 @@ extra-doc-files: CHANGELOG.md
 -- extra-source-files:
 
 common warnings
-  ghc-options: -Wall
+  ghc-options: -Wall -Werror
 
 common ghc2021
   -- These options are all on by default in GHC2021, so once we drop GHC8 we
@@ -68,6 +68,7 @@ library
     , cborg
     , containers
     , data-default-class
+    , foldable1-classes-compat
     , generic-optics
     , hashable
     , megaparsec
@@ -80,6 +81,7 @@ library
     , random              <1.3
     , scientific
     , text
+    , tree-diff
 
   hs-source-dirs:   src
   default-language: Haskell2010
@@ -141,3 +143,4 @@ test-suite cuddle-test
     , prettyprinter
     , QuickCheck
     , text
+    , tree-diff

--- a/example/cddl-files/basic_assign.cddl
+++ b/example/cddl-files/basic_assign.cddl
@@ -33,3 +33,20 @@ set<a> = [ * a]
 set2<a> = set<a>
 
 coin_bag = set2<coin>
+
+big_group = (
+  "hello",
+  32,
+  8* 4,
+  & group,
+  uint,
+  unit_interval<uint>,
+  5 ...10,
+  h'11aaff3351bc'
+)
+
+test = ~ aaaa .. "j" / 
+# /
+{xco, lhXH // // } .cborseq # /
+& (* kkhw // // ) /
+"b"

--- a/example/cddl-files/conway.cddl
+++ b/example/cddl-files/conway.cddl
@@ -546,8 +546,7 @@ constr<a> =
   / #6.124([* a])
   / #6.125([* a])
   / #6.126([* a])
-  / #6.127([* a])
-  ; similarly for tag range: 6.1280 .. 6.1400 inclusive
+  / #6.127([* a]) ; similarly for tag range: 6.1280 .. 6.1400 inclusive
   / #6.102([uint, [* a]])
 
 redeemers =

--- a/example/cddl-files/pretty.cddl
+++ b/example/cddl-files/pretty.cddl
@@ -1,0 +1,11 @@
+a = [ 2*30 2 : uint
+  , ? 33 : bytes
+  , 4444 : set<uint>
+  , * 55 => uint
+  ]
+
+b = [1,uint,(3,4)]
+
+c = { x 
+, y ; hello
+}

--- a/src/Codec/CBOR/Cuddle/CDDL/CtlOp.hs
+++ b/src/Codec/CBOR/Cuddle/CDDL/CtlOp.hs
@@ -1,6 +1,10 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DerivingStrategies #-}
+
 module Codec.CBOR.Cuddle.CDDL.CtlOp where
 
 import Data.Hashable (Hashable)
+import Data.TreeDiff (ToExpr)
 import GHC.Generics (Generic)
 
 -- | A _control_ allows relating a _target_ type with a _controller_ type
@@ -31,5 +35,6 @@ data CtlOp
   | Ne
   | Default
   deriving (Eq, Generic, Show)
+  deriving anyclass (ToExpr)
 
 instance Hashable CtlOp

--- a/src/Codec/CBOR/Cuddle/CDDL/Prelude.hs
+++ b/src/Codec/CBOR/Cuddle/CDDL/Prelude.hs
@@ -4,12 +4,12 @@ module Codec.CBOR.Cuddle.CDDL.Prelude (prependPrelude) where
 
 import Codec.CBOR.Cuddle.CDDL (CDDL (..))
 import Codec.CBOR.Cuddle.Parser (pCDDL)
-import Text.Megaparsec (parse)
+import Text.Megaparsec (errorBundlePretty, parse)
 
 -- TODO switch to quasiquotes
 cddlPrelude :: CDDL
 cddlPrelude =
-  either (error . show) id $
+  either (error . errorBundlePretty) id $
     parse
       pCDDL
       "<HARDCODED>"

--- a/src/Codec/CBOR/Cuddle/CDDL/Resolve.hs
+++ b/src/Codec/CBOR/Cuddle/CDDL/Resolve.hs
@@ -82,8 +82,11 @@ parameters (Unparametrised _) = mempty
 parameters (Parametrised _ ps) = ps
 
 asMap :: CDDL -> CDDLMap
-asMap (CDDL rules) = foldl' assignOrExtend Map.empty (stripComment <$> rules)
+asMap (CDDL rules) = foldl' go Map.empty rules
   where
+    go x (TopLevelComment _) = x
+    go x (TopLevelRule _ r _) = assignOrExtend x r
+
     assignOrExtend :: CDDLMap -> Rule -> CDDLMap
     assignOrExtend m (Rule n gps assign tog) = case assign of
       -- Equals assignment

--- a/src/Codec/CBOR/Cuddle/Pretty.hs
+++ b/src/Codec/CBOR/Cuddle/Pretty.hs
@@ -8,31 +8,52 @@ module Codec.CBOR.Cuddle.Pretty where
 import Codec.CBOR.Cuddle.CDDL
 import Codec.CBOR.Cuddle.CDDL.CtlOp (CtlOp)
 import Data.ByteString.Char8 qualified as BS
+import Data.Foldable (Foldable (..))
 import Data.List.NonEmpty qualified as NE
-import Data.Maybe (catMaybes)
+import Data.Maybe (isJust)
 import Data.String (fromString)
 import Data.Text qualified as T
 import Prettyprinter
+import Prettyprinter.Render.Text (renderStrict)
 
 instance Pretty CDDL where
-  pretty (CDDL (NE.toList -> xs)) = vsep . punctuate hardline $ fmap pretty xs
+  pretty (CDDL (NE.toList -> xs)) = vsep $ fmap pretty xs
+
+instance Pretty TopLevel where
+  pretty (TopLevelComment cmt) = pretty cmt
+  pretty (TopLevelRule pre x post) = pretty pre <> pretty x <> post' <> hardline
+    where
+      post' =
+        case post of
+          Nothing -> mempty
+          Just cmt -> hardline <> pretty cmt
 
 deriving newtype instance Pretty Name
 
-instance Pretty a => Pretty (WithComments a) where
-  pretty (WithComments a Nothing) = pretty a
-  pretty (WithComments a (Just cmt)) = pretty cmt <> hardline <> pretty a
+data CommentRender
+  = PreComment
+  | PostComment
+
+prettyWithComments :: Pretty a => CommentRender -> WithComments a -> Doc ann
+prettyWithComments _ (WithComments a Nothing) = pretty a
+prettyWithComments PostComment (WithComments a (Just cmt)) = pretty a <> softline <> pretty cmt
+prettyWithComments PreComment (WithComments a (Just cmt)) = align $ pretty cmt <> pretty a
+
+prettyCommentNoBreak :: Comment -> Doc ann
+prettyCommentNoBreak = align . vsep . toList . fmap ((";" <>) . pretty) . unComment
 
 instance Pretty Comment where
-  pretty (Comment t) =
-    let clines = T.splitOn "\n" t
-     in vsep $ fmap (("; " <>) . pretty) clines
+  pretty = (<> hardline) . prettyCommentNoBreak
+
+type0Def :: Type0 -> Doc ann
+type0Def t = nest 2 $ line' <> pretty t
 
 instance Pretty Rule where
   pretty (Rule n mgen assign tog) =
-    pretty n <> pretty mgen <+> case tog of
-      TOGType t -> ppAssignT <+> pretty t
-      TOGGroup g -> ppAssignG <+> pretty g
+    group $
+      pretty n <> pretty mgen <+> case tog of
+        TOGType t -> ppAssignT <+> type0Def t
+        TOGGroup g -> ppAssignG <+> nest 2 (line' <> pretty g)
     where
       ppAssignT = case assign of
         AssignEq -> "="
@@ -42,13 +63,13 @@ instance Pretty Rule where
         AssignExt -> "//="
 
 instance Pretty GenericArg where
-  pretty (GenericArg (NE.toList -> l)) = align . encloseSep "<" ">" ", " $ fmap pretty l
+  pretty (GenericArg (NE.toList -> l)) = cEncloseSep "<" ">" "," $ fmap pretty l
 
 instance Pretty GenericParam where
-  pretty (GenericParam (NE.toList -> l)) = align . encloseSep "<" ">" ", " $ fmap pretty l
+  pretty (GenericParam (NE.toList -> l)) = cEncloseSep "<" ">" "," $ fmap pretty l
 
 instance Pretty Type0 where
-  pretty (Type0 (NE.toList -> l)) = align . encloseSep mempty mempty " / " $ fmap pretty l
+  pretty (Type0 (NE.toList -> l)) = align . sep . punctuate (space <> "/") $ fmap pretty l
 
 instance Pretty CtlOp where
   pretty = pretty . T.toLower . T.pack . show
@@ -67,13 +88,13 @@ instance Pretty Type1 where
 instance Pretty Type2 where
   pretty (T2Value v) = pretty v
   pretty (T2Name n mg) = pretty n <> pretty mg
-  pretty (T2Group g) = enclose "(" ")" . align $ pretty g
+  pretty (T2Group g) = cEncloseSep "(" ")" mempty [pretty g]
   pretty (T2Map g) = prettyGroup AsMap g
   pretty (T2Array g) = prettyGroup AsArray g
   pretty (T2Unwrapped n mg) = "~" <+> pretty n <> pretty mg
   pretty (T2Enum g) = "&" <+> prettyGroup AsGroup g
   pretty (T2EnumRef g mg) = "&" <+> pretty g <> pretty mg
-  pretty (T2Tag minor t) = "#6" <> min' <> enclose "(" ")" (pretty t)
+  pretty (T2Tag minor t) = "#6" <> min' <> enclose "(" ")" (group $ nest 2 (line' <> pretty t) <> line')
     where
       min' = case minor of
         Nothing -> mempty
@@ -96,32 +117,97 @@ data GroupRender
   | AsArray
   | AsGroup
 
-prettyGroup :: GroupRender -> Group -> Doc ann
-prettyGroup gr (Group (NE.toList -> xs)) =
-  align $ encloseSep lp rp " // " (fmap prettyGrpChoice xs)
+renderedLen :: Doc ann -> Int
+renderedLen = T.length . renderStrict . layoutCompact
+
+softspace :: Doc ann
+softspace = flatAlt space mempty
+
+spaces :: Int -> Doc ann
+spaces i = mconcat $ replicate i softspace
+
+fillLeft :: Int -> Doc ann -> Doc ann
+fillLeft len doc = spaces (len - renderedLen doc) <> doc
+
+fillRight :: Int -> Doc ann -> Doc ann
+fillRight len doc = doc <> spaces (len - renderedLen doc)
+
+memberKeySep :: MemberKey -> Doc ann
+memberKeySep MKType {} = " => "
+memberKeySep _ = " : "
+
+columnarGroupChoice :: GrpChoice -> Doc ann
+columnarGroupChoice [] = mempty
+columnarGroupChoice groupEntries@(x : xs) =
+  groupIfNoComments (columnar x : fmap (\a -> "," <+> columnar a) xs)
   where
-    prettyGrpChoice = encloseSep mempty mempty ", " . fmap pretty
-    (lp, rp) = case gr of
+    occurrenceIndicatorLength (WithComments ge _) =
+      renderedLen . pretty $ groupEntryOccurrenceIndicator ge
+
+    longestOccurrenceIndicator = maximum $ occurrenceIndicatorLength <$> groupEntries
+
+    memberKeyLength (WithComments (GEType _ (Just mk) _) _) = renderedLen $ pretty mk
+    memberKeyLength _ = 0
+
+    longestMemberKey = maximum $ memberKeyLength <$> groupEntries
+
+    oiDoc oi =
+      fillLeft longestOccurrenceIndicator (pretty oi)
+        <> if longestOccurrenceIndicator > 0 then space else mempty
+
+    memberKeyDoc mmk = fillRight longestMemberKey (pretty mmk) <> fillLeft longestKeySep (memberKeySep mmk)
+
+    memberKeySepLen (WithComments (GEType _ mmk _) _) = renderedLen $ maybe mempty memberKeySep mmk
+    memberKeySepLen _ = 0
+
+    longestKeySep = maximum $ memberKeySepLen <$> groupEntries
+
+    longestLineColumnar =
+      maximum $ renderedLen . columnar' . stripComment <$> groupEntries
+
+    columnar (WithComments ge Nothing) = columnar' ge
+    columnar (WithComments ge (Just cmt)) = fillRight longestLineColumnar (columnar' ge) <+> prettyCommentNoBreak cmt
+
+    columnar' (GEType oi mmk t0) = oiDoc oi <> maybe mempty memberKeyDoc mmk <> pretty t0
+    columnar' (GEGroup oi g) = oiDoc oi <> prettyGroup AsGroup g
+    columnar' (GERef oi n mga) = oiDoc oi <> pretty n <> pretty mga
+
+    mapInit _ [] = []
+    mapInit _ [a] = [a]
+    mapInit f (a : as) = f a : mapInit f as
+
+    groupIfNoComments
+      | any (\(WithComments _ cmt) -> isJust cmt) groupEntries = mconcat . mapInit (<> hardline)
+      | otherwise = vcat
+
+cEncloseSep :: Doc ann -> Doc ann -> Doc ann -> [Doc ann] -> Doc ann
+cEncloseSep lEnc rEnc _ [] = lEnc <> rEnc
+cEncloseSep lEnc rEnc _ [x] =
+  group . align . vcat $
+    [ lEnc <> softspace <> x
+    , rEnc
+    ]
+cEncloseSep lEnc rEnc s (h : tl) =
+  group . align $ vsep ((lEnc <> lSpaces <> group h) : fmap ((s <> space) <>) tl) <> line' <> rEnc
+  where
+    lSpaces = mconcat $ replicate (renderedLen s) softspace
+
+prettyGroup :: GroupRender -> Group -> Doc ann
+prettyGroup gr (Group (toList -> xs)) =
+  cEncloseSep lEnc rEnc "//" $ fmap (group . columnarGroupChoice) xs
+  where
+    (lEnc, rEnc) = case gr of
       AsMap -> ("{", "}")
       AsArray -> ("[", "]")
       AsGroup -> ("(", ")")
 
 instance Pretty GroupEntry where
-  pretty (GEType moi mmk t) =
-    hsep $
-      catMaybes
-        [fmap pretty moi, fmap pretty mmk, Just $ pretty t]
-  pretty (GERef moi n mga) =
-    hsep (catMaybes [fmap pretty moi, Just $ pretty n])
-      <> pretty mga
-  pretty (GEGroup moi g) =
-    hsep $
-      catMaybes [fmap pretty moi, Just $ prettyGroup AsGroup g]
+  pretty ge = columnarGroupChoice [noComment ge]
 
 instance Pretty MemberKey where
-  pretty (MKType t1) = pretty t1 <+> "=>"
-  pretty (MKBareword n) = pretty n <+> ":"
-  pretty (MKValue v) = pretty v <+> ":"
+  pretty (MKType t1) = pretty t1
+  pretty (MKBareword n) = pretty n
+  pretty (MKValue v) = pretty v
 
 instance Pretty Value where
   pretty (VUInt i) = pretty i

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,5 +1,6 @@
 module Main (main) where
 
+import System.IO (BufferMode (..), hSetBuffering, hSetEncoding, stdout, utf8)
 import Test.Codec.CBOR.Cuddle.CDDL.Examples qualified as Examples
 import Test.Codec.CBOR.Cuddle.CDDL.Parser (parserSpec)
 import Test.Codec.CBOR.Cuddle.Huddle (huddleSpec)
@@ -13,7 +14,9 @@ hspecConfig =
     }
 
 main :: IO ()
-main =
+main = do
+  hSetBuffering stdout LineBuffering
+  hSetEncoding stdout utf8
   hspecWith hspecConfig $ do
     describe "cddlParser" parserSpec
     describe "Huddle" huddleSpec


### PR DESCRIPTION
This PR improves the parsing and prettyprinting of comments. It's far from perfect, but should work well enough in most cases. The parser will try its hardest to attach any comments to a term that can have comments. In the current version if a comment couldn't be attached to a term, the parser will silently drop that comment.

Comments in front of a rule will get attached to that rule.
Any comments after group entries are put on the same line as the entry if possible.

I also rewrote a big part of the pretty printer to make terms align better. 
See an example of a formatted CDDL file here:
https://gist.github.com/Soupstraw/d1fbaea0396bf8807427dea3e653d2d6

Note that there is a bug with comment alignment (see `transaction_body` in the gist). This will be solved in a future PR.