### PR TITLE
Add a dependabot configuration for the github-actions ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+  open-pull-requests-limit: 5
+  groups:
+    actions:
+      patterns:
+      - "*"


### PR DESCRIPTION
This will keep our use of third-party GitHub Actions up to date

This is a copy of the file that was added in IntersectMBO/cardano-ledger#5703