### PR TITLE
Make generator omit tags when zapped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.5.0.0
 
+* Make generator omit tags when zapped
 * Fix custom validators not running when reached via type-specific validators
 * Replace `TerminalRule (Maybe ControlInfo)` with `TerminalRule` and a new `ControlTrace` constructor
 * Fix `InvalidTag` trace showing the bad tag as the expected value

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Changelog for `cuddle`
 
-## 1.5.0.0
+## 1.5.1.0
 
 * Make generator omit tags when zapped
+
+## 1.5.0.0
+
 * Fix custom validators not running when reached via type-specific validators
 * Replace `TerminalRule (Maybe ControlInfo)` with `TerminalRule` and a new `ControlTrace` constructor
 * Fix `InvalidTag` trace showing the bad tag as the expected value

--- a/cuddle.cabal
+++ b/cuddle.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.4
 name: cuddle
-version: 1.5.0.0
+version: 1.5.1.0
 synopsis: CDDL Generator and test utilities
 description:
   Cuddle is a library for generating and manipulating [CDDL](https://datatracker.ietf.org/doc/html/rfc8610).

--- a/src/Codec/CBOR/Cuddle/CBOR/Gen.hs
+++ b/src/Codec/CBOR/Cuddle/CBOR/Gen.hs
@@ -82,6 +82,7 @@ import System.Random.Stateful (Random, StatefulGen (..), runStateGen_, uniformBy
 import Test.AntiGen (
   AntiGen,
   antiChoose,
+  faultyBool,
   faultyNum,
   reweigh,
   runAntiGen,
@@ -558,16 +559,20 @@ genEnum tree = case tree of
 -- | Generate a tagged value
 genTag :: HasCallStack => Word64 -> CTree GenPhase -> CBORGen WrappedTerm
 genTag t node = do
-  tag <- liftAntiGen $ faultyNum t
-  enc <- case tag of
-    n
-      | n == 2 || n == 3 ->
-          -- TODO remove this once `cborg` can decode indefinite bytes in bignums
-          withTwiddle False $ genForCTree node
-    _ -> genForCTree node
-  case enc of
-    S x -> pure $ S $ TTagged tag x
-    _ -> error "Tag controller does not correspond to a single term"
+  omitTag <- liftAntiGen $ faultyBool False
+  if omitTag
+    then genForCTree node
+    else do
+      tag <- liftAntiGen $ faultyNum t
+      enc <- case tag of
+        n
+          | n == 2 || n == 3 ->
+              -- TODO remove this once `cborg` can decode indefinite bytes in bignums
+              withTwiddle False $ genForCTree node
+        _ -> genForCTree node
+      case enc of
+        S x -> pure $ S $ TTagged tag x
+        _ -> error "Tag controller does not correspond to a single term"
 
 genForNode :: HasCallStack => Name -> CBORGen WrappedTerm
 genForNode = genForCTree <=< resolveRef

--- a/test/Test/Codec/CBOR/Cuddle/CDDL/Examples/Huddle.hs
+++ b/test/Test/Codec/CBOR/Cuddle/CDDL/Examples/Huddle.hs
@@ -26,6 +26,7 @@ module Test.Codec.CBOR.Cuddle.CDDL.Examples.Huddle (
   listZeroOrMoreExample,
   mapNestedValueExample,
   deeplyNestedRefExample,
+  taggedUintExample,
 ) where
 
 import Codec.CBOR.Cuddle.CDDL (Name)
@@ -43,6 +44,7 @@ import Codec.CBOR.Cuddle.Huddle (
   idx,
   mp,
   opt,
+  tag,
   withCBORGen,
   (...),
   (=:=),
@@ -305,3 +307,9 @@ deeplyNestedRefExample =
     barRef = "bar" =:= bazRef
     aRef = "a_ref" =:= barRef
     listRule = "list_rule" =:= arr [a VInt, a VInt]
+
+taggedUintExample :: Huddle
+taggedUintExample =
+  collectFrom
+    [ HIRule $ "root" =:= tag 42 VBytes
+    ]

--- a/test/Test/Codec/CBOR/Cuddle/CDDL/GeneratorSpec.hs
+++ b/test/Test/Codec/CBOR/Cuddle/CDDL/GeneratorSpec.hs
@@ -30,12 +30,13 @@ import Test.Codec.CBOR.Cuddle.CDDL.Examples.Huddle (
   refTermExample,
   sizeBytesExample,
   sizeTextExample,
+  taggedUintExample,
  )
 import Test.Codec.CBOR.Cuddle.CDDL.Validator (expectInvalid, genAndValidateRule)
 import Test.Hspec (HasCallStack, Spec, describe, runIO, shouldSatisfy, xdescribe)
 import Test.Hspec.Core.Spec (SpecM)
 import Test.Hspec.QuickCheck (prop)
-import Test.QuickCheck (Gen, Property, Testable (..), counterexample)
+import Test.QuickCheck (Gen, Property, Testable (..), classify, counterexample)
 import Text.Pretty.Simple (pShow)
 
 generateCDDL :: CTreeRoot GenPhase -> Gen Term
@@ -138,3 +139,33 @@ spec = do
             TBytes "\x01\x02\x03\xff" -> True
             TBytesI "\x01\x02\x03\xff" -> True
             _ -> False
+
+  describe "Tagged bytes zapping" $ do
+    taggedBytesCddl <- tryResolveHuddle taggedUintExample
+    let env =
+          GenEnv
+            { geRoot = mapIndex taggedBytesCddl
+            , geTwiddle = True
+            }
+    prop "labels zapped result" $ do
+      ZapResult {zrValue} <-
+        zapAntiGenResult 1 . runCBORGen env $ generateFromName "root"
+      let
+        isBytes TBytes {} = True
+        isBytes TBytesI {} = True
+        isBytes _ = False
+        tagOmitted = case zrValue of
+          TTagged {} -> False
+          _ -> True
+        tagChanged = case zrValue of
+          TTagged t _ -> t /= 42
+          _ -> False
+        innerValueZapped = case zrValue of
+          TTagged 42 inner -> not (isBytes inner)
+          _ -> False
+      pure
+        . classify tagOmitted "tag omitted"
+        . classify tagChanged "tag changed"
+        . classify innerValueZapped "inner value zapped"
+        $ expectInvalid
+          (validateCBOR (toStrictByteString $ encodeTerm zrValue) "root" $ mapIndex taggedBytesCddl)


### PR DESCRIPTION
This PR adds a decision point to `genTag` that omits the tag when zapped.

resolve https://github.com/input-output-hk/cuddle/issues/175