### PR TITLE
Fix InvalidTag trace showing bad tag as expected value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Fix custom validators not running when reached via type-specific validators
 * Replace `TerminalRule (Maybe ControlInfo)` with `TerminalRule` and a new `ControlTrace` constructor
+* Fix `InvalidTag` trace showing the bad tag as the expected value
 
 ## 1.4.0.0
 

--- a/src/Codec/CBOR/Cuddle/CBOR/Validator.hs
+++ b/src/Codec/CBOR/Cuddle/CBOR/Validator.hs
@@ -726,7 +726,7 @@ validateTagged cddl tag term rule =
       -- If the tag does not match, this is a direct fail
       if tag == tag'
         then mapTrace (TagTrace tag) $ validateTerm cddl term rule'
-        else evidence $ InvalidTag tag
+        else evidence $ InvalidTag tag' tag
     Choice opts -> validateChoice (validateTagged cddl tag term) opts
     _ -> unapplicable rule
 

--- a/src/Codec/CBOR/Cuddle/CBOR/Validator/Trace.hs
+++ b/src/Codec/CBOR/Cuddle/CBOR/Validator/Trace.hs
@@ -180,7 +180,7 @@ data ValidationTrace (v :: Validity) where
   ListTrace :: ListValidationTrace v -> ValidationTrace v
   MapTrace :: MapValidationTrace v -> ValidationTrace v
   TagTrace :: Word64 -> ValidationTrace v -> ValidationTrace v
-  InvalidTag :: Word64 -> ValidationTrace IsInvalid
+  InvalidTag :: Word64 -> Word64 -> ValidationTrace IsInvalid
 
 deriving instance Show (ValidationTrace v)
 
@@ -515,8 +515,8 @@ prettyValidationTrace opts = \case
       [ "tag:" <+> annotate (color Green) ("#6." <> pretty t)
       , nestContainer $ prettyValidationTrace opts x
       ]
-  InvalidTag t ->
-    "expected tag #6." <> pretty t
+  InvalidTag expected actual ->
+    "expected tag #6." <> pretty expected <> ", got #6." <> pretty actual
 
 showValidationTrace :: ValidationTrace v -> String
 showValidationTrace =


### PR DESCRIPTION
## Summary
- `InvalidTag` now stores both expected and actual tag numbers instead of only the actual tag
- Pretty-printer displays both values: `expected tag #6.X, got #6.Y`

Fixes #174