### PR TITLE
Add `format-cbor` subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 * Export `Type0`
 * Removed `Codec.CBOR.Cuddle.Huddle.HuddleM`
+* Add `format-cbor` subcommand
+* Changed `--cbor` option of `validate` to a proper argument
+* Added `binary` and `hex` output formats. Providing an output file argument to 
+  `gen` no longer affects the output format.
 
 ## 1.1.1.0
 

--- a/cuddle.cabal
+++ b/cuddle.cabal
@@ -103,6 +103,7 @@ executable example
   main-is: Main.hs
   build-depends:
     base,
+    bytestring,
     cuddle,
     megaparsec,
     prettyprinter,
@@ -119,6 +120,7 @@ executable cuddle
     base16-bytestring,
     bytestring,
     cborg,
+    containers,
     cuddle,
     megaparsec,
     mtl,


### PR DESCRIPTION
This PR adds a new `format-cbor` subcommand, which can be used to output CBOR files in various encodings. I also made some changes to the `gen` command, namely the input CBOR file is no longer an option but rather a required argument to the subcommand.