### PR TITLE
Improve CLI argument parsing and autocompletion

### DIFF
--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -23,8 +23,7 @@ jobs:
       id: build
       run: |
         nix build --accept-flake-config .#static
-        echo "name=$(nix derivation show ./result | jq -r .[].env.name)" >>"$GITHUB_OUTPUT"
-        echo "artifacts=$(find -L result -type f)" >>"$GITHUB_OUTPUT"
+        echo "name=$(nix derivation show ./result | jq -r '.[].env.name')" >>"$GITHUB_OUTPUT"
 
     - name: Record system details
       id: system-details
@@ -36,4 +35,4 @@ jobs:
       uses: actions/upload-artifact@v7
       with:
         name: ${{ steps.build.outputs.name }}-${{ steps.system-details.outputs.system }}-${{ steps.system-details.outputs.machine }}
-        path: ${{ steps.build.outputs.artifacts }}
+        path: result/bin/*

--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -23,7 +23,7 @@ jobs:
       id: build
       run: |
         nix build --accept-flake-config .#static
-        echo "name=$(nix derivation show ./result | jq -r '.[].env.name')" >>"$GITHUB_OUTPUT"
+        echo "name=$(nix eval --raw .#static.name)" >>"$GITHUB_OUTPUT"
 
     - name: Record system details
       id: system-details
@@ -35,4 +35,4 @@ jobs:
       uses: actions/upload-artifact@v7
       with:
         name: ${{ steps.build.outputs.name }}-${{ steps.system-details.outputs.system }}-${{ steps.system-details.outputs.machine }}
-        path: result/bin/*
+        path: echo "artifacts=$(find -L result/bin -type f)" >>"$GITHUB_OUTPUT"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## 1.7.0.0
 
-* Make `--no-twiddle` optional
+* Fix `--no-twiddle` argument
+* Add autocompletion hints
+* Add footer, improve output format failure message
 
 ## 1.6.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for `cuddle`
 
+## 1.7.0.0
+
+* Make `--no-twiddle` optional
+
 ## 1.6.0.0
 
 * Remove `example` executable

--- a/bin/Main.hs
+++ b/bin/Main.hs
@@ -152,13 +152,14 @@ pGenOpts =
     <*> switch
       ( long "negative"
           <> short 'n'
-          <> help "Generate a negative example"
+          <> help "Generate a negative (zapped) example"
       )
-    <*> option
-      (not <$> auto)
-      ( long "no-twiddle"
-          <> help "Do not generate indefinite encodings"
-      )
+    <*> ( not
+            <$> switch
+              ( long "no-twiddle"
+                  <> help "Do not generate indefinite encodings"
+              )
+        )
     <*> argument
       str
       (metavar "RULE" <> help "Name of the CDDL rule to generate a CBOR term for")

--- a/bin/Main.hs
+++ b/bin/Main.hs
@@ -329,8 +329,6 @@ main = do
                     , "  Bash: source <(cuddle --bash-completion-script cuddle)"
                     , "  Zsh:  source <(cuddle --zsh-completion-script cuddle)"
                     , "  Fish: cuddle --fish-completion-script cuddle | source"
-                    , mempty
-                    , "Report bugs at https://github.com/input-output-hk/cuddle/issues"
                     ]
               )
         )

--- a/bin/Main.hs
+++ b/bin/Main.hs
@@ -50,6 +50,7 @@ import Prettyprinter (
   PageWidth (..),
   defaultLayoutOptions,
   layoutPretty,
+  vsep,
  )
 import Prettyprinter.Render.Terminal qualified as Ansi
 import System.Exit (exitFailure, exitSuccess)
@@ -102,7 +103,12 @@ pCBOROutputFormat :: ReadM CBOROutputFormat
 pCBOROutputFormat = eitherReader $ \k ->
   case Map.lookup k outputFormatOptions of
     Just x -> Right x
-    Nothing -> Left k
+    Nothing ->
+      Left $
+        unlines
+          [ "invalid value: " <> k
+          , "expecting one of: " <> unwords (Map.keys outputFormatOptions)
+          ]
 
 data GenOpts = GenOpts
   { outputFormat :: CBOROutputFormat
@@ -236,7 +242,12 @@ data FormatCBOROpts = FormatCBOROpts
 pCBORInputFormat :: ReadM CBORInputFormat
 pCBORInputFormat = eitherReader $ \k -> case Map.lookup k inputFormatOptions of
   Just x -> Right x
-  Nothing -> Left k
+  Nothing ->
+    Left $
+      unlines
+        [ "invalid value: " <> k
+        , "expecting one of: " <> unwords (Map.keys inputFormatOptions)
+        ]
 
 pFormatCBOROpts :: Parser FormatCBOROpts
 pFormatCBOROpts =
@@ -310,7 +321,18 @@ main = do
         (pCommand <**> helper <**> simpleVersioner (showVersion version))
         ( fullDesc
             <> progDesc "Manipulate CDDL files"
-            <> header "cuddle"
+            <> header "cuddle - a CDDL tool for validating, formatting, and generating CBOR"
+            <> footerDoc
+              ( Just $
+                  vsep
+                    [ "To enable shell completions, add the appropriate line to your shell config:"
+                    , "  Bash: source <(cuddle --bash-completion-script cuddle)"
+                    , "  Zsh:  source <(cuddle --zsh-completion-script cuddle)"
+                    , "  Fish: cuddle --fish-completion-script cuddle | source"
+                    , mempty
+                    , "Report bugs at https://github.com/input-output-hk/cuddle/issues"
+                    ]
+              )
         )
   run options
 

--- a/bin/Main.hs
+++ b/bin/Main.hs
@@ -131,6 +131,7 @@ pGenOpts =
           ( long "out-file"
               <> short 'o'
               <> help "Write to"
+              <> action "file"
           )
       )
     <*> switch
@@ -213,7 +214,7 @@ pValidateCBOROpts =
       ( metavar "RULE"
           <> help "Name of the CDDL rule to validate this file with"
       )
-    <*> argument str (metavar "CBOR_FILE")
+    <*> argument str (metavar "CBOR_FILE" <> action "file")
 
 data CBORInputFormat
   = FromHex
@@ -259,6 +260,7 @@ pFormatCBOROpts =
           ( long "out-file"
               <> short 'o'
               <> help "Write to"
+              <> action "file"
           )
       )
 
@@ -268,31 +270,34 @@ pCommand =
     ( command
         "format"
         ( info
-            (Format <$> pFormatOpts <*> argument str (metavar "CDDL_FILE") <**> helper)
+            (Format <$> pFormatOpts <*> argument str (metavar "CDDL_FILE" <> action "file") <**> helper)
             (progDesc "Format the provided CDDL file")
         )
         <> command
           "validate"
           ( info
-              (Validate <$> pValidateOpts <*> argument str (metavar "CDDL_FILE") <**> helper)
+              (Validate <$> pValidateOpts <*> argument str (metavar "CDDL_FILE" <> action "file") <**> helper)
               (progDesc "Validate the provided CDDL file")
           )
         <> command
           "gen"
           ( info
-              (GenerateCBOR <$> pGenOpts <*> argument str (metavar "CDDL_FILE") <**> helper)
+              (GenerateCBOR <$> pGenOpts <*> argument str (metavar "CDDL_FILE" <> action "file") <**> helper)
               (progDesc "Generate a CBOR term matching the schema")
           )
         <> command
           "validate-cbor"
           ( info
-              (ValidateCBOR <$> pValidateCBOROpts <*> argument str (metavar "CDDL_FILE") <**> helper)
+              ( ValidateCBOR
+                  <$> pValidateCBOROpts
+                  <*> argument str (metavar "CDDL_FILE" <> action "file") <**> helper
+              )
               (progDesc "Validate a CBOR file against a schema")
           )
         <> command
           "format-cbor"
           ( info
-              (FormatCBOR <$> pFormatCBOROpts <*> argument str (metavar "CBOR_FILE") <**> helper)
+              (FormatCBOR <$> pFormatCBOROpts <*> argument str (metavar "CBOR_FILE" <> action "file") <**> helper)
               (progDesc "Output a CBOR binary in diagnostic formatting")
           )
     )

--- a/cuddle.cabal
+++ b/cuddle.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.4
 name: cuddle
-version: 1.6.0.0
+version: 1.7.0.0
 synopsis: CDDL Generator and test utilities
 description:
   Cuddle is a library for generating and manipulating [CDDL](https://datatracker.ietf.org/doc/html/rfc8610).

--- a/nix/outputs.nix
+++ b/nix/outputs.nix
@@ -28,15 +28,28 @@ let
 
   packages = flake.packages;
 
-  static = pkgs.symlinkJoin {
-    inherit name;
+  addShellCompletions = drv: pkgs.runCommand name
+    {
+      nativeBuildInputs = [ pkgs.installShellFiles ];
+      meta.mainProgram = name;
+    } ''
+    mkdir -p $out/bin
+    cp ${drv}/bin/${name} $out/bin/${name}
+    installShellCompletion --cmd ${name} \
+      --bash <($out/bin/${name} --bash-completion-script $out/bin/${name}) \
+      --zsh  <($out/bin/${name} --zsh-completion-script $out/bin/${name}) \
+      --fish <($out/bin/${name} --fish-completion-script $out/bin/${name})
+  '';
+
+  static = addShellCompletions (pkgs.symlinkJoin {
+    name = "${name}-unwrapped";
     paths =
       builtins.concatMap
         (p: lib.attrsets.attrValues p.components.exes)
         (builtins.filter
           (p: (p.isLocal or false) && p.identifier.name != "example")
           (lib.attrsets.attrValues project.projectCross.musl64.hsPkgs));
-  };
+  });
 
   devShells = lib.attrsets.mapAttrs
     (ghcName: _: mkShell ghcName)
@@ -53,6 +66,9 @@ let
 in
 
 flake // {
-  packages = packages // { inherit static; };
+  packages = packages // {
+    inherit static;
+    "${name}:exe:${name}" = addShellCompletions packages."${name}:exe:${name}";
+  };
   devShells = devShells // { default = devShells.${defaultVariant}; };
 }

--- a/nix/outputs.nix
+++ b/nix/outputs.nix
@@ -12,63 +12,80 @@ let
 
   name = "cuddle";
 
-  project = pkgs.haskell-nix.cabalProject' ({ ... }: {
-    inherit name;
-    src = lib.cleanSource ../.;
-    compiler-nix-name = lib.mkDefault "ghc967";
-    flake.variants = {
-      ghc96 = { }; # Alias for the default variant
-      ghc98.compiler-nix-name = "ghc984";
-      ghc910.compiler-nix-name = "ghc9102";
-      ghc912.compiler-nix-name = "ghc9122";
-    };
-  });
+  project = pkgs.haskell-nix.cabalProject' (
+    { ... }:
+    {
+      inherit name;
+      src = lib.cleanSource ../.;
+      compiler-nix-name = lib.mkDefault "ghc967";
+      flake.variants = {
+        ghc96 = { }; # Alias for the default variant
+        ghc98.compiler-nix-name = "ghc984";
+        ghc910.compiler-nix-name = "ghc9102";
+        ghc912.compiler-nix-name = "ghc9122";
+      };
+      modules = [
+        {
+          packages.${name}.components.exes.${name} = addShellCompletions name;
+        }
+      ];
+    }
+  );
+
+  addShellCompletions = name: {
+    build-tools = [ pkgs.installShellFiles ];
+    postInstall = ''
+      installShellCompletion --cmd ${name} \
+        --bash <($out/bin/${name} --bash-completion-script $out/bin/${name}) \
+        --zsh  <($out/bin/${name} --zsh-completion-script $out/bin/${name}) \
+        --fish <($out/bin/${name} --fish-completion-script $out/bin/${name})
+    '';
+  };
 
   flake = project.flake { };
 
   packages = flake.packages;
 
-  addShellCompletions = drv: pkgs.runCommand name
-    {
-      nativeBuildInputs = [ pkgs.installShellFiles ];
-      meta.mainProgram = name;
-    } ''
-    mkdir -p $out/bin
-    cp ${drv}/bin/${name} $out/bin/${name}
-    installShellCompletion --cmd ${name} \
-      --bash <($out/bin/${name} --bash-completion-script $out/bin/${name}) \
-      --zsh  <($out/bin/${name} --zsh-completion-script $out/bin/${name}) \
-      --fish <($out/bin/${name} --fish-completion-script $out/bin/${name})
-  '';
+  static = pkgs.symlinkJoin {
+    inherit name;
+    paths = builtins.concatMap (p: lib.attrsets.attrValues p.components.exes) (
+      builtins.filter (p: (p.isLocal or false) && p.identifier.name != "example") (
+        lib.attrsets.attrValues project.projectCross.musl64.hsPkgs
+      )
+    );
+  };
 
-  static = addShellCompletions (pkgs.symlinkJoin {
-    name = "${name}-unwrapped";
-    paths =
-      builtins.concatMap
-        (p: lib.attrsets.attrValues p.components.exes)
-        (builtins.filter
-          (p: (p.isLocal or false) && p.identifier.name != "example")
-          (lib.attrsets.attrValues project.projectCross.musl64.hsPkgs));
-  });
+  devShells = lib.attrsets.mapAttrs (ghcName: _: mkShell ghcName) project.projectVariants;
 
-  devShells = lib.attrsets.mapAttrs
-    (ghcName: _: mkShell ghcName)
-    project.projectVariants;
+  mkShell =
+    ghc:
+    import ./shell.nix {
+      inherit
+        ghc
+        pkgs
+        lib
+        project
+        pre-commit-hooks
+        ;
+    };
 
-  mkShell = ghc: import ./shell.nix { inherit ghc pkgs lib project pre-commit-hooks; };
-
-  defaultVariant =
-    lib.attrsets.foldlAttrs
-      (acc: k: v: if v ? "compiler-nix-name" then acc else k)
-      builtins.null
-      project.args.flake.variants;
+  defaultVariant = lib.attrsets.foldlAttrs
+    (
+      acc: k: v:
+        if v ? "compiler-nix-name" then acc else k
+    )
+    builtins.null
+    project.args.flake.variants;
 
 in
 
-flake // {
+flake
+  // {
   packages = packages // {
     inherit static;
-    "${name}:exe:${name}" = addShellCompletions packages."${name}:exe:${name}";
+    default = project.hsPkgs.${name}.components.exes.${name};
   };
-  devShells = devShells // { default = devShells.${defaultVariant}; };
+  devShells = devShells // {
+    default = devShells.${defaultVariant};
+  };
 }


### PR DESCRIPTION
The `--no-twiddle` argument was implemented incorrectly, which caused the option to be mandatory and made it take a `Bool` argument. I also fixed some other issues with the CLI and made the footer and header more informative.

resolve https://github.com/input-output-hk/cuddle/issues/140