### PR TITLE
Use prelude by default when validating CBOR

### DIFF
--- a/bin/Main.hs
+++ b/bin/Main.hs
@@ -234,7 +234,7 @@ run (Opts cmd cddlFile) = do
           let
             cddl
               | vcNoPrelude vcOpts = res
-              | otherwise = res
+              | otherwise = appendPostlude res
            in
             case fullResolveCDDL $ mapCDDLDropExt cddl of
               Left err -> putStrLnErr (show err) >> exitFailure


### PR DESCRIPTION
This isn't working:

```shellsession
$ cabal run -- cuddle gen -f cbor -r block -o test.block example/cddl-files/byron.cddl
$ cabal run -- cuddle validate-cbor -r block -c test.block example/cddl-files/byron.cddl
UnboundReference (Name {unName = "bigint"})
```

The code in `Main.hs` fails to call `appendPostlude` when it should.