### PR TITLE
Fix issue with calling generics

### DIFF
--- a/example/cddl-files/issue80-min.cddl
+++ b/example/cddl-files/issue80-min.cddl
@@ -1,0 +1,8 @@
+main = test<int, int>
+set<x> = [x]
+test<x, x1> = [
+	1,
+	x,
+	set<x>
+]
+


### PR DESCRIPTION
Issue #80 identified a case where the resolver would hang when calling a generic function with a parameter whose name matched the name of the argument.

This occurred due to the order of resolution. Since we resolved bindings in a depth-first fashion, we simply ended up resolving a generic parameter to itself.

One way to resolve this would have been to synthesize new names for each parameter in the scope of a local binding. But generating names and ensuring they are all unique is annoying. Instead, we switch the order of resolution. When binding generic args, we first resolve the arguments before traversing the body.

That is, for a replacement series

int -> x -> x

We previously did

int -> (x -> x)

whereas now we do

(int -> x) -> x

Since the top-level (LHS) is always concrete, this process must terminate.