### PR TITLE
Generate tstr as TString

### DIFF
--- a/src/Codec/CBOR/Cuddle/CBOR/Gen.hs
+++ b/src/Codec/CBOR/Cuddle/CBOR/Gen.hs
@@ -199,7 +199,7 @@ genPostlude pt = case pt of
     genRandomM
       <&> TDouble
   PTBytes -> TBytes <$> genBytes 30
-  PTText -> TBytes <$> genBytes 30
+  PTText -> TString <$> genText 30
   PTAny -> pure $ TString "Any"
   PTNil -> pure TNull
 


### PR DESCRIPTION
This commit changes the generator of text/tstr to `Text` so that the examples in https://github.com/input-output-hk/cuddle/issues/65 now work as expected.