### PR TITLE
Bump `fourmolu` to `0.18.0.0` in the nix shell

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -6,11 +6,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1745303921,
-        "narHash": "sha256-zYucemS2QvJUR5GKJ/u3eZAoe82AKhcxMtNVZDERXsw=",
+        "lastModified": 1757659051,
+        "narHash": "sha256-pQfaow3cp1YJtV0JZiz8jC4Y8VQjT4CYZ3OAfFe41Zs=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "14850d5984f3696a2972f85f19085e5fb46daa95",
+        "rev": "9479f6dd16e83add0ef0186662d65e7763b37ebe",
         "type": "github"
       },
       "original": {
@@ -55,11 +55,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1744932701,
-        "narHash": "sha256-fusHbZCyv126cyArUwwKrLdCkgVAIaa/fQJYFlCEqiU=",
+        "lastModified": 1757487488,
+        "narHash": "sha256-zwE/e7CuPJUWKdvvTCB7iunV4E/+G0lKfv4kk/5Izdg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b024ced1aac25639f8ca8fdfc2f8c4fbd66c48ef",
+        "rev": "ab0f3607a6c7486ea22229b92ed2d355f1482ee0",
         "type": "github"
       },
       "original": {
@@ -71,11 +71,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1744932701,
-        "narHash": "sha256-fusHbZCyv126cyArUwwKrLdCkgVAIaa/fQJYFlCEqiU=",
+        "lastModified": 1757487488,
+        "narHash": "sha256-zwE/e7CuPJUWKdvvTCB7iunV4E/+G0lKfv4kk/5Izdg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b024ced1aac25639f8ca8fdfc2f8c4fbd66c48ef",
+        "rev": "ab0f3607a6c7486ea22229b92ed2d355f1482ee0",
         "type": "github"
       },
       "original": {
@@ -106,11 +106,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1732527420,
-        "narHash": "sha256-CODu6b7XDqUr09KCWgG++JtFpy6H2aHVfnKi1SPV/NA=",
+        "lastModified": 1755004808,
+        "narHash": "sha256-ivs3qgkRULIF925fJTEJfH85B4f+tl5e2gSrVJH58MU=",
         "owner": "nickel-lang",
         "repo": "organist",
-        "rev": "16afff2ab58d1d72d0bbca6cf37e0e3a541f5b6e",
+        "rev": "a7e4e638cade5e7c4f36a129b80d91bf3538088e",
         "type": "github"
       },
       "original": {
@@ -129,11 +129,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1745247864,
-        "narHash": "sha256-QA1Ba8Flz5K+0GbG03HwiX9t46mh/jjKgwavbuKtwMg=",
+        "lastModified": 1757362324,
+        "narHash": "sha256-/PAhxheUq4WBrW5i/JHzcCqK5fGWwLKdH6/Lu1tyS18=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "31dbec70c68e97060916d4754c687a3e93c2440f",
+        "rev": "9edc9cbe5d8e832b5864e09854fa94861697d2fd",
         "type": "github"
       },
       "original": {

--- a/nickel.lock.ncl
+++ b/nickel.lock.ncl
@@ -1,3 +1,3 @@
 {
-  organist = import "/nix/store/7zrf2b1ysrgrx7613qlmbz71cfyxgyfb-source/lib/organist.ncl",
+  organist = import "/nix/store/fjxrgrx0s69m5vkss5ff1i5akjcx39ss-source/lib/organist.ncl",
 }

--- a/project.ncl
+++ b/project.ncl
@@ -1,14 +1,15 @@
 let inputs = import "./nickel.lock.ncl" in
 let organist = inputs.organist in
 
-let import_hs = fun ghcver pkgname =>
-  organist.import_nix "nixpkgs#haskell.packages.%{ghcver}.%{pkgname}"
+let 
+  import_hs = fun ghcver pkgname =>
+    organist.import_nix "nixpkgs#haskell.packages.%{ghcver}.%{pkgname}"
 in
 let shellFor = fun ghcver =>
   let hspkg = import_hs ghcver in {
     packages = {
       haskell-language-server = hspkg "haskell-language-server",
-      fourmolu = hspkg "fourmolu",
+      fourmolu = organist.import_nix "nixpkgs#haskell.packages.ghc912.fourmolu",
       ghc = organist.import_nix "nixpkgs#haskell.compiler.%{ghcver}",
       cabal-install = hspkg "cabal-install",
       cabal-fmt = hspkg "cabal-fmt",
@@ -24,7 +25,7 @@ let shellFor = fun ghcver =>
       packages = {},
     },
 
-    shells.dev = shellFor "ghc964",
+    shells.dev = shellFor "ghc910",
   }
 }
   | organist.OrganistExpression

--- a/src/Codec/CBOR/Cuddle/CBOR/Validator.hs
+++ b/src/Codec/CBOR/Cuddle/CBOR/Validator.hs
@@ -145,7 +145,9 @@ validateCBOR' bs rule cddl@(CTreeRoot tree) =
 -- spec
 validateTerm ::
   MonadReader CDDL m =>
-  Term -> Rule -> m CBORTermResult
+  Term ->
+  Rule ->
+  m CBORTermResult
 validateTerm term rule =
   let f = case term of
         TInt i -> validateInteger (fromIntegral i)
@@ -183,7 +185,9 @@ validateTerm term rule =
 -- Ints, so we convert everything to Integer.
 validateInteger ::
   MonadReader CDDL m =>
-  Integer -> Rule -> m CDDLResult
+  Integer ->
+  Rule ->
+  m CDDLResult
 validateInteger i rule =
   ($ rule) <$> do
     getRule rule >>= \case
@@ -308,7 +312,9 @@ controlInteger i Ne ctrl =
 -- | Validating a `Float16`
 validateHalf ::
   MonadReader CDDL m =>
-  Float -> Rule -> m CDDLResult
+  Float ->
+  Rule ->
+  m CDDLResult
 validateHalf f rule =
   ($ rule) <$> do
     getRule rule >>= \case
@@ -343,7 +349,9 @@ controlHalf f Ne ctrl =
 -- | Validating a `Float32`
 validateFloat ::
   MonadReader CDDL m =>
-  Float -> Rule -> m CDDLResult
+  Float ->
+  Rule ->
+  m CDDLResult
 validateFloat f rule =
   ($ rule) <$> do
     getRule rule >>= \case
@@ -383,7 +391,9 @@ controlFloat f Ne ctrl =
 -- | Validating a `Float64`
 validateDouble ::
   MonadReader CDDL m =>
-  Double -> Rule -> m CDDLResult
+  Double ->
+  Rule ->
+  m CDDLResult
 validateDouble f rule =
   ($ rule) <$> do
     getRule rule >>= \case
@@ -430,7 +440,9 @@ controlDouble f Ne ctrl =
 -- | Validating a boolean
 validateBool ::
   MonadReader CDDL m =>
-  Bool -> Rule -> m CDDLResult
+  Bool ->
+  Rule ->
+  m CDDLResult
 validateBool b rule =
   ($ rule) <$> do
     getRule rule >>= \case
@@ -463,7 +475,9 @@ controlBool b Ne ctrl =
 -- | Validating a `TSimple`. It is unclear if this is used for anything else than undefined.
 validateSimple ::
   MonadReader CDDL m =>
-  Word8 -> Rule -> m CDDLResult
+  Word8 ->
+  Rule ->
+  m CDDLResult
 validateSimple 23 rule =
   ($ rule) <$> do
     getRule rule >>= \case
@@ -498,7 +512,9 @@ validateNull rule =
 -- | Validating a byte sequence
 validateBytes ::
   MonadReader CDDL m =>
-  BS.ByteString -> Rule -> m CDDLResult
+  BS.ByteString ->
+  Rule ->
+  m CDDLResult
 validateBytes bs rule =
   ($ rule) <$> do
     getRule rule >>= \case
@@ -517,7 +533,11 @@ validateBytes bs rule =
 -- | Controls for byte strings
 controlBytes ::
   forall m.
-  MonadReader CDDL m => BS.ByteString -> CtlOp -> Rule -> m (Either (Maybe CBORTermResult) ())
+  MonadReader CDDL m =>
+  BS.ByteString ->
+  CtlOp ->
+  Rule ->
+  m (Either (Maybe CBORTermResult) ())
 controlBytes bs Size ctrl =
   getRule ctrl >>= \case
     Literal (Value (VUInt (fromIntegral -> sz)) _) -> pure $ boolCtrl $ BS.length bs == sz
@@ -568,7 +588,9 @@ controlBytes bs Cborseq ctrl =
 -- | Validating text strings
 validateText ::
   MonadReader CDDL m =>
-  T.Text -> Rule -> m CDDLResult
+  T.Text ->
+  Rule ->
+  m CDDLResult
 validateText txt rule =
   ($ rule) <$> do
     getRule rule >>= \case
@@ -607,7 +629,10 @@ controlText s Regexp ctrl =
 -- | Validating a `TTagged`
 validateTagged ::
   MonadReader CDDL m =>
-  Word64 -> Term -> Rule -> m CDDLResult
+  Word64 ->
+  Term ->
+  Rule ->
+  m CDDLResult
 validateTagged tag term rule =
   ($ rule) <$> do
     getRule rule >>= \case
@@ -725,7 +750,9 @@ isOptional rule =
 validateListWithExpandedRules ::
   forall m.
   MonadReader CDDL m =>
-  [Term] -> [Rule] -> m [(Rule, CBORTermResult)]
+  [Term] ->
+  [Rule] ->
+  m [(Rule, CBORTermResult)]
 validateListWithExpandedRules terms rules =
   go (zip terms rules)
   where
@@ -795,7 +822,9 @@ validateList terms rule =
 validateMapWithExpandedRules ::
   forall m.
   MonadReader CDDL m =>
-  [(Term, Term)] -> [Rule] -> m ([AMatchedItem], Maybe ANonMatchedItem)
+  [(Term, Term)] ->
+  [Rule] ->
+  m ([AMatchedItem], Maybe ANonMatchedItem)
 validateMapWithExpandedRules =
   go
   where
@@ -853,7 +882,9 @@ validateExpandedMap terms rules = go rules
 
 validateMap ::
   MonadReader CDDL m =>
-  [(Term, Term)] -> Rule -> m CDDLResult
+  [(Term, Term)] ->
+  Rule ->
+  m CDDLResult
 validateMap terms rule =
   ($ rule) <$> do
     getRule rule >>= \case
@@ -899,7 +930,10 @@ dummyRule = MRuleRef (Name "dummy" mempty)
 -- | Validate both rules
 ctrlAnd ::
   Monad m =>
-  (Rule -> m CDDLResult) -> Rule -> Rule -> m (Rule -> CDDLResult)
+  (Rule -> m CDDLResult) ->
+  Rule ->
+  Rule ->
+  m (Rule -> CDDLResult)
 ctrlAnd v tgt ctrl =
   v tgt >>= \case
     Valid _ ->


### PR DESCRIPTION
This makes the `fourmolu` available in the nix shell consistent with the one that is used by the CI. I also bumped the `GHC` version to `9.10`, because `cabal-fmt` seems to not work anymore on `ghc-9.6.4` once I updated the nix flake.