### PR TITLE
Make generator omit optional fields less frequently

### DIFF
--- a/src/Codec/CBOR/Cuddle/CBOR/Gen.hs
+++ b/src/Codec/CBOR/Cuddle/CBOR/Gen.hs
@@ -408,7 +408,7 @@ genMap nodes = do
         -- No term was produced, keep the index
         same x y = scale (\s -> max 0 (s - 1)) $ genNodes i x y
         optGenKV kNode vNode = sized $ \sz ->
-          frequency [(100, pure Nothing), (max 0 sz, ann $ tryGenKV 10 m kNode vNode)]
+          frequency [(1, pure Nothing), (max 0 sz, ann $ tryGenKV 10 m kNode vNode)]
        in
         case n of
           KV kNode vNode _ -> do


### PR DESCRIPTION
The probability for omitting a KV from a map was too high previously, causing the generator to generate empty maps too frequently. This PR tweaks the weights to improve generator quality.