### PR TITLE
Prepare release to hackage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,45 +1,20 @@
-# Revision history for cuddle
+# Changelog for `cuddle`
 
-## 0.1.0.0 -- YYYY-mm-dd
+## 0.5.0.0
 
-* First version. Released on an unsuspecting world.
+* Implement a validator for CBOR terms.
 
-## 0.3.0.0 --2024-07-25
+## 0.4.0.0
 
-* Rationalise the choice operators. Drop (//) and provide detailed comments
-  explaining the use of (/).
+* Rewrote the prettyprinter to make the output more human-readable.
+* Added `collectFromInit` to make it possible to specify the order of
+  definitions manually. `collectFrom` and `collectFromInit` now expect
+  `HuddleItem`s in their arguments
+* More Huddle terms now accept comments (e.g. `ArrayEntry`, `ArrayChoice`)
+* Parser now preserves most comments.
 
-## 0.3.0.1 -- 2024-07-31
+## 0.3.6.0
 
-* Improvements in the pretty printer - various groups should be formatted more
-  cleanly
-
-## 0.3.1.0 -- 2024-08-15
-
-* `collectFrom` now adds a first definition in the generated Huddle referencing
-  the top level elements, to be compatible with the CDDL spec.
-
-## 0.3.2.0 -- 2024-09-11
-
-* Leading rather than trailing commas in the pretty printer.
-
-## 0.3.3.0 -- 2024-11-13
-
-* Introduce HuddleM, another way to define a Huddle spec. This allows total
-  control over the order that items are presented in the CDDL, at the cost
-  of making it somewhat harder to re-use items (they need to be returned from
-  the monad).
-
-## O.3.5.0 -- 2024-11-25
-
-* Add support for constraints on references and generic references.
-* Add support for using references as range bounds. Note that this breaks
-  backwards compatibility - because the range arguments are now more generic,
-  additional hints are required to type literal numerics correctly. Typically
-  this is most easily fixed by adding a call `int` for any numeric literals in
-  ranges. An example is shown in `example/Conway.hs`
-
-## 0.3.6.0 -- 2024-12-02
 * Support having keys in group entries. This is needed when using a group to
   define a map, or when wishing to include keys in for-use-in-array groups for
   documentation purposes. This may introduce problems with existing specifications
@@ -49,14 +24,42 @@
   Note that it is not yet supported to use a group inside a map, where the
   issue of merging keys arises.
 
-## 0.4.0.0 -- 2025-05-02
-* Rewrote the prettyprinter to make the output more human-readable.
-* Added `collectFromInit` to make it possible to specify the order of
-  definitions manually. `collectFrom` and `collectFromInit` now expect
-  `HuddleItem`s in their arguments
-* More Huddle terms now accept comments (e.g. `ArrayEntry`, `ArrayChoice`)
-* Parser now preserves most comments.
+## O.3.5.0
 
-## 0.5.0.0 -- 2025-06-03
+* Add support for constraints on references and generic references.
+* Add support for using references as range bounds. Note that this breaks
+  backwards compatibility - because the range arguments are now more generic,
+  additional hints are required to type literal numerics correctly. Typically
+  this is most easily fixed by adding a call `int` for any numeric literals in
+  ranges. An example is shown in `example/Conway.hs`
 
-* Implement a validator for CBOR terms.
+## 0.3.3.0
+
+* Introduce HuddleM, another way to define a Huddle spec. This allows total
+  control over the order that items are presented in the CDDL, at the cost
+  of making it somewhat harder to re-use items (they need to be returned from
+  the monad).
+
+## 0.3.2.0
+
+* Leading rather than trailing commas in the pretty printer.
+
+## 0.3.1.0
+
+* `collectFrom` now adds a first definition in the generated Huddle referencing
+  the top level elements, to be compatible with the CDDL spec.
+
+## 0.3.0.1
+
+* Improvements in the pretty printer - various groups should be formatted more
+  cleanly
+
+## 0.3.0.0
+
+* Rationalise the choice operators. Drop (//) and provide detailed comments
+  explaining the use of (/).
+
+## 0.1.0.0
+
+* First version. Released on an unsuspecting world.
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog for `cuddle`
 
+## 1.0.0.0
+
+* First official release to Hackage
+* Added one more parameter to `BindingEnv`
+
 ## 0.5.0.0
 
 * Implement a validator for CBOR terms.

--- a/cuddle.cabal
+++ b/cuddle.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.4
 name: cuddle
-version: 0.5.0.0
+version: 1.0.0.0
 synopsis: CDDL Generator and test utilities
 description:
   Cuddle is a library for generating and manipulating [CDDL](https://datatracker.ietf.org/doc/html/rfc8610).

--- a/cuddle.cabal
+++ b/cuddle.cabal
@@ -16,7 +16,7 @@ description:
 license: Apache-2.0
 license-file: LICENSE
 author: IOG Ledger Team
-maintainer: nicholas.clarke@iohk.io, hackage@iohk.io
+maintainer: hackage@iohk.io
 copyright: 2025 Input Output Global Inc (IOG)
 category: Codec
 build-type: Simple


### PR DESCRIPTION
There is currently an unsanctioned release to hackage of [`cuddle-0.5.0.0`](https://hackage.haskell.org/package/cuddle-0.5.0.0), which we need to deprecate and make an official `cuddle-1.0.0.0` release, which this PR has prepared