### PR TITLE
`random-1.3` support

### DIFF
--- a/cuddle.cabal
+++ b/cuddle.cabal
@@ -81,7 +81,7 @@ library
     ordered-containers ^>=0.2.4,
     parser-combinators ^>=1.3,
     prettyprinter ^>=1.7.1,
-    random <1.3,
+    random >=1.2,
     regex-tdfa ^>=1.3.2,
     scientific ^>=0.3.8,
     text >=2.0.2 && <2.2,


### PR DESCRIPTION
Also simplifies usage of `random` by:

* Removing `fakeSeed` field

This is an alternative way of supporting `random-1.3` when compared to #84