### PR TITLE
Make generateFromName use CBORGen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Changelog for `cuddle`
 
-## 1.3.0.1
+## 1.4.0.0
 
-*
+* Changed `generateFromName` to return a `CBORGen` instead of `AntiGen`
+* Add `no-twiddle` option
 
 ## 1.3.0.0
 

--- a/bin/Main.hs
+++ b/bin/Main.hs
@@ -15,6 +15,7 @@ import Codec.CBOR.Cuddle.CBOR.Validator.Trace (
   prettyValidationTrace,
  )
 import Codec.CBOR.Cuddle.CDDL (CDDL, Name (..), fromRules, sortCDDL)
+import Codec.CBOR.Cuddle.CDDL.CBORGenerator (GenEnv (..), runCBORGen)
 import Codec.CBOR.Cuddle.CDDL.CTree (CTreeRoot)
 import Codec.CBOR.Cuddle.CDDL.Postlude (appendPostlude)
 import Codec.CBOR.Cuddle.CDDL.Resolve (
@@ -113,6 +114,7 @@ data GenOpts = GenOpts
   , goSeed :: Maybe Int
   , goSize :: Int
   , goNegative :: Bool
+  , goTwiddle :: Bool
   , itemName :: T.Text
   }
 
@@ -154,6 +156,11 @@ pGenOpts =
       ( long "negative"
           <> short 'n'
           <> help "Generate a negative example"
+      )
+    <*> option
+      (not <$> auto)
+      ( long "no-twiddle"
+          <> help "Do not generate indefinite encodings"
       )
     <*> argument
       str
@@ -370,7 +377,12 @@ run = \case
           zapN
             | goNegative = 1
             | otherwise = 0
-          term = runGen seed goSize . zapAntiGen zapN $ generateFromName (mapIndex mt) (Name itemName)
+          env =
+            GenEnv
+              { geRoot = mapIndex mt
+              , geTwiddle = goTwiddle
+              }
+          term = runGen seed goSize . zapAntiGen zapN . runCBORGen env $ generateFromName (Name itemName)
           formatted = formatTerm term outputFormat
         case outputTo of
           Just outputPath -> BS.writeFile outputPath formatted

--- a/cuddle.cabal
+++ b/cuddle.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.4
 name: cuddle
-version: 1.3.0.1
+version: 1.4.0.0
 synopsis: CDDL Generator and test utilities
 description:
   Cuddle is a library for generating and manipulating [CDDL](https://datatracker.ietf.org/doc/html/rfc8610).

--- a/src/Codec/CBOR/Cuddle/CBOR/Gen.hs
+++ b/src/Codec/CBOR/Cuddle/CBOR/Gen.hs
@@ -38,13 +38,11 @@ import Codec.CBOR.Cuddle.CDDL.CBORGenerator (
   XXCTree (..),
   liftAntiGen,
   lookupCddl,
-  runCBORGen,
   withAntiGen,
   withTwiddle,
  )
 import Codec.CBOR.Cuddle.CDDL.CTree (
   CTree (..),
-  CTreeRoot (..),
   PTerm (..),
   foldCTree,
   nintMin,
@@ -590,13 +588,13 @@ resolveRef n = do
 -- This will throw an error if the generated item does not correspond to a
 -- single CBOR term (e.g. if the name resolves to a group, which cannot be
 -- generated outside a context).
-generateFromName :: HasCallStack => CTreeRoot GenPhase -> Name -> AntiGen Term
-generateFromName root@(CTreeRoot cddlMap) n = do
-  let env = GenEnv {geRoot = root, geTwiddle = True}
-  case Map.lookup n cddlMap of
+generateFromName :: HasCallStack => Name -> CBORGen Term
+generateFromName n = do
+  mRule <- lookupCddl n
+  case mRule of
     Nothing -> error $ "Unbound reference: " <> show n
     Just val ->
-      runCBORGen env (genForCTree val) >>= \case
+      genForCTree val >>= \case
         S x -> pure x
         _ ->
           error $

--- a/test/Test/Codec/CBOR/Cuddle/CDDL/GeneratorSpec.hs
+++ b/test/Test/Codec/CBOR/Cuddle/CDDL/GeneratorSpec.hs
@@ -7,6 +7,7 @@ module Test.Codec.CBOR.Cuddle.CDDL.GeneratorSpec (spec) where
 import Codec.CBOR.Cuddle.CBOR.Gen (GenPhase, generateFromName)
 import Codec.CBOR.Cuddle.CBOR.Validator (validateCBOR)
 import Codec.CBOR.Cuddle.CDDL (Name)
+import Codec.CBOR.Cuddle.CDDL.CBORGenerator (GenEnv (..), runCBORGen)
 import Codec.CBOR.Cuddle.CDDL.CTree (CTreeRoot (..))
 import Codec.CBOR.Cuddle.CDDL.Resolve (MonoReferenced, MonoSimple, fullResolveCDDL)
 import Codec.CBOR.Cuddle.Huddle (Huddle, toCDDL)
@@ -38,7 +39,13 @@ import Test.QuickCheck (Gen, Property, Testable (..), counterexample)
 import Text.Pretty.Simple (pShow)
 
 generateCDDL :: CTreeRoot GenPhase -> Gen Term
-generateCDDL cddl = runAntiGen $ generateFromName cddl "root"
+generateCDDL cddl = runAntiGen . runCBORGen env $ generateFromName "root"
+  where
+    env =
+      GenEnv
+        { geRoot = cddl
+        , geTwiddle = True
+        }
 
 tryResolveHuddle :: HasCallStack => Huddle -> SpecM () (CTreeRoot MonoReferenced)
 tryResolveHuddle huddle = do
@@ -48,7 +55,13 @@ tryResolveHuddle huddle = do
 
 expectZapInvalidates :: CTreeRoot MonoReferenced -> Name -> Property
 expectZapInvalidates cddl name = property $ do
-  res@ZapResult {zrValue} <- zapAntiGenResult 1 $ generateFromName (mapIndex cddl) name
+  let
+    env =
+      GenEnv
+        { geRoot = mapIndex cddl
+        , geTwiddle = True
+        }
+  res@ZapResult {zrValue} <- zapAntiGenResult 1 . runCBORGen env $ generateFromName name
   let
     bs = toStrictByteString $ encodeTerm zrValue
     validationRes = validateCBOR bs name $ mapIndex cddl

--- a/test/Test/Codec/CBOR/Cuddle/CDDL/Validator.hs
+++ b/test/Test/Codec/CBOR/Cuddle/CDDL/Validator.hs
@@ -22,7 +22,7 @@ import Codec.CBOR.Cuddle.CBOR.Validator.Trace (
   prettyValidationTrace,
  )
 import Codec.CBOR.Cuddle.CDDL (Name (..))
-import Codec.CBOR.Cuddle.CDDL.CBORGenerator (CustomValidatorResult (..))
+import Codec.CBOR.Cuddle.CDDL.CBORGenerator (CustomValidatorResult (..), GenEnv (..), runCBORGen)
 import Codec.CBOR.Cuddle.CDDL.CTree (CTreeRoot (..))
 import Codec.CBOR.Cuddle.CDDL.CTree qualified as CTree
 import Codec.CBOR.Cuddle.CDDL.Postlude (appendPostlude)
@@ -97,7 +97,13 @@ import Text.Megaparsec (runParser)
 genAndValidateRule :: String -> Name -> CTreeRoot MonoReferenced -> Spec
 genAndValidateRule description name resolvedCddl =
   prop description $ do
-    cborTerm <- runAntiGen $ generateFromName (mapIndex resolvedCddl) name
+    let
+      genEnv =
+        GenEnv
+          { geRoot = mapIndex resolvedCddl
+          , geTwiddle = True
+          }
+    cborTerm <- runAntiGen . runCBORGen genEnv $ generateFromName name
     let
       generatedCbor = toStrictByteString $ encodeTerm cborTerm
       res = validateCBOR generatedCbor name (mapIndex resolvedCddl)


### PR DESCRIPTION
This PR modifies `generateFromName` so that it returns `CBORGen` instead of `AntiGen`. This way the user can provide their own `GenEnv`.