### PR TITLE
Downgrade fourmolu in the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
 
     - name: Install fourmolu
       run: |
-        FOURMOLU_VERSION="0.18.0.0"
+        FOURMOLU_VERSION="0.17.0.0"
         mkdir -p "$HOME/.local/bin"
         curl -sL "https://github.com/fourmolu/fourmolu/releases/download/v${FOURMOLU_VERSION}/fourmolu-${FOURMOLU_VERSION}-linux-x86_64" -o "$HOME/.local/bin/fourmolu"
         chmod a+x "$HOME/.local/bin/fourmolu"


### PR DESCRIPTION
This PR downgrades the version of `fourmolu` used by the CI to `0.17.0.0` to make it consistent with the fourmolu that is provided by the Nix shell.

See also: https://github.com/input-output-hk/cuddle/issues/98