### PR TITLE
Preserve line breaks in parsed comments

### DIFF
--- a/golden/pretty/basic_assign.txt
+++ b/golden/pretty/basic_assign.txt
@@ -6,7 +6,7 @@ header =
   [ header_body
   , body_signature : $kes_signature
   , test           : coin/ null
-  , withComment    : null ;  This is a comment
+  , withComment    : null ; This is a comment
   , true
   ]
 

--- a/golden/pretty/conway.txt
+++ b/golden/pretty/conway.txt
@@ -15,26 +15,38 @@ $kes_signature /= bytes .size 448
 
 signkeyKES = bytes .size 64
 
-$signature /=
-  bytes .size 64 ;  extra.cddl Conway era introduces an optional 258 tag for sets, which will become mandatory in the second era after Conway. We recommend all the tooling to account for this future breaking change sooner rather than later, in order to provide a smooth transition for their users. This is an unordered set. Duplicate elements are not allowed and the order of elements is implementation specific.
+$signature /= bytes .size 64
 
-set<a> =
-  #6.258([* a])
-  / [* a] ;  Just like `set`, but must contain at least one element.
+;  extra.cddl
+;  Conway era introduces an optional 258 tag for sets, which will become mandatory in the
+;  second era after Conway. We recommend all the tooling to account for this future breaking
+;  change sooner rather than later, in order to provide a smooth transition for their users.
 
-nonempty_set<a> =
-  #6.258([+ a])
-  / [ + a
-  ] ;  This is a non-empty ordered set. Duplicate elements are not allowed and the order of elements will be preserved.
+;  This is an unordered set. Duplicate elements are not allowed and the order of elements is implementation specific.
+set<a> = #6.258([* a])/ [* a]
 
+;  Just like `set`, but must contain at least one element.
+nonempty_set<a> = #6.258([+ a])/ [+ a]
+
+;  This is a non-empty ordered set. Duplicate elements are not allowed and the order of elements will be preserved.
 nonempty_oset<a> = #6.258([+ a])/ [+ a]
 
 positive_int = 1 .. 18446744073709551615
 
 unit_interval =
-  #6.30(
-    [1, 2]
-  ) ;  unit_interval = #6.30([uint, uint]) Comment above depicts the actual definition for `unit_interval`. Unit interval is a number in the range between 0 and 1, which means there are two extra constraints: * numerator <= denominator * denominator > 0 Relation between numerator and denominator cannot be expressed in CDDL, which poses a problem for testing. We need to be able to generate random valid data for testing implementation of our encoders/decoders. Which means we cannot use the actual definition here and we hard code the value to 1/2
+  #6.30([1, 2]) ;  unit_interval = #6.30([uint, uint])
+                ;
+                ;  Comment above depicts the actual definition for `unit_interval`.
+                ;
+                ;  Unit interval is a number in the range between 0 and 1, which
+                ;  means there are two extra constraints:
+                ;  * numerator <= denominator
+                ;  * denominator > 0
+                ;
+                ;  Relation between numerator and denominator cannot be expressed in CDDL, which
+                ;  poses a problem for testing. We need to be able to generate random valid data
+                ;  for testing implementation of our encoders/decoders. Which means we cannot use
+                ;  the actual definition here and we hard code the value to 1/2
 
 nonnegative_interval = #6.30([uint, positive_int])
 
@@ -54,23 +66,33 @@ reward_account =
 
 bounded_bytes =
   bytes .size ( 0 .. 64
-              ) ;  the real bounded_bytes does not have this limit. it instead has a different limit which cannot be expressed in CDDL. The limit is as follows:  - bytes with a definite-length encoding are limited to size 0..64  - for bytes with an indefinite-length CBOR encoding, each chunk is    limited to size 0..64  ( reminder: in CBOR, the indefinite-length encoding of bytestrings    consists of a token #2.31 followed by a sequence of definite-length    encoded bytestrings and a stop code ) a type for distinct values. The type parameter must support .size, for example: bytes or uint
+              ) ;  the real bounded_bytes does not have this limit. it instead has a different
+                ;  limit which cannot be expressed in CDDL.
+                ;  The limit is as follows:
+                ;   - bytes with a definite-length encoding are limited to size 0..64
+                ;   - for bytes with an indefinite-length CBOR encoding, each chunk is
+                ;     limited to size 0..64
+                ;   ( reminder: in CBOR, the indefinite-length encoding of bytestrings
+                ;     consists of a token #2.31 followed by a sequence of definite-length
+                ;     encoded bytestrings and a stop code )
 
+;  a type for distinct values.
+;  The type parameter must support .size, for example: bytes or uint
 distinct<a> =
-  a .size 8
-  / a .size 16
-  / a .size 20
-  / a .size 24
-  / a .size 30
-  / a .size 32 ;  conway.cddl
+  a .size 8/ a .size 16/ a .size 20/ a .size 24/ a .size 30/ a .size 32
 
+;  conway.cddl
 block =
   [ header
   , transaction_bodies       : [* transaction_body]
   , transaction_witness_sets : [* transaction_witness_set]
   , auxiliary_data_set       : {* transaction_index => auxiliary_data}
   , invalid_transactions     : [* transaction_index]
-  ] ;  Valid blocks must also satisfy the following two constraints: 1) the length of transaction_bodies and transaction_witness_sets    must be the same 2) every transaction_index must be strictly smaller than the    length of transaction_bodies
+  ] ;  Valid blocks must also satisfy the following two constraints:
+    ;  1) the length of transaction_bodies and transaction_witness_sets
+    ;     must be the same
+    ;  2) every transaction_index must be strictly smaller than the
+    ;     length of transaction_bodies
 
 transaction =
   [transaction_body, transaction_witness_set, bool, auxiliary_data/ null]
@@ -171,9 +193,13 @@ new_constitution = (5, gov_action_id/ null, constitution)
 
 constitution = [anchor, scripthash/ null]
 
-info_action =
-  6 ;  Constitutional Committee Hot KeyHash: 0 Constitutional Committee Hot ScriptHash: 1 DRep KeyHash: 2 DRep ScriptHash: 3 StakingPool KeyHash: 4
+info_action = 6
 
+;  Constitutional Committee Hot KeyHash: 0
+;  Constitutional Committee Hot ScriptHash: 1
+;  DRep KeyHash: 2
+;  DRep ScriptHash: 3
+;  StakingPool KeyHash: 4
 voter =
   [  0, addr_keyhash
   // 1, scripthash
@@ -182,9 +208,11 @@ voter =
   // 4, addr_keyhash
   ]
 
-anchor =
-  [anchor_url : url, anchor_data_hash : $hash32] ;  no - 0 yes - 1 abstain - 2
+anchor = [anchor_url : url, anchor_data_hash : $hash32]
 
+;  no - 0
+;  yes - 1
+;  abstain - 2
 vote = 0 .. 2
 
 gov_action_id = [transaction_id : $hash32, gov_action_index : uint]
@@ -205,7 +233,103 @@ post_alonzo_transaction_output =
   }
 
 script_data_hash =
-  $hash32 ;  This is a hash of data which may affect evaluation of a script. This data consists of:   - The redeemers from the transaction_witness_set (the value of field 5).   - The datums from the transaction_witness_set (the value of field 4).   - The value in the costmdls map corresponding to the script's language     (in field 18 of protocol_param_update.) (In the future it may contain additional protocol parameters.) Since this data does not exist in contiguous form inside a transaction, it needs to be independently constructed by each recipient. The bytestring which is hashed is the concatenation of three things:   redeemers || datums || language views The redeemers are exactly the data present in the transaction witness set. Similarly for the datums, if present. If no datums are provided, the middle field is omitted (i.e. it is the empty/null bytestring). language views CDDL: { * language => script_integrity_data } This must be encoded canonically, using the same scheme as in RFC7049 section 3.9:  - Maps, strings, and bytestrings must use a definite-length encoding  - Integers must be as small as possible.  - The expressions for map length, string length, and bytestring length    must be as short as possible.  - The keys in the map must be sorted as follows:     -  If two keys have different lengths, the shorter one sorts earlier.     -  If two keys have the same length, the one with the lower value        in (byte-wise) lexical order sorts earlier. For PlutusV1 (language id 0), the language view is the following:   - the value of costmdls map at key 0 (in other words, the script_integrity_data)     is encoded as an indefinite length list and the result is encoded as a bytestring.     (our apologies)     For example, the script_integrity_data corresponding to the all zero costmodel for V1     would be encoded as (in hex):     58a89f00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ff   - the language ID tag is also encoded twice. first as a uint then as     a bytestring. (our apologies)     Concretely, this means that the language version for V1 is encoded as     4100 in hex. For PlutusV2 (language id 1), the language view is the following:   - the value of costmdls map at key 1 is encoded as an definite length list.     For example, the script_integrity_data corresponding to the all zero costmodel for V2     would be encoded as (in hex):     98af0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000   - the language ID tag is encoded as expected.     Concretely, this means that the language version for V2 is encoded as     01 in hex. For PlutusV3 (language id 2), the language view is the following:   - the value of costmdls map at key 2 is encoded as a definite length list. Note that each Plutus language represented inside a transaction must have a cost model in the costmdls protocol parameter in order to execute, regardless of what the script integrity data is. Finally, note that in the case that a transaction includes datums but does not include the redeemers field, the script data format becomes (in hex): [ 80 | datums | A0 ] corresponding to a CBOR empty list and an empty map. Note that a transaction might include the redeemers field and  it to the empty map, in which case the user supplied encoding of the empty map is used. address = bytes reward_account = bytes address format: [ 8 bit header | payload ]; shelley payment addresses: bit 7: 0 bit 6: base/other bit 5: pointer/enterprise [for base: stake cred is keyhash/scripthash] bit 4: payment cred is keyhash/scripthash bits 3-0: network id reward addresses: bits 7-5: 111 bit 4: credential is keyhash/scripthash bits 3-0: network id byron addresses: bits 7-4: 1000 0000: base address: keyhash28,keyhash28 0001: base address: scripthash28,keyhash28 0010: base address: keyhash28,scripthash28 0011: base address: scripthash28,scripthash28 0100: pointer address: keyhash28, 3 variable length uint 0101: pointer address: scripthash28, 3 variable length uint 0110: enterprise address: keyhash28 0111: enterprise address: scripthash28 1000: byron address 1110: reward account: keyhash28 1111: reward account: scripthash28 1001 - 1101: future formats
+  $hash32 ;  This is a hash of data which may affect evaluation of a script.
+          ;  This data consists of:
+          ;    - The redeemers from the transaction_witness_set (the value of field 5).
+          ;    - The datums from the transaction_witness_set (the value of field 4).
+          ;    - The value in the costmdls map corresponding to the script's language
+          ;      (in field 18 of protocol_param_update.)
+          ;  (In the future it may contain additional protocol parameters.)
+          ;
+          ;  Since this data does not exist in contiguous form inside a transaction, it needs
+          ;  to be independently constructed by each recipient.
+          ;
+          ;  The bytestring which is hashed is the concatenation of three things:
+          ;    redeemers || datums || language views
+          ;  The redeemers are exactly the data present in the transaction witness set.
+          ;  Similarly for the datums, if present. If no datums are provided, the middle
+          ;  field is omitted (i.e. it is the empty/null bytestring).
+          ;
+          ;  language views CDDL:
+          ;  { * language => script_integrity_data }
+          ;
+          ;  This must be encoded canonically, using the same scheme as in
+          ;  RFC7049 section 3.9:
+          ;   - Maps, strings, and bytestrings must use a definite-length encoding
+          ;   - Integers must be as small as possible.
+          ;   - The expressions for map length, string length, and bytestring length
+          ;     must be as short as possible.
+          ;   - The keys in the map must be sorted as follows:
+          ;      -  If two keys have different lengths, the shorter one sorts earlier.
+          ;      -  If two keys have the same length, the one with the lower value
+          ;         in (byte-wise) lexical order sorts earlier.
+          ;
+          ;  For PlutusV1 (language id 0), the language view is the following:
+          ;    - the value of costmdls map at key 0 (in other words, the script_integrity_data)
+          ;      is encoded as an indefinite length list and the result is encoded as a bytestring.
+          ;      (our apologies)
+          ;      For example, the script_integrity_data corresponding to the all zero costmodel for V1
+          ;      would be encoded as (in hex):
+          ;      58a89f00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ff
+          ;    - the language ID tag is also encoded twice. first as a uint then as
+          ;      a bytestring. (our apologies)
+          ;      Concretely, this means that the language version for V1 is encoded as
+          ;      4100 in hex.
+          ;  For PlutusV2 (language id 1), the language view is the following:
+          ;    - the value of costmdls map at key 1 is encoded as an definite length list.
+          ;      For example, the script_integrity_data corresponding to the all zero costmodel for V2
+          ;      would be encoded as (in hex):
+          ;      98af0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+          ;    - the language ID tag is encoded as expected.
+          ;      Concretely, this means that the language version for V2 is encoded as
+          ;      01 in hex.
+          ;  For PlutusV3 (language id 2), the language view is the following:
+          ;    - the value of costmdls map at key 2 is encoded as a definite length list.
+          ;
+          ;  Note that each Plutus language represented inside a transaction must have
+          ;  a cost model in the costmdls protocol parameter in order to execute,
+          ;  regardless of what the script integrity data is.
+          ;
+          ;  Finally, note that in the case that a transaction includes datums but does not
+          ;  include the redeemers field, the script data format becomes (in hex):
+          ;  [ 80 | datums | A0 ]
+          ;  corresponding to a CBOR empty list and an empty map.
+          ;  Note that a transaction might include the redeemers field and  it to the
+          ;  empty map, in which case the user supplied encoding of the empty map is used.
+
+;  address = bytes
+;  reward_account = bytes
+
+;  address format:
+;  [ 8 bit header | payload ];
+;
+;  shelley payment addresses:
+;  bit 7: 0
+;  bit 6: base/other
+;  bit 5: pointer/enterprise [for base: stake cred is keyhash/scripthash]
+;  bit 4: payment cred is keyhash/scripthash
+;  bits 3-0: network id
+;
+;  reward addresses:
+;  bits 7-5: 111
+;  bit 4: credential is keyhash/scripthash
+;  bits 3-0: network id
+;
+;  byron addresses:
+;  bits 7-4: 1000
+
+;  0000: base address: keyhash28,keyhash28
+;  0001: base address: scripthash28,keyhash28
+;  0010: base address: keyhash28,scripthash28
+;  0011: base address: scripthash28,scripthash28
+;  0100: pointer address: keyhash28, 3 variable length uint
+;  0101: pointer address: scripthash28, 3 variable length uint
+;  0110: enterprise address: keyhash28
+;  0111: enterprise address: scripthash28
+;  1000: byron address
+;  1110: reward account: keyhash28
+;  1111: reward account: scripthash28
+;  1001 - 1101: future formats
 
 certificate =
   [  stake_registration
@@ -392,8 +516,12 @@ transaction_witness_set =
   , ? 5 : redeemers
   , ? 6 : nonempty_set<plutus_v2_script>
   , ? 7 : nonempty_set<plutus_v3_script>
-  } ;  The real type of  plutus_v1_script, plutus_v2_script and plutus_v3_script is bytes. However, because we enforce uniqueness when many scripts are supplied, we need to hack around for tests in order to avoid generating duplicates, since the cddl tool we use for roundtrip testing doesn't generate distinct collections.
+  }
 
+;  The real type of  plutus_v1_script, plutus_v2_script and plutus_v3_script is bytes.
+;  However, because we enforce uniqueness when many scripts are supplied,
+;  we need to hack around for tests in order to avoid generating duplicates,
+;  since the cddl tool we use for roundtrip testing doesn't generate distinct collections.
 plutus_v1_script = distinct<bytes>
 
 plutus_v2_script = distinct<bytes>
@@ -431,7 +559,8 @@ redeemers =
   , data     : plutus_data
   , ex_units : ex_units
   ]
-  ] ;  TODO: Add alternative implementation that reflects the reality more accuratly:  / { + [ tag: redeemer_tag, index: uint ] => [ data: plutus_data, ex_units: ex_units ] }
+  ] ;  TODO: Add alternative implementation that reflects the reality more accuratly:
+    ;   / { + [ tag: redeemer_tag, index: uint ] => [ data: plutus_data, ex_units: ex_units ] }
 
 redeemer_tag =
   0 ;  Spending
@@ -451,9 +580,11 @@ language =
   / 1 ;  Plutus v2
   / 2 ;  Plutus v3
 
-potential_languages =
-  0 .. 255 ;  The format for costmdls is flexible enough to allow adding Plutus built-ins and language versions in the future.
+potential_languages = 0 .. 255
 
+;  The format for costmdls is flexible enough to allow adding Plutus built-ins and language
+;  versions in the future.
+;
 costmdls =
   { ? 0 : [ 166* int
           ] ;  Plutus v1, only 166 integers are used, but more are accepted (and ignored)
@@ -504,8 +635,10 @@ native_script =
   // script_all
   // script_any
   // script_n_of_k
-  // invalid_before ;  Timelock validity intervals are half-open intervals [a, b). This field specifies the left (included) endpoint a.
-  // invalid_hereafter ;  Timelock validity intervals are half-open intervals [a, b). This field specifies the right (excluded) endpoint b.
+  // invalid_before ;  Timelock validity intervals are half-open intervals [a, b).
+                    ;  This field specifies the left (included) endpoint a.
+  // invalid_hereafter ;  Timelock validity intervals are half-open intervals [a, b).
+                       ;  This field specifies the right (excluded) endpoint b.
   ]
 
 script_pubkey = (0, addr_keyhash)
@@ -556,9 +689,16 @@ vrf_keyhash = $hash32
 
 auxiliary_data_hash = $hash32
 
-pool_metadata_hash =
-  $hash32 ;  To compute a script hash, note that you must prepend a tag to the bytes of the script before hashing. The tag is determined by the language. The tags in the Conway era are:   "\x00" for multisig scripts   "\x01" for Plutus V1 scripts   "\x02" for Plutus V2 scripts   "\x03" for Plutus V3 scripts
+pool_metadata_hash = $hash32
 
+;  To compute a script hash, note that you must prepend
+;  a tag to the bytes of the script before hashing.
+;  The tag is determined by the language.
+;  The tags in the Conway era are:
+;    "\x00" for multisig scripts
+;    "\x01" for Plutus V1 scripts
+;    "\x02" for Plutus V2 scripts
+;    "\x03" for Plutus V3 scripts
 scripthash = $hash28
 
 datum_hash = $hash32

--- a/golden/pretty/conway.txt
+++ b/golden/pretty/conway.txt
@@ -1,4 +1,4 @@
-;  crypto.cddl
+; crypto.cddl
 $hash28 /= bytes .size 28
 
 $hash32 /= bytes .size 32
@@ -17,36 +17,36 @@ signkeyKES = bytes .size 64
 
 $signature /= bytes .size 64
 
-;  extra.cddl
-;  Conway era introduces an optional 258 tag for sets, which will become mandatory in the
-;  second era after Conway. We recommend all the tooling to account for this future breaking
-;  change sooner rather than later, in order to provide a smooth transition for their users.
+; extra.cddl
+; Conway era introduces an optional 258 tag for sets, which will become mandatory in the
+; second era after Conway. We recommend all the tooling to account for this future breaking
+; change sooner rather than later, in order to provide a smooth transition for their users.
 
-;  This is an unordered set. Duplicate elements are not allowed and the order of elements is implementation specific.
+; This is an unordered set. Duplicate elements are not allowed and the order of elements is implementation specific.
 set<a> = #6.258([* a])/ [* a]
 
-;  Just like `set`, but must contain at least one element.
+; Just like `set`, but must contain at least one element.
 nonempty_set<a> = #6.258([+ a])/ [+ a]
 
-;  This is a non-empty ordered set. Duplicate elements are not allowed and the order of elements will be preserved.
+; This is a non-empty ordered set. Duplicate elements are not allowed and the order of elements will be preserved.
 nonempty_oset<a> = #6.258([+ a])/ [+ a]
 
 positive_int = 1 .. 18446744073709551615
 
 unit_interval =
-  #6.30([1, 2]) ;  unit_interval = #6.30([uint, uint])
+  #6.30([1, 2]) ; unit_interval = #6.30([uint, uint])
                 ;
-                ;  Comment above depicts the actual definition for `unit_interval`.
+                ; Comment above depicts the actual definition for `unit_interval`.
                 ;
-                ;  Unit interval is a number in the range between 0 and 1, which
-                ;  means there are two extra constraints:
-                ;  * numerator <= denominator
-                ;  * denominator > 0
+                ; Unit interval is a number in the range between 0 and 1, which
+                ; means there are two extra constraints:
+                ; * numerator <= denominator
+                ; * denominator > 0
                 ;
-                ;  Relation between numerator and denominator cannot be expressed in CDDL, which
-                ;  poses a problem for testing. We need to be able to generate random valid data
-                ;  for testing implementation of our encoders/decoders. Which means we cannot use
-                ;  the actual definition here and we hard code the value to 1/2
+                ; Relation between numerator and denominator cannot be expressed in CDDL, which
+                ; poses a problem for testing. We need to be able to generate random valid data
+                ; for testing implementation of our encoders/decoders. Which means we cannot use
+                ; the actual definition here and we hard code the value to 1/2
 
 nonnegative_interval = #6.30([uint, positive_int])
 
@@ -66,33 +66,33 @@ reward_account =
 
 bounded_bytes =
   bytes .size ( 0 .. 64
-              ) ;  the real bounded_bytes does not have this limit. it instead has a different
-                ;  limit which cannot be expressed in CDDL.
-                ;  The limit is as follows:
-                ;   - bytes with a definite-length encoding are limited to size 0..64
-                ;   - for bytes with an indefinite-length CBOR encoding, each chunk is
-                ;     limited to size 0..64
-                ;   ( reminder: in CBOR, the indefinite-length encoding of bytestrings
-                ;     consists of a token #2.31 followed by a sequence of definite-length
-                ;     encoded bytestrings and a stop code )
+              ) ; the real bounded_bytes does not have this limit. it instead has a different
+                ; limit which cannot be expressed in CDDL.
+                ; The limit is as follows:
+                ;  - bytes with a definite-length encoding are limited to size 0..64
+                ;  - for bytes with an indefinite-length CBOR encoding, each chunk is
+                ;    limited to size 0..64
+                ;  ( reminder: in CBOR, the indefinite-length encoding of bytestrings
+                ;    consists of a token #2.31 followed by a sequence of definite-length
+                ;    encoded bytestrings and a stop code )
 
-;  a type for distinct values.
-;  The type parameter must support .size, for example: bytes or uint
+; a type for distinct values.
+; The type parameter must support .size, for example: bytes or uint
 distinct<a> =
   a .size 8/ a .size 16/ a .size 20/ a .size 24/ a .size 30/ a .size 32
 
-;  conway.cddl
+; conway.cddl
 block =
   [ header
   , transaction_bodies       : [* transaction_body]
   , transaction_witness_sets : [* transaction_witness_set]
   , auxiliary_data_set       : {* transaction_index => auxiliary_data}
   , invalid_transactions     : [* transaction_index]
-  ] ;  Valid blocks must also satisfy the following two constraints:
-    ;  1) the length of transaction_bodies and transaction_witness_sets
-    ;     must be the same
-    ;  2) every transaction_index must be strictly smaller than the
-    ;     length of transaction_bodies
+  ] ; Valid blocks must also satisfy the following two constraints:
+    ; 1) the length of transaction_bodies and transaction_witness_sets
+    ;    must be the same
+    ; 2) every transaction_index must be strictly smaller than the
+    ;    length of transaction_bodies
 
 transaction =
   [transaction_body, transaction_witness_set, bool, auxiliary_data/ null]
@@ -107,9 +107,9 @@ header_body =
   , prev_hash            : $hash32/ null
   , issuer_vkey          : $vkey
   , vrf_vkey             : $vrf_vkey
-  , vrf_result           : $vrf_cert ;  replaces nonce_vrf and leader_vrf
+  , vrf_result           : $vrf_cert ; replaces nonce_vrf and leader_vrf
   , block_body_size      : uint
-  , block_body_hash      : $hash32 ;  merkle triple root
+  , block_body_hash      : $hash32 ; merkle triple root
   , operational_cert
   , [protocol_version]
   ]
@@ -128,26 +128,26 @@ major_protocol_version = 1 .. next_major_protocol_version
 protocol_version = (major_protocol_version, uint)
 
 transaction_body =
-  {   0  : set<transaction_input> ;  inputs
+  {   0  : set<transaction_input> ; inputs
   ,   1  : [* transaction_output]
-  ,   2  : coin ;  fee
-  , ? 3  : uint ;  time to live
+  ,   2  : coin ; fee
+  , ? 3  : uint ; time to live
   , ? 4  : certificates
   , ? 5  : withdrawals
   , ? 7  : auxiliary_data_hash
-  , ? 8  : uint ;  validity interval start
+  , ? 8  : uint ; validity interval start
   , ? 9  : mint
   , ? 11 : script_data_hash
-  , ? 13 : nonempty_set<transaction_input> ;  collateral inputs
+  , ? 13 : nonempty_set<transaction_input> ; collateral inputs
   , ? 14 : required_signers
   , ? 15 : network_id
-  , ? 16 : transaction_output ;  collateral return
-  , ? 17 : coin ;  total collateral
-  , ? 18 : nonempty_set<transaction_input> ;  reference inputs
-  , ? 19 : voting_procedures ;  New; Voting procedures
-  , ? 20 : proposal_procedures ;  New; Proposal procedures
-  , ? 21 : coin ;  New; current treasury value
-  , ? 22 : positive_coin ;  New; donation
+  , ? 16 : transaction_output ; collateral return
+  , ? 17 : coin ; total collateral
+  , ? 18 : nonempty_set<transaction_input> ; reference inputs
+  , ? 19 : voting_procedures ; New; Voting procedures
+  , ? 20 : proposal_procedures ; New; Proposal procedures
+  , ? 21 : coin ; New; current treasury value
+  , ? 22 : positive_coin ; New; donation
   }
 
 voting_procedures = {+ voter => {+ gov_action_id => voting_procedure}}
@@ -195,11 +195,11 @@ constitution = [anchor, scripthash/ null]
 
 info_action = 6
 
-;  Constitutional Committee Hot KeyHash: 0
-;  Constitutional Committee Hot ScriptHash: 1
-;  DRep KeyHash: 2
-;  DRep ScriptHash: 3
-;  StakingPool KeyHash: 4
+; Constitutional Committee Hot KeyHash: 0
+; Constitutional Committee Hot ScriptHash: 1
+; DRep KeyHash: 2
+; DRep ScriptHash: 3
+; StakingPool KeyHash: 4
 voter =
   [  0, addr_keyhash
   // 1, scripthash
@@ -210,9 +210,9 @@ voter =
 
 anchor = [anchor_url : url, anchor_data_hash : $hash32]
 
-;  no - 0
-;  yes - 1
-;  abstain - 2
+; no - 0
+; yes - 1
+; abstain - 2
 vote = 0 .. 2
 
 gov_action_id = [transaction_id : $hash32, gov_action_index : uint]
@@ -228,108 +228,108 @@ legacy_transaction_output = [address, amount : value, ? datum_hash : $hash32]
 post_alonzo_transaction_output =
   {   0 : address
   ,   1 : value
-  , ? 2 : datum_option ;  datum option
-  , ? 3 : script_ref ;  script reference
+  , ? 2 : datum_option ; datum option
+  , ? 3 : script_ref ; script reference
   }
 
 script_data_hash =
-  $hash32 ;  This is a hash of data which may affect evaluation of a script.
-          ;  This data consists of:
-          ;    - The redeemers from the transaction_witness_set (the value of field 5).
-          ;    - The datums from the transaction_witness_set (the value of field 4).
-          ;    - The value in the costmdls map corresponding to the script's language
-          ;      (in field 18 of protocol_param_update.)
-          ;  (In the future it may contain additional protocol parameters.)
+  $hash32 ; This is a hash of data which may affect evaluation of a script.
+          ; This data consists of:
+          ;   - The redeemers from the transaction_witness_set (the value of field 5).
+          ;   - The datums from the transaction_witness_set (the value of field 4).
+          ;   - The value in the costmdls map corresponding to the script's language
+          ;     (in field 18 of protocol_param_update.)
+          ; (In the future it may contain additional protocol parameters.)
           ;
-          ;  Since this data does not exist in contiguous form inside a transaction, it needs
-          ;  to be independently constructed by each recipient.
+          ; Since this data does not exist in contiguous form inside a transaction, it needs
+          ; to be independently constructed by each recipient.
           ;
-          ;  The bytestring which is hashed is the concatenation of three things:
-          ;    redeemers || datums || language views
-          ;  The redeemers are exactly the data present in the transaction witness set.
-          ;  Similarly for the datums, if present. If no datums are provided, the middle
-          ;  field is omitted (i.e. it is the empty/null bytestring).
+          ; The bytestring which is hashed is the concatenation of three things:
+          ;   redeemers || datums || language views
+          ; The redeemers are exactly the data present in the transaction witness set.
+          ; Similarly for the datums, if present. If no datums are provided, the middle
+          ; field is omitted (i.e. it is the empty/null bytestring).
           ;
-          ;  language views CDDL:
-          ;  { * language => script_integrity_data }
+          ; language views CDDL:
+          ; { * language => script_integrity_data }
           ;
-          ;  This must be encoded canonically, using the same scheme as in
-          ;  RFC7049 section 3.9:
-          ;   - Maps, strings, and bytestrings must use a definite-length encoding
-          ;   - Integers must be as small as possible.
-          ;   - The expressions for map length, string length, and bytestring length
-          ;     must be as short as possible.
-          ;   - The keys in the map must be sorted as follows:
-          ;      -  If two keys have different lengths, the shorter one sorts earlier.
-          ;      -  If two keys have the same length, the one with the lower value
-          ;         in (byte-wise) lexical order sorts earlier.
+          ; This must be encoded canonically, using the same scheme as in
+          ; RFC7049 section 3.9:
+          ;  - Maps, strings, and bytestrings must use a definite-length encoding
+          ;  - Integers must be as small as possible.
+          ;  - The expressions for map length, string length, and bytestring length
+          ;    must be as short as possible.
+          ;  - The keys in the map must be sorted as follows:
+          ;     -  If two keys have different lengths, the shorter one sorts earlier.
+          ;     -  If two keys have the same length, the one with the lower value
+          ;        in (byte-wise) lexical order sorts earlier.
           ;
-          ;  For PlutusV1 (language id 0), the language view is the following:
-          ;    - the value of costmdls map at key 0 (in other words, the script_integrity_data)
-          ;      is encoded as an indefinite length list and the result is encoded as a bytestring.
-          ;      (our apologies)
-          ;      For example, the script_integrity_data corresponding to the all zero costmodel for V1
-          ;      would be encoded as (in hex):
-          ;      58a89f00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ff
-          ;    - the language ID tag is also encoded twice. first as a uint then as
-          ;      a bytestring. (our apologies)
-          ;      Concretely, this means that the language version for V1 is encoded as
-          ;      4100 in hex.
-          ;  For PlutusV2 (language id 1), the language view is the following:
-          ;    - the value of costmdls map at key 1 is encoded as an definite length list.
-          ;      For example, the script_integrity_data corresponding to the all zero costmodel for V2
-          ;      would be encoded as (in hex):
-          ;      98af0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
-          ;    - the language ID tag is encoded as expected.
-          ;      Concretely, this means that the language version for V2 is encoded as
-          ;      01 in hex.
-          ;  For PlutusV3 (language id 2), the language view is the following:
-          ;    - the value of costmdls map at key 2 is encoded as a definite length list.
+          ; For PlutusV1 (language id 0), the language view is the following:
+          ;   - the value of costmdls map at key 0 (in other words, the script_integrity_data)
+          ;     is encoded as an indefinite length list and the result is encoded as a bytestring.
+          ;     (our apologies)
+          ;     For example, the script_integrity_data corresponding to the all zero costmodel for V1
+          ;     would be encoded as (in hex):
+          ;     58a89f00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ff
+          ;   - the language ID tag is also encoded twice. first as a uint then as
+          ;     a bytestring. (our apologies)
+          ;     Concretely, this means that the language version for V1 is encoded as
+          ;     4100 in hex.
+          ; For PlutusV2 (language id 1), the language view is the following:
+          ;   - the value of costmdls map at key 1 is encoded as an definite length list.
+          ;     For example, the script_integrity_data corresponding to the all zero costmodel for V2
+          ;     would be encoded as (in hex):
+          ;     98af0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+          ;   - the language ID tag is encoded as expected.
+          ;     Concretely, this means that the language version for V2 is encoded as
+          ;     01 in hex.
+          ; For PlutusV3 (language id 2), the language view is the following:
+          ;   - the value of costmdls map at key 2 is encoded as a definite length list.
           ;
-          ;  Note that each Plutus language represented inside a transaction must have
-          ;  a cost model in the costmdls protocol parameter in order to execute,
-          ;  regardless of what the script integrity data is.
+          ; Note that each Plutus language represented inside a transaction must have
+          ; a cost model in the costmdls protocol parameter in order to execute,
+          ; regardless of what the script integrity data is.
           ;
-          ;  Finally, note that in the case that a transaction includes datums but does not
-          ;  include the redeemers field, the script data format becomes (in hex):
-          ;  [ 80 | datums | A0 ]
-          ;  corresponding to a CBOR empty list and an empty map.
-          ;  Note that a transaction might include the redeemers field and  it to the
-          ;  empty map, in which case the user supplied encoding of the empty map is used.
+          ; Finally, note that in the case that a transaction includes datums but does not
+          ; include the redeemers field, the script data format becomes (in hex):
+          ; [ 80 | datums | A0 ]
+          ; corresponding to a CBOR empty list and an empty map.
+          ; Note that a transaction might include the redeemers field and  it to the
+          ; empty map, in which case the user supplied encoding of the empty map is used.
 
-;  address = bytes
-;  reward_account = bytes
+; address = bytes
+; reward_account = bytes
 
-;  address format:
-;  [ 8 bit header | payload ];
+; address format:
+; [ 8 bit header | payload ];
 ;
-;  shelley payment addresses:
-;  bit 7: 0
-;  bit 6: base/other
-;  bit 5: pointer/enterprise [for base: stake cred is keyhash/scripthash]
-;  bit 4: payment cred is keyhash/scripthash
-;  bits 3-0: network id
+; shelley payment addresses:
+; bit 7: 0
+; bit 6: base/other
+; bit 5: pointer/enterprise [for base: stake cred is keyhash/scripthash]
+; bit 4: payment cred is keyhash/scripthash
+; bits 3-0: network id
 ;
-;  reward addresses:
-;  bits 7-5: 111
-;  bit 4: credential is keyhash/scripthash
-;  bits 3-0: network id
+; reward addresses:
+; bits 7-5: 111
+; bit 4: credential is keyhash/scripthash
+; bits 3-0: network id
 ;
-;  byron addresses:
-;  bits 7-4: 1000
+; byron addresses:
+; bits 7-4: 1000
 
-;  0000: base address: keyhash28,keyhash28
-;  0001: base address: scripthash28,keyhash28
-;  0010: base address: keyhash28,scripthash28
-;  0011: base address: scripthash28,scripthash28
-;  0100: pointer address: keyhash28, 3 variable length uint
-;  0101: pointer address: scripthash28, 3 variable length uint
-;  0110: enterprise address: keyhash28
-;  0111: enterprise address: scripthash28
-;  1000: byron address
-;  1110: reward account: keyhash28
-;  1111: reward account: scripthash28
-;  1001 - 1101: future formats
+; 0000: base address: keyhash28,keyhash28
+; 0001: base address: scripthash28,keyhash28
+; 0010: base address: keyhash28,scripthash28
+; 0011: base address: scripthash28,scripthash28
+; 0100: pointer address: keyhash28, 3 variable length uint
+; 0101: pointer address: scripthash28, 3 variable length uint
+; 0110: enterprise address: keyhash28
+; 0111: enterprise address: scripthash28
+; 1000: byron address
+; 1110: reward account: keyhash28
+; 1111: reward account: scripthash28
+; 1001 - 1101: future formats
 
 certificate =
   [  stake_registration
@@ -353,21 +353,21 @@ certificate =
 
 stake_registration = (0, stake_credential)
 
-;  to be deprecated in era after Conway
+; to be deprecated in era after Conway
 stake_deregistration = (1, stake_credential)
 
-;  to be deprecated in era after Conway
+; to be deprecated in era after Conway
 stake_delegation = (2, stake_credential, pool_keyhash)
 
-;  POOL
+; POOL
 pool_registration = (3, pool_params)
 
 pool_retirement = (4, pool_keyhash, epoch)
 
-;  numbers 5 and 6 used to be the Genesis and MIR certificates respectively,
-;  which were deprecated in Conway
+; numbers 5 and 6 used to be the Genesis and MIR certificates respectively,
+; which were deprecated in Conway
 
-;  DELEG
+; DELEG
 reg_cert = (7, stake_credential, coin)
 
 unreg_cert = (8, stake_credential, coin)
@@ -382,7 +382,7 @@ vote_reg_deleg_cert = (12, stake_credential, drep, coin)
 
 stake_vote_reg_deleg_cert = (13, stake_credential, pool_keyhash, drep, coin)
 
-;  GOVCERT
+; GOVCERT
 auth_committee_hot_cert =
   (14, committee_cold_credential, committee_hot_credential)
 
@@ -401,8 +401,8 @@ credential = [0, addr_keyhash// 1, scripthash]
 drep =
   [  0, addr_keyhash
   // 1, scripthash
-  // 2 ;  always abstain
-  // 3 ;  always no confidence
+  // 2 ; always abstain
+  // 3 ; always no confidence
   ]
 
 stake_credential = credential
@@ -438,12 +438,12 @@ single_host_addr = (0, port/ null, ipv4/ null, ipv6/ null)
 single_host_name =
   ( 1
   , port/ null
-  , dns_name ;  An A or AAAA DNS record
+  , dns_name ; An A or AAAA DNS record
   )
 
 multi_host_name =
   ( 2
-  , dns_name ;  A SRV DNS record
+  , dns_name ; A SRV DNS record
   )
 
 relay = [single_host_addr// single_host_name// multi_host_name]
@@ -455,56 +455,56 @@ url = tstr .size (0 .. 128)
 withdrawals = {+ reward_account => coin}
 
 protocol_param_update =
-  { ? 0  : coin ;  minfee A
-  , ? 1  : coin ;  minfee B
-  , ? 2  : uint ;  max block body size
-  , ? 3  : uint ;  max transaction size
-  , ? 4  : uint ;  max block header size
-  , ? 5  : coin ;  key deposit
-  , ? 6  : coin ;  pool deposit
-  , ? 7  : epoch ;  maximum epoch
-  , ? 8  : uint ;  n_opt: desired number of stake pools
-  , ? 9  : nonnegative_interval ;  pool pledge influence
-  , ? 10 : unit_interval ;  expansion rate
-  , ? 11 : unit_interval ;  treasury growth rate
-  , ? 16 : coin ;  min pool cost
-  , ? 17 : coin ;  ada per utxo byte
-  , ? 18 : costmdls ;  cost models for script languages
-  , ? 19 : ex_unit_prices ;  execution costs
-  , ? 20 : ex_units ;  max tx ex units
-  , ? 21 : ex_units ;  max block ex units
-  , ? 22 : uint ;  max value size
-  , ? 23 : uint ;  collateral percentage
-  , ? 24 : uint ;  max collateral inputs
-  , ? 25 : pool_voting_thresholds ;  pool voting thresholds
-  , ? 26 : drep_voting_thresholds ;  DRep voting thresholds
-  , ? 27 : uint ;  min committee size
-  , ? 28 : epoch ;  committee term limit
-  , ? 29 : epoch ;  governance action validity period
-  , ? 30 : coin ;  governance action deposit
-  , ? 31 : coin ;  DRep deposit
-  , ? 32 : epoch ;  DRep inactivity period
+  { ? 0  : coin ; minfee A
+  , ? 1  : coin ; minfee B
+  , ? 2  : uint ; max block body size
+  , ? 3  : uint ; max transaction size
+  , ? 4  : uint ; max block header size
+  , ? 5  : coin ; key deposit
+  , ? 6  : coin ; pool deposit
+  , ? 7  : epoch ; maximum epoch
+  , ? 8  : uint ; n_opt: desired number of stake pools
+  , ? 9  : nonnegative_interval ; pool pledge influence
+  , ? 10 : unit_interval ; expansion rate
+  , ? 11 : unit_interval ; treasury growth rate
+  , ? 16 : coin ; min pool cost
+  , ? 17 : coin ; ada per utxo byte
+  , ? 18 : costmdls ; cost models for script languages
+  , ? 19 : ex_unit_prices ; execution costs
+  , ? 20 : ex_units ; max tx ex units
+  , ? 21 : ex_units ; max block ex units
+  , ? 22 : uint ; max value size
+  , ? 23 : uint ; collateral percentage
+  , ? 24 : uint ; max collateral inputs
+  , ? 25 : pool_voting_thresholds ; pool voting thresholds
+  , ? 26 : drep_voting_thresholds ; DRep voting thresholds
+  , ? 27 : uint ; min committee size
+  , ? 28 : epoch ; committee term limit
+  , ? 29 : epoch ; governance action validity period
+  , ? 30 : coin ; governance action deposit
+  , ? 31 : coin ; DRep deposit
+  , ? 32 : epoch ; DRep inactivity period
   }
 
 pool_voting_thresholds =
-  [ unit_interval ;  motion no confidence
-  , unit_interval ;  committee normal
-  , unit_interval ;  committee no confidence
-  , unit_interval ;  hard fork initiation
-  , unit_interval ;  security relevant parameter voting threshold
+  [ unit_interval ; motion no confidence
+  , unit_interval ; committee normal
+  , unit_interval ; committee no confidence
+  , unit_interval ; hard fork initiation
+  , unit_interval ; security relevant parameter voting threshold
   ]
 
 drep_voting_thresholds =
-  [ unit_interval ;  motion no confidence
-  , unit_interval ;  committee normal
-  , unit_interval ;  committee no confidence
-  , unit_interval ;  update constitution
-  , unit_interval ;  hard fork initiation
-  , unit_interval ;  PP network group
-  , unit_interval ;  PP economic group
-  , unit_interval ;  PP technical group
-  , unit_interval ;  PP governance group
-  , unit_interval ;  treasury withdrawal
+  [ unit_interval ; motion no confidence
+  , unit_interval ; committee normal
+  , unit_interval ; committee no confidence
+  , unit_interval ; update constitution
+  , unit_interval ; hard fork initiation
+  , unit_interval ; PP network group
+  , unit_interval ; PP economic group
+  , unit_interval ; PP technical group
+  , unit_interval ; PP governance group
+  , unit_interval ; treasury withdrawal
   ]
 
 transaction_witness_set =
@@ -518,10 +518,10 @@ transaction_witness_set =
   , ? 7 : nonempty_set<plutus_v3_script>
   }
 
-;  The real type of  plutus_v1_script, plutus_v2_script and plutus_v3_script is bytes.
-;  However, because we enforce uniqueness when many scripts are supplied,
-;  we need to hack around for tests in order to avoid generating duplicates,
-;  since the cddl tool we use for roundtrip testing doesn't generate distinct collections.
+; The real type of  plutus_v1_script, plutus_v2_script and plutus_v3_script is bytes.
+; However, because we enforce uniqueness when many scripts are supplied,
+; we need to hack around for tests in order to avoid generating duplicates,
+; since the cddl tool we use for roundtrip testing doesn't generate distinct collections.
 plutus_v1_script = distinct<bytes>
 
 plutus_v2_script = distinct<bytes>
@@ -550,7 +550,7 @@ constr<a> =
   / #6.126([* a])
   / #6.127(
     [* a]
-  )               ;  similarly for tag range: 6.1280 .. 6.1400 inclusive
+  )               ; similarly for tag range: 6.1280 .. 6.1400 inclusive
   / #6.102([uint, [* a]])
 
 redeemers =
@@ -559,16 +559,16 @@ redeemers =
   , data     : plutus_data
   , ex_units : ex_units
   ]
-  ] ;  TODO: Add alternative implementation that reflects the reality more accuratly:
-    ;   / { + [ tag: redeemer_tag, index: uint ] => [ data: plutus_data, ex_units: ex_units ] }
+  ] ; TODO: Add alternative implementation that reflects the reality more accuratly:
+    ;  / { + [ tag: redeemer_tag, index: uint ] => [ data: plutus_data, ex_units: ex_units ] }
 
 redeemer_tag =
-  0 ;  Spending
-  / 1 ;  Minting
-  / 2 ;  Certifying
-  / 3 ;  Rewarding
-  / 4 ;  Voting
-  / 5 ;  Proposing
+  0 ; Spending
+  / 1 ; Minting
+  / 2 ; Certifying
+  / 3 ; Rewarding
+  / 4 ; Voting
+  / 5 ; Proposing
 
 ex_units = [mem : uint, steps : uint]
 
@@ -576,24 +576,24 @@ ex_unit_prices =
   [mem_price : nonnegative_interval, step_price : nonnegative_interval]
 
 language =
-  0 ;  Plutus v1
-  / 1 ;  Plutus v2
-  / 2 ;  Plutus v3
+  0 ; Plutus v1
+  / 1 ; Plutus v2
+  / 2 ; Plutus v3
 
 potential_languages = 0 .. 255
 
-;  The format for costmdls is flexible enough to allow adding Plutus built-ins and language
-;  versions in the future.
+; The format for costmdls is flexible enough to allow adding Plutus built-ins and language
+; versions in the future.
 ;
 costmdls =
   { ? 0 : [ 166* int
-          ] ;  Plutus v1, only 166 integers are used, but more are accepted (and ignored)
+          ] ; Plutus v1, only 166 integers are used, but more are accepted (and ignored)
   , ? 1 : [ 175* int
-          ] ;  Plutus v2, only 175 integers are used, but more are accepted (and ignored)
+          ] ; Plutus v2, only 175 integers are used, but more are accepted (and ignored)
   , ? 2 : [ 223* int
-          ] ;  Plutus v3, only 223 integers are used, but more are accepted (and ignored)
+          ] ; Plutus v3, only 223 integers are used, but more are accepted (and ignored)
   , ? 3 : [ int
-          ] ;  Any 8-bit unsigned number can be used as a key.
+          ] ; Any 8-bit unsigned number can be used as a key.
   }
 
 transaction_metadatum =
@@ -608,12 +608,12 @@ transaction_metadatum_label = uint
 metadata = {* transaction_metadatum_label => transaction_metadatum}
 
 auxiliary_data =
-  metadata                                                                                                                                                                           ;  Shelley
-  / [ transaction_metadata : metadata ;  Shelley-ma
+  metadata                                                                                                                                                                          ; Shelley
+  / [ transaction_metadata : metadata ; Shelley-ma
   , auxiliary_scripts : [* native_script]
   ]
   / #6.259(
-    { ? 0 => metadata ;  Alonzo and beyond
+    { ? 0 => metadata ; Alonzo and beyond
     , ? 1 => [* native_script]
     , ? 2 => [* plutus_v1_script]
     , ? 3 => [* plutus_v2_script]
@@ -635,10 +635,10 @@ native_script =
   // script_all
   // script_any
   // script_n_of_k
-  // invalid_before ;  Timelock validity intervals are half-open intervals [a, b).
-                    ;  This field specifies the left (included) endpoint a.
-  // invalid_hereafter ;  Timelock validity intervals are half-open intervals [a, b).
-                       ;  This field specifies the right (excluded) endpoint b.
+  // invalid_before ; Timelock validity intervals are half-open intervals [a, b).
+                    ; This field specifies the left (included) endpoint a.
+  // invalid_hereafter ; Timelock validity intervals are half-open intervals [a, b).
+                       ; This field specifies the right (excluded) endpoint b.
   ]
 
 script_pubkey = (0, addr_keyhash)
@@ -667,7 +667,7 @@ posInt64 = 1 .. 9223372036854775807
 
 nonZeroInt64 =
   negInt64
-  / posInt64 ;  this is the same as the current int64 definition but without zero
+  / posInt64 ; this is the same as the current int64 definition but without zero
 
 positive_coin = 1 .. 18446744073709551615
 
@@ -691,14 +691,14 @@ auxiliary_data_hash = $hash32
 
 pool_metadata_hash = $hash32
 
-;  To compute a script hash, note that you must prepend
-;  a tag to the bytes of the script before hashing.
-;  The tag is determined by the language.
-;  The tags in the Conway era are:
-;    "\x00" for multisig scripts
-;    "\x01" for Plutus V1 scripts
-;    "\x02" for Plutus V2 scripts
-;    "\x03" for Plutus V3 scripts
+; To compute a script hash, note that you must prepend
+; a tag to the bytes of the script before hashing.
+; The tag is determined by the language.
+; The tags in the Conway era are:
+;   "\x00" for multisig scripts
+;   "\x01" for Plutus V1 scripts
+;   "\x02" for Plutus V2 scripts
+;   "\x03" for Plutus V3 scripts
 scripthash = $hash28
 
 datum_hash = $hash32

--- a/golden/pretty/costmdls_min.txt
+++ b/golden/pretty/costmdls_min.txt
@@ -1,4 +1,4 @@
 costmdls =
   { 0 : [ 11* int
-        ] ;  Plutus v1, only 166 integers are used, but more are accepted (and ignored)
+        ] ; Plutus v1, only 166 integers are used, but more are accepted (and ignored)
   }

--- a/golden/pretty/pretty.txt
+++ b/golden/pretty/pretty.txt
@@ -6,5 +6,5 @@ b = [1, uint, (3, 4)]
 
 c =
   { 1 : a
-  , 2 : b ;  hello
+  , 2 : b ; hello
   }

--- a/src/Codec/CBOR/Cuddle/Comments.hs
+++ b/src/Codec/CBOR/Cuddle/Comments.hs
@@ -33,13 +33,8 @@ import Optics.Core (Lens', lens, view, (%~), (&), (.~), (^.))
 
 newtype Comment = Comment T.Text
   deriving (Eq, Ord, Generic, Show)
-  deriving newtype (Monoid)
+  deriving newtype (Semigroup, Monoid)
   deriving anyclass (ToExpr, Hashable)
-
-instance Semigroup Comment where
-  Comment "" <> x = x
-  x <> Comment "" = x
-  Comment x <> Comment y = Comment $ x <> "\n" <> y
 
 unComment :: Comment -> [T.Text]
 unComment (Comment c) = T.lines c

--- a/src/Codec/CBOR/Cuddle/Parser.hs
+++ b/src/Codec/CBOR/Cuddle/Parser.hs
@@ -23,6 +23,7 @@ import Codec.CBOR.Cuddle.Parser.Lexer (
   charInRange,
   pCommentBlock,
   space,
+  trailingSpace,
  )
 import Control.Applicative.Combinators.NonEmpty qualified as NE
 import Data.ByteString.Base16 qualified as Base16
@@ -143,7 +144,7 @@ pGenericArg =
     <$> between "<" ">" (NE.sepBy1 (space !*> pType1 <*! space) ",")
 
 pType0 :: Parser (Type0 ParserStage)
-pType0 = Type0 <$> sepBy1' (space !*> pType1 <*! space) (try "/")
+pType0 = Type0 <$> sepBy1' (space !*> pType1 <*! trailingSpace) (try "/")
 
 pType1 :: Parser (Type1 ParserStage)
 pType1 = do

--- a/src/Codec/CBOR/Cuddle/Parser/Lexer.hs
+++ b/src/Codec/CBOR/Cuddle/Parser/Lexer.hs
@@ -4,8 +4,8 @@ module Codec.CBOR.Cuddle.Parser.Lexer (
   Parser,
   charInRange,
   space,
+  trailingSpace,
   pComment,
-  sameLineComment,
   (|||),
   pCommentBlock,
 ) where
@@ -13,12 +13,12 @@ module Codec.CBOR.Cuddle.Parser.Lexer (
 import Codec.CBOR.Cuddle.Comments (Comment (..))
 import Control.Applicative.Combinators.NonEmpty qualified as NE
 import Data.Foldable1 (Foldable1 (..))
-import Data.Functor (($>))
 import Data.Text (Text)
 import Data.Void (Void)
 import Text.Megaparsec (
   MonadParsec (..),
   Parsec,
+  many,
   sepEndBy,
   (<|>),
  )
@@ -35,7 +35,7 @@ charInRange lb ub x = lb <= x && x <= ub
 
 pComment :: Parser Comment
 pComment =
-  Comment <$> label "comment" (char ';' *> takeWhileP Nothing validChar <* eol)
+  Comment . (<> "\n") <$> label "comment" (char ';' *> takeWhileP Nothing validChar <* eol)
   where
     validChar = charInRange '\x20' '\x7e' ||| charInRange '\x80' '\x10fffd'
 
@@ -45,6 +45,24 @@ pCommentBlock = fold1 <$> NE.some (L.hspace *> pComment)
 space :: Parser Comment
 space = mconcat <$> (L.space *> sepEndBy pComment L.space)
 
-sameLineComment :: Parser Comment
-sameLineComment =
-  try ((<>) <$> (L.hspace *> pComment) <*> space) <|> (L.space $> mempty)
+-- | Non-greedy space consumer for use at construct boundaries.
+-- Consumes a same-line comment and any immediately adjacent comment lines
+-- (no blank line gap), then eats trailing blank lines.
+-- Does NOT cross blank-line boundaries to consume further comment blocks.
+trailingSpace :: Parser Comment
+trailingSpace = do
+  _ <- L.hspace
+  comments <- sameLineComments
+  L.space
+  pure $ mconcat comments
+  where
+    sameLineComments =
+      ( do
+          c <- pComment
+          rest <- adjacentComments
+          pure (c : rest)
+      )
+        <|> (eol *> adjacentComments)
+        <|> pure []
+
+    adjacentComments = many (try (L.hspace *> pComment))

--- a/src/Codec/CBOR/Cuddle/Pretty.hs
+++ b/src/Codec/CBOR/Cuddle/Pretty.hs
@@ -89,7 +89,7 @@ data CommentRender
   | PostComment
 
 prettyCommentNoBreak :: Comment -> Doc ann
-prettyCommentNoBreak = align . vsep . toList . fmap (pretty . ("; " <>)) . unComment
+prettyCommentNoBreak = align . vsep . toList . fmap (pretty . (";" <>)) . unComment
 
 prettyCommentNoBreakWS :: Comment -> Doc ann
 prettyCommentNoBreakWS cmt

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -4,6 +4,7 @@ import System.IO (BufferMode (..), hSetBuffering, hSetEncoding, stdout, utf8)
 import Test.Codec.CBOR.Cuddle.CDDL.Examples qualified as Examples
 import Test.Codec.CBOR.Cuddle.CDDL.GeneratorSpec qualified as Generator
 import Test.Codec.CBOR.Cuddle.CDDL.Parser (parserSpec)
+import Test.Codec.CBOR.Cuddle.CDDL.Pretty (roundtripSpec)
 import Test.Codec.CBOR.Cuddle.CDDL.Pretty.Golden qualified as PrettyGolden
 import Test.Codec.CBOR.Cuddle.CDDL.Validator qualified as Validator
 import Test.Codec.CBOR.Cuddle.CDDL.Validator.Golden qualified as ValidatorGolden
@@ -28,6 +29,7 @@ main = do
     describe "Generator" Generator.spec
     describe "Pretty" $ do
       describe "Golden" PrettyGolden.spec
+      describe "Roundtrip" roundtripSpec
     describe "Validator" $ do
       describe "Properties" Validator.spec
       describe "Golden" ValidatorGolden.spec

--- a/test/Test/Codec/CBOR/Cuddle/CDDL/Pretty.hs
+++ b/test/Test/Codec/CBOR/Cuddle/CDDL/Pretty.hs
@@ -4,6 +4,7 @@
 
 module Test.Codec.CBOR.Cuddle.CDDL.Pretty (
   spec,
+  roundtripSpec,
 ) where
 
 import Codec.CBOR.Cuddle.CDDL (
@@ -25,18 +26,23 @@ import Codec.CBOR.Cuddle.CDDL (
 import Codec.CBOR.Cuddle.Huddle (HuddleItem (..), a, bstr, (<+), (=:=), (=:~))
 import Codec.CBOR.Cuddle.Huddle qualified as H
 import Codec.CBOR.Cuddle.IndexMappable (IndexMappable (..))
-import Codec.CBOR.Cuddle.Pretty (PrettyStage, XRule (..))
+import Codec.CBOR.Cuddle.Parser (pCDDL)
+import Codec.CBOR.Cuddle.Pretty (PrettyStage, XRule (..), renderCDDL)
 import Data.Default.Class (Default (..))
 import Data.List.NonEmpty (NonEmpty (..))
 import Data.Text qualified as T
+import Data.Text.IO qualified as T
 import Data.TreeDiff (ToExpr (..), prettyExpr)
+import Paths_cuddle (getDataFileName)
 import Prettyprinter (Pretty (..), defaultLayoutOptions, layoutPretty)
 import Prettyprinter.Render.String (renderString)
 import Test.Codec.CBOR.Cuddle.CDDL.Gen ()
 import Test.HUnit (assertEqual)
-import Test.Hspec (Expectation, Spec, describe, it, shouldBe, xit)
+import Test.Hspec (Expectation, Spec, describe, it, runIO, shouldBe, xit)
 import Test.Hspec.QuickCheck (xprop)
 import Test.QuickCheck (counterexample)
+import Text.Megaparsec (parse)
+import Text.Megaparsec.Error (errorBundlePretty)
 import Prelude hiding ((/))
 
 prettyPrintsTo :: (Pretty a, ToExpr a) => a -> String -> Expectation
@@ -164,7 +170,7 @@ unitSpec = describe "HUnit" $ do
                     :| []
                 )
             )
-            `prettyPrintsTo` "[ 1 ; one\n, 2 ; two\n]"
+            `prettyPrintsTo` "[ 1 ;one\n, 2 ;two\n]"
         it "two elements with multiline comments" $
           T2Array
             ( Group
@@ -182,7 +188,7 @@ unitSpec = describe "HUnit" $ do
                     :| []
                 )
             )
-            `prettyPrintsTo` "[ 1 ; first\n    ; multiline comment\n, 2 ; second\n    ; multiline comment\n]"
+            `prettyPrintsTo` "[ 1 ;first\n    ;multiline comment\n, 2 ;second\n    ;multiline comment\n]"
     describe "Rule" $ do
       it "simple assignment" $
         Rule @PrettyStage
@@ -199,7 +205,7 @@ unitSpec = describe "HUnit" $ do
           AssignEq
           (TOGType (Type0 (Type1 (T2Name (Name "b") mempty) Nothing mempty :| [])))
           (PrettyXRule "comment")
-          `prettyPrintsTo` "; comment\na = b"
+          `prettyPrintsTo` ";comment\na = b"
       xit "drep" $
         drep
           `prettyPrintsTo` "drep = [0, addr_keyhash // 1, script_hash // 2 // 3]"
@@ -214,14 +220,14 @@ unitSpec = describe "HUnit" $ do
           `huddlePrettyPrintsTo` "a = true\n"
       it "simple assignment with comment" $
         [HIRule $ H.comment "comment" $ "a" =:= H.bool True]
-          `huddlePrettyPrintsTo` "; comment\na = true\n"
+          `huddlePrettyPrintsTo` ";comment\na = true\n"
       it "comment and reference" $
         let
           b = H.comment "this is rule 'b'" $ "b" =:= H.text "bee"
          in
           [ HIRule $ H.comment "comment" $ "a" =:= b
           ]
-            `huddlePrettyPrintsTo` "; comment\na = b\n\n; this is rule 'b'\nb = \"bee\"\n"
+            `huddlePrettyPrintsTo` ";comment\na = b\n\n;this is rule 'b'\nb = \"bee\"\n"
       it "bstr expects hex, not bytes" $
         [ HIRule $ "a" =:= bstr "010200ff"
         ]
@@ -234,18 +240,45 @@ unitSpec = describe "HUnit" $ do
          in
           [ HIRule . H.comment "foo" $ "a" =:= b (H.bool True)
           ]
-            `huddlePrettyPrintsTo` "; foo\na = b<true>\n\n; bar\nb<a0> = [* a0]\n"
+            `huddlePrettyPrintsTo` ";foo\na = b<true>\n\n;bar\nb<a0> = [* a0]\n"
     describe "GroupDef" $ do
       it "simple pair" $
         [HIGroup $ "a" =:~ [a $ H.bool True, a $ H.int 3]]
           `huddlePrettyPrintsTo` "a = (true, 3)\n"
       it "simple pair with comment" $
         [HIGroup $ H.comment "comment" $ "a" =:~ [a $ H.bool True, a $ H.int 3]]
-          `huddlePrettyPrintsTo` "; comment\na = (true, 3)\n"
+          `huddlePrettyPrintsTo` ";comment\na = (true, 3)\n"
       it "comment and reference" $
         let
           b = H.comment "bar" $ "b" =:~ [a $ H.int 2, a $ H.text "bee"]
          in
           [ HIGroup . H.comment "foo" $ "a" =:~ [a $ H.bool True, a b]
           ]
-            `huddlePrettyPrintsTo` "; foo\na = (true, b)\n\n; bar\nb = (2, \"bee\")\n"
+            `huddlePrettyPrintsTo` ";foo\na = (true, b)\n\n;bar\nb = (2, \"bee\")\n"
+
+roundtripSpec :: Spec
+roundtripSpec = describe "Roundtrip (parse -> pretty -> parse)" $ do
+  prettyRoundtrip "basic_assign" "cddl/basic_assign.cddl"
+  prettyRoundtrip "pretty" "cddl/pretty.cddl"
+  prettyRoundtrip "costmdls_min" "cddl/costmdls_min.cddl"
+  prettyRoundtrip "issue80-min" "cddl/issue80-min.cddl"
+  prettyRoundtrip "conway" "cddl/conway.cddl"
+
+prettyRoundtrip :: String -> FilePath -> Spec
+prettyRoundtrip testName cddlPath = do
+  original <- runIO $ do
+    absolutePath <- getDataFileName cddlPath
+    contents <- T.readFile absolutePath
+    case parse pCDDL "" contents of
+      Left err -> fail $ "Failed to parse CDDL:\n" <> errorBundlePretty err
+      Right x -> pure x
+  it testName $ do
+    let
+      prettyStage1 = mapIndex @_ @_ @PrettyStage original
+      rendered = renderCDDL defaultLayoutOptions prettyStage1
+    case parse pCDDL "" rendered of
+      Left err ->
+        fail $ "Failed to re-parse pretty-printed CDDL:\n" <> errorBundlePretty err
+      Right reparsed ->
+        let prettyStage2 = mapIndex @_ @_ @PrettyStage reparsed
+         in prettyStage2 `shouldBe` prettyStage1


### PR DESCRIPTION
The parser used to remove newlines from comments, this PR fixes that issue. 

Also fixes the prettyprinter so that it doesn't add an extra space at the start of the comments. Without this fix, the comments would gain an extra space at the start for each parse -> prettyprint cycle.