### PR TITLE
Add a missing IndexMappable instance

### DIFF
--- a/src/Codec/CBOR/Cuddle/IndexMappable.hs
+++ b/src/Codec/CBOR/Cuddle/IndexMappable.hs
@@ -275,6 +275,9 @@ instance IndexMappable XXType2 HuddleStage PrettyStage where
 instance IndexMappable XTerm HuddleStage PrettyStage where
   mapIndex (HuddleXTerm c) = PrettyXTerm c
 
+instance IndexMappable XRule HuddleStage PrettyStage where
+  mapIndex (HuddleXRule c _) = PrettyXRule c
+
 -- ParserStage -> ParserStage
 
 instance IndexMappable XCddl ParserStage ParserStage


### PR DESCRIPTION
This adds a missing `IndexMappable XRule HuddleStage PrettyStage` instance.