### PR TITLE
Rework custom validators to work with generic rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@
 * Hide the `Comment` constructor; use `toComment` or `commentLine` smart constructors instead
 * Add `appendComment` for raw comment concatenation in parser combinators
 * Export `GRef` constructor
+* Custom generators and validators on generic rules can now refer to their
+  generic argument: looking up a `GRef` resolves to the type bound at the
+  enclosing rule
+* Add `generateFromGRef`
+* Add `validateFromName` and `validateFromGRef`
+* Move `GRef` to `Codec.CBOR.Cuddle.CDDL`
+* Add `MonadCddl`
+* `runCBORValidator` now takes `CTreeRoot ValidatorPhase` instead of `ValidateEnv`
+* Split `GenEnv` into a user-supplied `GenConfig` and a runtime `GenEnv`. `runCBORGen` now takes a `GenConfig`.
+* Rename `ValidatorStage` to `ValidatorPhase`
 
 ## 1.6.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Make `(//-)` prefix each comment line with a leading space and change its fixity from `infixr 0` to `infixl 1`
 * Hide the `Comment` constructor; use `toComment` or `commentLine` smart constructors instead
 * Add `appendComment` for raw comment concatenation in parser combinators
+* Export `GRef` constructor
 
 ## 1.6.0.0
 

--- a/bin/Main.hs
+++ b/bin/Main.hs
@@ -443,7 +443,7 @@ parseFromFile ::
   IO (Either (ParseErrorBundle T.Text e) a)
 parseFromFile p file = runParser p file <$> T.readFile file
 
-runValidateCBOR :: BS.ByteString -> Name -> CTreeRoot ValidatorStage -> TraceOptions -> IO ()
+runValidateCBOR :: BS.ByteString -> Name -> CTreeRoot ValidatorPhase -> TraceOptions -> IO ()
 runValidateCBOR bs rule cddl traceOpts =
   case validateCBOR bs rule cddl of
     Evidenced validity trc -> do

--- a/bin/Main.hs
+++ b/bin/Main.hs
@@ -15,7 +15,7 @@ import Codec.CBOR.Cuddle.CBOR.Validator.Trace (
   prettyValidationTrace,
  )
 import Codec.CBOR.Cuddle.CDDL (CDDL, Name (..), fromRules, sortCDDL)
-import Codec.CBOR.Cuddle.CDDL.CBORGenerator (GenEnv (..), runCBORGen)
+import Codec.CBOR.Cuddle.CDDL.CBORGenerator (GenConfig (..), runCBORGen)
 import Codec.CBOR.Cuddle.CDDL.CTree (CTreeRoot)
 import Codec.CBOR.Cuddle.CDDL.Postlude (appendPostlude)
 import Codec.CBOR.Cuddle.CDDL.Resolve (
@@ -398,12 +398,12 @@ run = \case
           zapN
             | goNegative = 1
             | otherwise = 0
-          env =
-            GenEnv
-              { geRoot = mapIndex mt
-              , geTwiddle = goTwiddle
+          cfg =
+            GenConfig
+              { gcRoot = mapIndex mt
+              , gcTwiddle = goTwiddle
               }
-          term = runGen seed goSize . zapAntiGen zapN . runCBORGen env $ generateFromName (Name itemName)
+          term = runGen seed goSize . zapAntiGen zapN . runCBORGen cfg $ generateFromName (Name itemName)
           formatted = formatTerm term outputFormat
         case outputTo of
           Just outputPath -> BS.writeFile outputPath formatted

--- a/example/Main.hs
+++ b/example/Main.hs
@@ -7,7 +7,7 @@ module Main (main) where
 
 import Codec.CBOR.Cuddle.CBOR.Gen (generateFromName)
 import Codec.CBOR.Cuddle.CDDL (Name (..))
-import Codec.CBOR.Cuddle.CDDL.CBORGenerator (GenEnv (..), runCBORGen)
+import Codec.CBOR.Cuddle.CDDL.CBORGenerator (GenConfig (..), runCBORGen)
 import Codec.CBOR.Cuddle.CDDL.Resolve (MonoSimple, fullResolveCDDL)
 import Codec.CBOR.Cuddle.Huddle (toCDDL)
 import Codec.CBOR.Cuddle.IndexMappable (IndexMappable (..), mapCDDLDropExt)
@@ -49,8 +49,8 @@ main = do
           case fullResolveCDDL (mapCDDLDropExt res) of
             Left nre -> error $ show nre
             Right resolved -> do
-              let genEnv = GenEnv {geRoot = mapIndex resolved, geTwiddle = True}
-              term <- generate . runAntiGen . runCBORGen genEnv $ generateFromName (Name (T.pack name))
+              let cfg = GenConfig {gcRoot = mapIndex resolved, gcTwiddle = True}
+              term <- generate . runAntiGen . runCBORGen cfg $ generateFromName (Name (T.pack name))
               print term
     [] -> do
       let cw = toCDDL conway

--- a/src/Codec/CBOR/Cuddle/CBOR/Gen.hs
+++ b/src/Codec/CBOR/Cuddle/CBOR/Gen.hs
@@ -16,6 +16,7 @@
 -- | Generate example CBOR given a CDDL specification
 module Codec.CBOR.Cuddle.CBOR.Gen (
   generateFromName,
+  generateFromGRef,
   GenPhase,
   GenSimple,
   XXCTree (..),
@@ -24,6 +25,7 @@ module Codec.CBOR.Cuddle.CBOR.Gen (
 #if MIN_VERSION_random(1,3,0)
 #endif
 import Codec.CBOR.Cuddle.CDDL (
+  GRef (..),
   Name (..),
   OccurrenceIndicator (..),
   RangeBound (..),
@@ -32,12 +34,14 @@ import Codec.CBOR.Cuddle.CDDL (
  )
 import Codec.CBOR.Cuddle.CDDL.CBORGenerator (
   CBORGen,
+  GenConfig (..),
   GenEnv (..),
   GenPhase,
   WrappedTerm (..),
   XXCTree (..),
   liftAntiGen,
   lookupCddl,
+  lookupGRef,
   withAntiGen,
   withTwiddle,
  )
@@ -160,28 +164,28 @@ genHalf = do
 
 twiddleString :: Text -> CBORGen Term
 twiddleString t = do
-  twiddle <- asks geTwiddle
+  twiddle <- asks (gcTwiddle . geConfig)
   if twiddle
     then ($ t) <$> elements [TString, TStringI . TL.fromStrict]
     else pure $ TString t
 
 twiddleList :: [Term] -> CBORGen Term
 twiddleList t = do
-  twiddle <- asks geTwiddle
+  twiddle <- asks (gcTwiddle . geConfig)
   if twiddle
     then ($ t) <$> elements [TList, TListI]
     else pure $ TList t
 
 twiddleBytes :: ByteString -> CBORGen Term
 twiddleBytes t = do
-  twiddle <- asks geTwiddle
+  twiddle <- asks (gcTwiddle . geConfig)
   if twiddle
     then ($ t) <$> elements [TBytes, TBytesI . LBS.fromStrict]
     else pure $ TBytes t
 
 twiddleMap :: [(Term, Term)] -> CBORGen Term
 twiddleMap t = do
-  twiddle <- asks geTwiddle
+  twiddle <- asks (gcTwiddle . geConfig)
   if twiddle
     then ($ t) <$> elements [TMap, TMapI]
     else pure $ TMap t
@@ -609,6 +613,16 @@ generateFromName n = do
             "Tried to generate a top-level term for "
               <> show n
               <> ", but it does not correspond to a single term."
+
+-- | Generate a 'WrappedTerm' for the type bound to the given generic
+-- parameter at the enclosing rule. Use this from inside a custom generator
+-- attached to a generic rule.
+generateFromGRef :: HasCallStack => GRef -> CBORGen WrappedTerm
+generateFromGRef ref = do
+  mRule <- lookupGRef ref
+  case mRule of
+    Nothing -> error $ "Unbound generic reference: " <> show ref
+    Just val -> genForCTree val
 
 sizeBiasedBool :: MonadGen m => m Bool
 sizeBiasedBool = sized $ \sz -> (> 1) <$> choose (0, sz)

--- a/src/Codec/CBOR/Cuddle/CBOR/Gen.hs
+++ b/src/Codec/CBOR/Cuddle/CBOR/Gen.hs
@@ -31,7 +31,7 @@ import Codec.CBOR.Cuddle.CDDL (
   ValueVariant (..),
  )
 import Codec.CBOR.Cuddle.CDDL.CBORGenerator (
-  CBORGen (..),
+  CBORGen,
   GenEnv (..),
   GenPhase,
   WrappedTerm (..),

--- a/src/Codec/CBOR/Cuddle/CBOR/Validator.hs
+++ b/src/Codec/CBOR/Cuddle/CBOR/Validator.hs
@@ -5,8 +5,9 @@
 
 module Codec.CBOR.Cuddle.CBOR.Validator (
   validateCBOR,
-  ValidatorPhase,
   validateFromName,
+  validateFromGRef,
+  ValidatorPhase,
 ) where
 
 import Codec.CBOR.Cuddle.CBOR.Validator.Trace (
@@ -33,6 +34,7 @@ import Codec.CBOR.Cuddle.CDDL.CBORGenerator (
   ValidatorPhase,
   WrappedTerm (..),
   lookupCddl,
+  lookupGRef,
   runValidator,
  )
 import Codec.CBOR.Cuddle.CDDL.CTree
@@ -83,7 +85,18 @@ validateFromName ::
 validateFromName n term = do
   mRule <- lookupCddl n
   case mRule of
-    Nothing -> fail $ "Unbound reference: " <> show n
+    Nothing -> fail $ "Unbound name: " <> show n
+    Just rule -> validateAgainst term rule
+
+-- | Validate a CBOR 'Term' against the type bound to the given generic
+-- parameter at the enclosing rule. Use this from inside a custom validator
+-- attached to a generic rule.
+validateFromGRef ::
+  HasCallStack => GRef -> Term -> Validator ()
+validateFromGRef ref term = do
+  mRule <- lookupGRef ref
+  case mRule of
+    Nothing -> fail $ "Unbound generic reference: " <> show ref
     Just rule -> validateAgainst term rule
 
 validateAgainst :: Term -> CTree ValidatorPhase -> Validator ()

--- a/src/Codec/CBOR/Cuddle/CBOR/Validator.hs
+++ b/src/Codec/CBOR/Cuddle/CBOR/Validator.hs
@@ -5,7 +5,8 @@
 
 module Codec.CBOR.Cuddle.CBOR.Validator (
   validateCBOR,
-  ValidatorStage,
+  ValidatorPhase,
+  validateFromName,
 ) where
 
 import Codec.CBOR.Cuddle.CBOR.Validator.Trace (
@@ -16,7 +17,6 @@ import Codec.CBOR.Cuddle.CBOR.Validator.Trace (
   MapValidationTrace (..),
   SValidity (..),
   ValidationTrace (..),
-  ValidatorStage,
   XXCTree (..),
   evidence,
   isValid,
@@ -24,12 +24,23 @@ import Codec.CBOR.Cuddle.CBOR.Validator.Trace (
   showSimple,
  )
 import Codec.CBOR.Cuddle.CDDL hiding (CDDL, Group, Rule)
-import Codec.CBOR.Cuddle.CDDL.CBORGenerator (CBORValidator (..), CustomValidatorResult (..))
+import Codec.CBOR.Cuddle.CDDL.CBORGenerator (
+  CustomValidatorResult (..),
+  MonadCddl (..),
+  TermValidator,
+  ValidateEnv (..),
+  Validator,
+  ValidatorPhase,
+  WrappedTerm (..),
+  lookupCddl,
+  runValidator,
+ )
 import Codec.CBOR.Cuddle.CDDL.CTree
 import Codec.CBOR.Cuddle.CDDL.CtlOp
 import Codec.CBOR.Cuddle.IndexMappable (IndexMappable (..))
 import Codec.CBOR.Read
 import Codec.CBOR.Term
+import Control.Monad.Reader (asks)
 import Data.Bifunctor (Bifunctor (..))
 import Data.Bits hiding (And)
 import Data.ByteString qualified as BS
@@ -56,7 +67,7 @@ validateCBOR ::
   HasCallStack =>
   BS.ByteString ->
   Name ->
-  CTreeRoot ValidatorStage ->
+  CTreeRoot ValidatorPhase ->
   Evidenced ValidationTrace
 validateCBOR bs rule cddl@(CTreeRoot tree) =
   case deserialiseFromBytes decodeTerm (BSL.fromStrict bs) of
@@ -65,21 +76,39 @@ validateCBOR bs rule cddl@(CTreeRoot tree) =
       | BSL.null rest -> validateTerm cddl term (tree Map.! rule)
       | otherwise -> error $ "Leftover bytes in CBOR: " <> show rest
 
+-- | Validate a CBOR 'Term' against a top-level rule from inside a custom
+-- validator.
+validateFromName ::
+  HasCallStack => Name -> Term -> Validator ()
+validateFromName n term = do
+  mRule <- lookupCddl n
+  case mRule of
+    Nothing -> fail $ "Unbound reference: " <> show n
+    Just rule -> validateAgainst term rule
+
+validateAgainst :: Term -> CTree ValidatorPhase -> Validator ()
+validateAgainst term rule = do
+  cddl <- asks veRoot
+  let res = validateTerm cddl term rule
+  if isValid res
+    then pure ()
+    else fail $ "Validation failed for term: " <> show term
+
 --------------------------------------------------------------------------------
 -- Terms
 
 -- | Core function that validates a CBOR term to a particular rule of the CDDL
 -- spec
 validateTerm ::
-  CTreeRoot ValidatorStage ->
+  CTreeRoot ValidatorPhase ->
   Term ->
-  CTree ValidatorStage ->
+  CTree ValidatorPhase ->
   Evidenced ValidationTrace
 validateTerm cddl term rule
   | CTreeE (VRuleRef n) <- rule =
       dereferenceAndValidate cddl n (validateTerm cddl term)
   | CTreeE (VValidator v _) <- rule =
-      runCustomValidator term v
+      runCustomValidator cddl (S term) v
   | otherwise =
       case term of
         TInt i -> validateInteger cddl (fromIntegral i) rule
@@ -100,18 +129,22 @@ validateTerm cddl term rule
         TFloat h -> validateFloat cddl h rule
         TDouble d -> validateDouble cddl d rule
 
-terminal :: CTree ValidatorStage -> Evidenced ValidationTrace
+terminal :: CTree ValidatorPhase -> Evidenced ValidationTrace
 terminal = evidence . TerminalRule . mapIndex
 
 -- | Run a custom validator on a term. This is used by type-specific validators
 -- when they encounter a 'VValidator' node after dereferencing a rule reference.
-runCustomValidator :: Term -> CBORValidator -> Evidenced ValidationTrace
-runCustomValidator term (CBORValidator validator) =
-  case validator term of
+runCustomValidator ::
+  CTreeRoot ValidatorPhase ->
+  WrappedTerm ->
+  TermValidator ->
+  Evidenced ValidationTrace
+runCustomValidator cddl term validator =
+  case runValidator (validator term) cddl of
     CustomValidatorSuccess -> evidence CustomSuccess
     CustomValidatorFailure err -> evidence $ CustomFailure err
 
-unapplicable :: CTree ValidatorStage -> Evidenced ValidationTrace
+unapplicable :: CTree ValidatorPhase -> Evidenced ValidationTrace
 unapplicable = evidence . UnapplicableRule . mapIndex
 
 --------------------------------------------------------------------------------
@@ -130,14 +163,14 @@ unapplicable = evidence . UnapplicableRule . mapIndex
 -- Ints, so we convert everything to Integer.
 validateInteger ::
   HasCallStack =>
-  CTreeRoot ValidatorStage ->
+  CTreeRoot ValidatorPhase ->
   Integer ->
-  CTree ValidatorStage ->
+  CTree ValidatorPhase ->
   Evidenced ValidationTrace
 validateInteger cddl i rule =
   case rule of
     CTreeE (VRuleRef n) -> dereferenceAndValidate cddl n $ validateInteger cddl i
-    CTreeE (VValidator v _) -> runCustomValidator (TInteger i) v
+    CTreeE (VValidator v _) -> runCustomValidator cddl (S $ TInteger i) v
     -- echo "C24101" | xxd -r -p - example.cbor
     -- echo "foo = int" > a.cddl
     -- cddl a.cddl validate example.cbor
@@ -229,10 +262,10 @@ validateInteger cddl i rule =
 -- | Controls for an Integer
 controlInteger ::
   HasCallStack =>
-  CTreeRoot ValidatorStage ->
+  CTreeRoot ValidatorPhase ->
   Integer ->
   CtlOp ->
-  CTree ValidatorStage ->
+  CTree ValidatorPhase ->
   Bool
 controlInteger cddl i op (CTreeE (VRuleRef n)) =
   controlInteger cddl i op $ dereference cddl n
@@ -302,12 +335,12 @@ controlInteger _ _ _ ctrl = error $ "unexpected control: " <> showSimple ctrl
 -- | Validating a `Float16`
 validateHalf ::
   HasCallStack =>
-  CTreeRoot ValidatorStage ->
+  CTreeRoot ValidatorPhase ->
   Float ->
-  CTree ValidatorStage ->
+  CTree ValidatorPhase ->
   Evidenced ValidationTrace
 validateHalf cddl f (CTreeE (VRuleRef n)) = dereferenceAndValidate cddl n $ validateHalf cddl f
-validateHalf _ f (CTreeE (VValidator v _)) = runCustomValidator (THalf f) v
+validateHalf cddl f (CTreeE (VValidator v _)) = runCustomValidator cddl (S $ THalf f) v
 validateHalf cddl f rule =
   case rule of
     -- a = any
@@ -332,10 +365,10 @@ validateHalf cddl f rule =
 -- | Controls for `Float16`
 controlHalf ::
   HasCallStack =>
-  CTreeRoot ValidatorStage ->
+  CTreeRoot ValidatorPhase ->
   Float ->
   CtlOp ->
-  CTree ValidatorStage ->
+  CTree ValidatorPhase ->
   Bool
 controlHalf cddl f op (CTreeE (VRuleRef n)) =
   controlHalf cddl f op $ dereference cddl n
@@ -352,13 +385,13 @@ controlHalf _ _ op _ = error $ "Not yet implemented for half: " <> show op
 -- | Validating a `Float32`
 validateFloat ::
   HasCallStack =>
-  CTreeRoot ValidatorStage ->
+  CTreeRoot ValidatorPhase ->
   Float ->
-  CTree ValidatorStage ->
+  CTree ValidatorPhase ->
   Evidenced ValidationTrace
 validateFloat cddl f (CTreeE (VRuleRef n)) =
   dereferenceAndValidate cddl n $ validateFloat cddl f
-validateFloat _ f (CTreeE (VValidator v _)) = runCustomValidator (TFloat f) v
+validateFloat cddl f (CTreeE (VValidator v _)) = runCustomValidator cddl (S $ TFloat f) v
 validateFloat cddl f rule =
   case rule of
     -- a = any
@@ -392,10 +425,10 @@ validateFloat cddl f rule =
 -- | Controls for `Float32`
 controlFloat ::
   HasCallStack =>
-  CTreeRoot ValidatorStage ->
+  CTreeRoot ValidatorPhase ->
   Float ->
   CtlOp ->
-  CTree ValidatorStage ->
+  CTree ValidatorPhase ->
   Bool
 controlFloat cddl f op (CTreeE (VRuleRef n)) =
   controlFloat cddl f op $ dereference cddl n
@@ -414,13 +447,13 @@ controlFloat _ _ op _ = error $ "Not yet implemented for float: " <> show op
 -- | Validating a `Float64`
 validateDouble ::
   HasCallStack =>
-  CTreeRoot ValidatorStage ->
+  CTreeRoot ValidatorPhase ->
   Double ->
-  CTree ValidatorStage ->
+  CTree ValidatorPhase ->
   Evidenced ValidationTrace
 validateDouble cddl f (CTreeE (VRuleRef n)) =
   dereferenceAndValidate cddl n $ validateDouble cddl f
-validateDouble _ f (CTreeE (VValidator v _)) = runCustomValidator (TDouble f) v
+validateDouble cddl f (CTreeE (VValidator v _)) = runCustomValidator cddl (S $ TDouble f) v
 validateDouble cddl f rule =
   case rule of
     -- a = any
@@ -458,10 +491,10 @@ validateDouble cddl f rule =
 -- | Controls for `Float64`
 controlDouble ::
   HasCallStack =>
-  CTreeRoot ValidatorStage ->
+  CTreeRoot ValidatorPhase ->
   Double ->
   CtlOp ->
-  CTree ValidatorStage ->
+  CTree ValidatorPhase ->
   Bool
 controlDouble cddl f op (CTreeE (VRuleRef n)) =
   controlDouble cddl f op $ dereference cddl n
@@ -484,13 +517,13 @@ controlDouble _ _ op _ = error $ "Not yet implmented for double: " <> show op
 
 -- | Validating a boolean
 validateBool ::
-  CTreeRoot ValidatorStage ->
+  CTreeRoot ValidatorPhase ->
   Bool ->
-  CTree ValidatorStage ->
+  CTree ValidatorPhase ->
   Evidenced ValidationTrace
 validateBool cddl b (CTreeE (VRuleRef n)) =
   dereferenceAndValidate cddl n $ validateBool cddl b
-validateBool _ b (CTreeE (VValidator v _)) = runCustomValidator (TBool b) v
+validateBool cddl b (CTreeE (VValidator v _)) = runCustomValidator cddl (S $ TBool b) v
 validateBool cddl b rule =
   case rule of
     -- a = any
@@ -508,10 +541,10 @@ validateBool cddl b rule =
 -- | Controls for `Bool`
 controlBool ::
   HasCallStack =>
-  CTreeRoot ValidatorStage ->
+  CTreeRoot ValidatorPhase ->
   Bool ->
   CtlOp ->
-  CTree ValidatorStage ->
+  CTree ValidatorPhase ->
   Bool
 controlBool cddl b op (CTreeE (VRuleRef n)) =
   controlBool cddl b op $ dereference cddl n
@@ -530,13 +563,13 @@ controlBool _ _ op _ = error $ "Not yet implemented for bool: " <> show op
 
 -- | Validating a `TSimple`. It is unclear if this is used for anything else than `undefined`.
 validateSimple ::
-  CTreeRoot ValidatorStage ->
+  CTreeRoot ValidatorPhase ->
   Word8 ->
-  CTree ValidatorStage ->
+  CTree ValidatorPhase ->
   Evidenced ValidationTrace
 validateSimple cddl i (CTreeE (VRuleRef n)) =
   dereferenceAndValidate cddl n $ validateSimple cddl i
-validateSimple _ i (CTreeE (VValidator v _)) = runCustomValidator (TSimple i) v
+validateSimple cddl i (CTreeE (VValidator v _)) = runCustomValidator cddl (S $ TSimple i) v
 validateSimple cddl 23 rule =
   case rule of
     -- a = any
@@ -552,10 +585,10 @@ validateSimple _ n _ = error $ "Found simple different to 23! please report this
 -- Null/nil
 
 -- | Validating nil
-validateNull :: CTreeRoot ValidatorStage -> CTree ValidatorStage -> Evidenced ValidationTrace
+validateNull :: CTreeRoot ValidatorPhase -> CTree ValidatorPhase -> Evidenced ValidationTrace
 validateNull cddl (CTreeE (VRuleRef n)) =
   dereferenceAndValidate cddl n $ validateNull cddl
-validateNull _ (CTreeE (VValidator v _)) = runCustomValidator TNull v
+validateNull cddl (CTreeE (VValidator v _)) = runCustomValidator cddl (S TNull) v
 validateNull cddl rule =
   case rule of
     -- a = any
@@ -570,10 +603,10 @@ validateNull cddl rule =
 
 -- | Validating a byte sequence
 validateBytes ::
-  CTreeRoot ValidatorStage -> BS.ByteString -> CTree ValidatorStage -> Evidenced ValidationTrace
+  CTreeRoot ValidatorPhase -> BS.ByteString -> CTree ValidatorPhase -> Evidenced ValidationTrace
 validateBytes cddl bs (CTreeE (VRuleRef n)) =
   dereferenceAndValidate cddl n $ validateBytes cddl bs
-validateBytes _ bs (CTreeE (VValidator v _)) = runCustomValidator (TBytes bs) v
+validateBytes cddl bs (CTreeE (VValidator v _)) = runCustomValidator cddl (S $ TBytes bs) v
 validateBytes cddl bs rule =
   case rule of
     -- a = any
@@ -591,10 +624,10 @@ validateBytes cddl bs rule =
 -- | Controls for byte strings
 controlBytes ::
   HasCallStack =>
-  CTreeRoot ValidatorStage ->
+  CTreeRoot ValidatorPhase ->
   BS.ByteString ->
   CtlOp ->
-  CTree ValidatorStage ->
+  CTree ValidatorPhase ->
   Bool
 controlBytes cddl bs op (CTreeE (VRuleRef n)) =
   controlBytes cddl bs op $ dereference cddl n
@@ -653,13 +686,13 @@ controlBytes _ _ op _ = error $ "Not yet implmented for bytes: " <> show op
 
 -- | Validating text strings
 validateText ::
-  CTreeRoot ValidatorStage ->
+  CTreeRoot ValidatorPhase ->
   T.Text ->
-  CTree ValidatorStage ->
+  CTree ValidatorPhase ->
   Evidenced ValidationTrace
 validateText cddl txt (CTreeE (VRuleRef n)) =
   dereferenceAndValidate cddl n $ validateText cddl txt
-validateText _ txt (CTreeE (VValidator v _)) = runCustomValidator (TString txt) v
+validateText cddl txt (CTreeE (VValidator v _)) = runCustomValidator cddl (S $ TString txt) v
 validateText cddl txt rule =
   case rule of
     -- a = any
@@ -677,10 +710,10 @@ validateText cddl txt rule =
 -- | Controls for text strings
 controlText ::
   HasCallStack =>
-  CTreeRoot ValidatorStage ->
+  CTreeRoot ValidatorPhase ->
   T.Text ->
   CtlOp ->
-  CTree ValidatorStage ->
+  CTree ValidatorPhase ->
   Bool
 controlText cddl bs op (CTreeE (VRuleRef n)) =
   controlText cddl bs op $ dereference cddl n
@@ -715,10 +748,10 @@ controlText _ _ op _ = error $ "Not yet implemented for text: " <> show op
 
 -- | Validating a `TTagged`
 validateTagged ::
-  CTreeRoot ValidatorStage -> Word64 -> Term -> CTree ValidatorStage -> Evidenced ValidationTrace
+  CTreeRoot ValidatorPhase -> Word64 -> Term -> CTree ValidatorPhase -> Evidenced ValidationTrace
 validateTagged cddl tag term (CTreeE (VRuleRef n)) =
   dereferenceAndValidate cddl n $ validateTagged cddl tag term
-validateTagged _ tag term (CTreeE (VValidator v _)) = runCustomValidator (TTagged tag term) v
+validateTagged cddl tag term (CTreeE (VValidator v _)) = runCustomValidator cddl (S $ TTagged tag term) v
 validateTagged cddl tag term rule =
   case rule of
     Postlude PTAny -> terminal rule
@@ -766,13 +799,13 @@ decrementBounds (lb, ub) = OIBounded (clampedPred <$> lb) (clampedPred <$> ub)
     clampedPred x = pred x
 
 validateList ::
-  CTreeRoot ValidatorStage ->
+  CTreeRoot ValidatorPhase ->
   [Term] ->
-  CTree ValidatorStage ->
+  CTree ValidatorPhase ->
   Evidenced ValidationTrace
 validateList cddl terms (CTreeE (VRuleRef n)) =
   dereferenceAndValidate cddl n $ validateList cddl terms
-validateList _ terms (CTreeE (VValidator v _)) = runCustomValidator (TList terms) v
+validateList cddl terms (CTreeE (VValidator v _)) = runCustomValidator cddl (S $ TList terms) v
 validateList cddl terms rule =
   case rule of
     Postlude PTAny -> terminal rule
@@ -797,10 +830,10 @@ validateList cddl terms rule =
     _ -> unapplicable rule
   where
     validate ::
-      ([CTree ValidatorStage] -> [Term] -> Evidenced ListValidationTrace) ->
-      [CTree ValidatorStage] ->
+      ([CTree ValidatorPhase] -> [Term] -> Evidenced ListValidationTrace) ->
+      [CTree ValidatorPhase] ->
       [Term] ->
-      [CTree ValidatorStage] ->
+      [CTree ValidatorPhase] ->
       (Evidenced ListValidationTrace, [Term])
     validate f skipped tss [] = (f skipped tss, tss)
     validate f skipped [] (r : rs)
@@ -852,13 +885,13 @@ validateList cddl terms rule =
 
 validateMap ::
   HasCallStack =>
-  CTreeRoot ValidatorStage ->
+  CTreeRoot ValidatorPhase ->
   [(Term, Term)] ->
-  CTree ValidatorStage ->
+  CTree ValidatorPhase ->
   Evidenced ValidationTrace
 validateMap cddl terms (CTreeE (VRuleRef n)) =
   dereferenceAndValidate cddl n $ validateMap cddl terms
-validateMap _ terms (CTreeE (VValidator v _)) = runCustomValidator (TMap terms) v
+validateMap cddl terms (CTreeE (VValidator v _)) = runCustomValidator cddl (S $ TMap terms) v
 validateMap cddl terms rule =
   case rule of
     Postlude PTAny -> terminal rule
@@ -867,7 +900,7 @@ validateMap cddl terms rule =
     _ -> unapplicable rule
   where
     validate ::
-      [CTree ValidatorStage] -> [(Term, Term)] -> [CTree ValidatorStage] -> Evidenced MapValidationTrace
+      [CTree ValidatorPhase] -> [(Term, Term)] -> [CTree ValidatorPhase] -> Evidenced MapValidationTrace
     validate _ [] [] = evidence MapValidationDone
     validate exhausted (kv : _) [] =
       let
@@ -930,12 +963,12 @@ validateMap cddl terms rule =
 -- Choices
 
 validateChoice ::
-  (CTree ValidatorStage -> Evidenced ValidationTrace) ->
-  NE.NonEmpty (CTree ValidatorStage) ->
+  (CTree ValidatorPhase -> Evidenced ValidationTrace) ->
+  NE.NonEmpty (CTree ValidatorPhase) ->
   Evidenced ValidationTrace
 validateChoice v = go 0
   where
-    go :: Int -> NE.NonEmpty (CTree ValidatorStage) -> Evidenced ValidationTrace
+    go :: Int -> NE.NonEmpty (CTree ValidatorPhase) -> Evidenced ValidationTrace
     go i (choice NE.:| xs) = do
       case v choice of
         Evidenced SValid trc -> evidence $ ChoiceBranch i trc
@@ -948,9 +981,9 @@ validateChoice v = go 0
 
 -- | Validate both rules
 ctrlAnd ::
-  (CTree ValidatorStage -> Evidenced ValidationTrace) ->
-  CTree ValidatorStage ->
-  CTree ValidatorStage ->
+  (CTree ValidatorPhase -> Evidenced ValidationTrace) ->
+  CTree ValidatorPhase ->
+  CTree ValidatorPhase ->
   Evidenced ValidationTrace
 ctrlAnd v tgt ctrl =
   case v tgt of
@@ -959,11 +992,11 @@ ctrlAnd v tgt ctrl =
 
 -- | Dispatch to the appropriate control
 ctrlDispatch ::
-  (CTree ValidatorStage -> Evidenced ValidationTrace) ->
+  (CTree ValidatorPhase -> Evidenced ValidationTrace) ->
   CtlOp ->
-  CTree ValidatorStage ->
-  CTree ValidatorStage ->
-  (CtlOp -> CTree ValidatorStage -> Bool) ->
+  CTree ValidatorPhase ->
+  CTree ValidatorPhase ->
+  (CtlOp -> CTree ValidatorPhase -> Bool) ->
   Evidenced ValidationTrace
 ctrlDispatch v And tgt ctrl _ = ctrlAnd v tgt ctrl
 ctrlDispatch v Within tgt ctrl _ = ctrlAnd v tgt ctrl
@@ -979,7 +1012,7 @@ ctrlDispatch v op tgt ctrl vctrl =
 --------------------------------------------------------------------------------
 -- Bits control
 
-getIndicesOfChoice :: CTreeRoot ValidatorStage -> NE.NonEmpty (CTree ValidatorStage) -> [Word64]
+getIndicesOfChoice :: CTreeRoot ValidatorPhase -> NE.NonEmpty (CTree ValidatorPhase) -> [Word64]
 getIndicesOfChoice cddl = concatMap go
   where
     go = \case
@@ -1000,7 +1033,7 @@ getIndicesOfChoice cddl = concatMap go
             <> showSimple somethingElse
 
 getIndicesOfRange ::
-  CTreeRoot ValidatorStage -> CTree ValidatorStage -> CTree ValidatorStage -> RangeBound -> [Word64]
+  CTreeRoot ValidatorPhase -> CTree ValidatorPhase -> CTree ValidatorPhase -> RangeBound -> [Word64]
 getIndicesOfRange cddl (CTreeE (VRuleRef n)) tt incl =
   dereference cddl n & \ff -> getIndicesOfRange cddl ff tt incl
 getIndicesOfRange cddl ff (CTreeE (VRuleRef n)) incl =
@@ -1015,7 +1048,7 @@ getIndicesOfRange _ ff tt incl =
         rng = [ff' .. tt']
     (lo, hi) -> error $ "Malformed range in .bits: (" <> showSimple lo <> ", " <> showSimple hi <> ")"
 
-getIndicesOfEnum :: CTreeRoot ValidatorStage -> CTree ValidatorStage -> [Word64]
+getIndicesOfEnum :: CTreeRoot ValidatorPhase -> CTree ValidatorPhase -> [Word64]
 getIndicesOfEnum cddl (CTreeE (VRuleRef n)) = getIndicesOfEnum cddl $ dereference cddl n
 getIndicesOfEnum cddl g =
   case g of
@@ -1023,18 +1056,18 @@ getIndicesOfEnum cddl g =
     somethingElse -> error $ "Malformed enum in .bits: " <> showSimple somethingElse
 
 dereference ::
-  CTreeRoot ValidatorStage ->
+  CTreeRoot ValidatorPhase ->
   Name ->
-  CTree ValidatorStage
+  CTree ValidatorPhase
 dereference (CTreeRoot m) n =
   case Map.lookup n m of
     Just r -> r
     Nothing -> error $ "Nonexistent rule referenced: " <> T.unpack (unName n)
 
 dereferenceAndValidate ::
-  CTreeRoot ValidatorStage ->
+  CTreeRoot ValidatorPhase ->
   Name ->
-  (CTree ValidatorStage -> Evidenced ValidationTrace) ->
+  (CTree ValidatorPhase -> Evidenced ValidationTrace) ->
   Evidenced ValidationTrace
 dereferenceAndValidate cddl n f =
   mapTrace (ReferenceRule n) . f $ dereference cddl n

--- a/src/Codec/CBOR/Cuddle/CBOR/Validator/Trace.hs
+++ b/src/Codec/CBOR/Cuddle/CBOR/Validator/Trace.hs
@@ -33,7 +33,7 @@ module Codec.CBOR.Cuddle.CBOR.Validator.Trace (
   foldEvidenced,
 ) where
 
-import Codec.CBOR.Cuddle.CDDL (Name (..), OccurrenceIndicator (..), RangeBound (..))
+import Codec.CBOR.Cuddle.CDDL (Name (..))
 import Codec.CBOR.Cuddle.CDDL.CBORGenerator (ValidatorPhase)
 import Codec.CBOR.Cuddle.CDDL.CTree (CTree (..), CTreeRoot (..), Node, XXCTree, foldCTree)
 import Codec.CBOR.Cuddle.CDDL.CtlOp (CtlOp)
@@ -53,14 +53,9 @@ import Prettyprinter (
   Pretty (..),
   annotate,
   defaultLayoutOptions,
-  encloseSep,
-  group,
   hang,
   indent,
   layoutPretty,
-  list,
-  punctuate,
-  tupled,
   vsep,
   (<+>),
  )
@@ -74,6 +69,9 @@ type data ValidatorPhaseSimple
 
 newtype instance XXCTree ValidatorPhaseSimple = VRuleRefSimple Name
 
+instance Pretty (XXCTree ValidatorPhaseSimple) where
+  pretty (VRuleRefSimple n) = pretty n
+
 instance IndexMappable CTreeRoot ValidatorPhase ValidatorPhaseSimple where
   mapIndex (CTreeRoot m) = CTreeRoot $ mapIndex <$> m
 
@@ -82,29 +80,6 @@ instance IndexMappable CTree ValidatorPhase ValidatorPhaseSimple where
     where
       mapExt (VRuleRef n) = CTreeE $ VRuleRefSimple n
       mapExt (VValidator _ x) = mapIndex x
-
-instance Pretty (CTree ValidatorPhaseSimple) where
-  pretty = \case
-    Literal v -> pretty v
-    Postlude v -> pretty v
-    Range lo hi ClOpen -> pretty lo <+> "..." <+> pretty hi
-    Range lo hi Closed -> pretty lo <+> ".." <+> pretty hi
-    KV k v _ -> pretty k <+> "==>" <+> pretty v
-    CTreeE (VRuleRefSimple (Name n)) -> pretty n
-    Occur v oi ->
-      case oi of
-        OIOptional -> "?" <+> pretty v
-        OIZeroOrMore -> "*" <+> pretty v
-        OIOneOrMore -> "+" <+> pretty v
-        OIBounded lo hi -> foldMap pretty lo <> "*" <> foldMap pretty hi <+> pretty v
-    Map m -> encloseSep "{" "}" "," $ pretty <$> m
-    Array e -> list $ pretty <$> e
-    Choice c -> group . vsep . punctuate "//" $ pretty <$> toList c
-    Group g -> tupled $ pretty <$> g
-    Control op tgt ctl -> pretty tgt <+> pretty op <+> pretty ctl
-    Enum e -> "&" <> pretty e
-    Unwrap x -> "~" <> pretty x
-    Tag t x -> "#6." <> pretty t <> "(" <> pretty x <> ")"
 
 showSimple ::
   ( IndexMappable a ValidatorPhase ValidatorPhaseSimple

--- a/src/Codec/CBOR/Cuddle/CBOR/Validator/Trace.hs
+++ b/src/Codec/CBOR/Cuddle/CBOR/Validator/Trace.hs
@@ -10,8 +10,7 @@
 {-# LANGUAGE UndecidableInstances #-}
 
 module Codec.CBOR.Cuddle.CBOR.Validator.Trace (
-  ValidatorStage,
-  ValidatorStageSimple,
+  ValidatorPhaseSimple,
   XXCTree (..),
   SValidity (..),
   Validity (..),
@@ -34,11 +33,11 @@ module Codec.CBOR.Cuddle.CBOR.Validator.Trace (
   foldEvidenced,
 ) where
 
-import Codec.CBOR.Cuddle.CDDL (Name (..), OccurrenceIndicator (..), RangeBound (..), XTerm)
-import Codec.CBOR.Cuddle.CDDL.CBORGenerator (CBORValidator)
+import Codec.CBOR.Cuddle.CDDL (Name (..), OccurrenceIndicator (..), RangeBound (..))
+import Codec.CBOR.Cuddle.CDDL.CBORGenerator (ValidatorPhase)
 import Codec.CBOR.Cuddle.CDDL.CTree (CTree (..), CTreeRoot (..), Node, XXCTree, foldCTree)
 import Codec.CBOR.Cuddle.CDDL.CtlOp (CtlOp)
-import Codec.CBOR.Cuddle.CDDL.Resolve (MonoReferenced, XXCTree (..))
+import Codec.CBOR.Cuddle.CDDL.Resolve (XXCTree (..))
 import Codec.CBOR.Cuddle.IndexMappable (IndexMappable (..))
 import Codec.CBOR.Term (Term)
 import Data.Foldable (Foldable (..))
@@ -69,41 +68,22 @@ import Prettyprinter.Render.Terminal (AnsiStyle, Color (..), color, italicized)
 import Prettyprinter.Render.Terminal qualified as Ansi
 
 --------------------------------------------------------------------------------
--- ValidatorStage
+-- ValidatorPhase
 
-type data ValidatorStage
+type data ValidatorPhaseSimple
 
-data instance XTerm ValidatorStage = ValidatorXTerm
-  deriving (Show, Eq)
+newtype instance XXCTree ValidatorPhaseSimple = VRuleRefSimple Name
 
-data instance XXCTree ValidatorStage
-  = VRuleRef Name
-  | VValidator CBORValidator (CTree ValidatorStage)
-
-instance IndexMappable CTreeRoot MonoReferenced ValidatorStage where
+instance IndexMappable CTreeRoot ValidatorPhase ValidatorPhaseSimple where
   mapIndex (CTreeRoot m) = CTreeRoot $ mapIndex <$> m
 
-instance IndexMappable CTree MonoReferenced ValidatorStage where
-  mapIndex = foldCTree mapExt mapIndex
-    where
-      mapExt (MRuleRef n) = CTreeE $ VRuleRef n
-      mapExt (MGenerator _ x) = mapIndex x
-      mapExt (MValidator v x) = CTreeE . VValidator v $ mapIndex x
-
-type data ValidatorStageSimple
-
-newtype instance XXCTree ValidatorStageSimple = VRuleRefSimple Name
-
-instance IndexMappable CTreeRoot ValidatorStage ValidatorStageSimple where
-  mapIndex (CTreeRoot m) = CTreeRoot $ mapIndex <$> m
-
-instance IndexMappable CTree ValidatorStage ValidatorStageSimple where
+instance IndexMappable CTree ValidatorPhase ValidatorPhaseSimple where
   mapIndex = foldCTree mapExt mapIndex
     where
       mapExt (VRuleRef n) = CTreeE $ VRuleRefSimple n
       mapExt (VValidator _ x) = mapIndex x
 
-instance Pretty (CTree ValidatorStageSimple) where
+instance Pretty (CTree ValidatorPhaseSimple) where
   pretty = \case
     Literal v -> pretty v
     Postlude v -> pretty v
@@ -127,15 +107,15 @@ instance Pretty (CTree ValidatorStageSimple) where
     Tag t x -> "#6." <> pretty t <> "(" <> pretty x <> ")"
 
 showSimple ::
-  ( IndexMappable a ValidatorStage ValidatorStageSimple
-  , Show (a ValidatorStageSimple)
+  ( IndexMappable a ValidatorPhase ValidatorPhaseSimple
+  , Show (a ValidatorPhaseSimple)
   ) =>
-  a ValidatorStage -> String
-showSimple = show . mapIndex @_ @_ @ValidatorStageSimple
+  a ValidatorPhase -> String
+showSimple = show . mapIndex @_ @_ @ValidatorPhaseSimple
 
-deriving instance Eq (Node ValidatorStageSimple)
+deriving instance Eq (Node ValidatorPhaseSimple)
 
-deriving instance Show (Node ValidatorStageSimple)
+deriving instance Show (Node ValidatorPhaseSimple)
 
 --------------------------------------------------------------------------------
 -- Validation result
@@ -161,7 +141,7 @@ instance TestEquality SValidity where
 
 data ControlInfo = ControlInfo
   { ciOp :: CtlOp
-  , ciRule :: CTree ValidatorStageSimple
+  , ciRule :: CTree ValidatorPhaseSimple
   }
   deriving (Show)
 
@@ -169,13 +149,13 @@ instance Pretty ControlInfo where
   pretty ControlInfo {..} = pretty ciOp <+> pretty ciRule
 
 data ValidationTrace (v :: Validity) where
-  UnapplicableRule :: CTree ValidatorStageSimple -> ValidationTrace IsInvalid
-  TerminalRule :: CTree ValidatorStageSimple -> ValidationTrace IsValid
+  UnapplicableRule :: CTree ValidatorPhaseSimple -> ValidationTrace IsInvalid
+  TerminalRule :: CTree ValidatorPhaseSimple -> ValidationTrace IsValid
   ControlTrace :: ControlInfo -> ValidationTrace IsValid -> ValidationTrace IsValid
   ReferenceRule :: Name -> ValidationTrace v -> ValidationTrace v
   CustomFailure :: Text -> ValidationTrace IsInvalid
   CustomSuccess :: ValidationTrace IsValid
-  UnsatisfiedControl :: CtlOp -> CTree ValidatorStageSimple -> ValidationTrace IsInvalid
+  UnsatisfiedControl :: CtlOp -> CTree ValidatorPhaseSimple -> ValidationTrace IsInvalid
   ChoiceBranch :: Int -> ValidationTrace IsValid -> ValidationTrace IsValid
   ListTrace :: ListValidationTrace v -> ValidationTrace v
   MapTrace :: MapValidationTrace v -> ValidationTrace v
@@ -188,18 +168,18 @@ data ListValidationTrace (v :: Validity) where
   ListValidationDone :: ListValidationTrace IsValid
   ListValidationLeftoverTerms ::
     NonEmpty Term ->
-    Maybe (CTree ValidatorStageSimple, ValidationTrace IsInvalid) ->
+    Maybe (CTree ValidatorPhaseSimple, ValidationTrace IsInvalid) ->
     ListValidationTrace IsInvalid
   ListValidationUnappliedRule ::
-    CTree ValidatorStageSimple ->
+    CTree ValidatorPhaseSimple ->
     ListValidationTrace IsInvalid
   ListValidationConsume ::
-    CTree ValidatorStageSimple ->
+    CTree ValidatorPhaseSimple ->
     ValidationTrace IsValid ->
     ListValidationTrace v ->
     ListValidationTrace v
   ListValidationMissingRequired ::
-    CTree ValidatorStageSimple ->
+    CTree ValidatorPhaseSimple ->
     ValidationTrace IsInvalid ->
     ListValidationTrace IsInvalid
   ListValidationConsumeGroup ::
@@ -218,16 +198,16 @@ data MapValidationTrace (v :: Validity) where
   MapValidationDone :: MapValidationTrace IsValid
   MapValidationLeftoverKVs ::
     (Term, Term) ->
-    Maybe (CTree ValidatorStageSimple, MapValidationTrace IsInvalid) ->
+    Maybe (CTree ValidatorPhaseSimple, MapValidationTrace IsInvalid) ->
     MapValidationTrace IsInvalid
-  MapValidationUnappliedRules :: NonEmpty (CTree ValidatorStageSimple) -> MapValidationTrace IsInvalid
+  MapValidationUnappliedRules :: NonEmpty (CTree ValidatorPhaseSimple) -> MapValidationTrace IsInvalid
   MapValidationInvalidValue ::
-    CTree ValidatorStageSimple ->
+    CTree ValidatorPhaseSimple ->
     ValidationTrace IsValid ->
     ValidationTrace IsInvalid ->
     MapValidationTrace IsInvalid
   MapValidationConsume ::
-    CTree ValidatorStageSimple ->
+    CTree ValidatorPhaseSimple ->
     ValidationTrace IsValid ->
     ValidationTrace IsValid ->
     MapValidationTrace v ->

--- a/src/Codec/CBOR/Cuddle/CDDL.hs
+++ b/src/Codec/CBOR/Cuddle/CDDL.hs
@@ -39,6 +39,7 @@ module Codec.CBOR.Cuddle.CDDL (
   unwrap,
   compareRuleName,
   HasName (..),
+  GRef (..),
   -- Extension
   ForAllExtensions,
   XCddl,
@@ -160,6 +161,10 @@ newtype Name = Name {unName :: T.Text}
   deriving (Generic)
   deriving (Eq, Ord, Show)
   deriving newtype (Semigroup, Monoid)
+
+-- | A reference to a generic parameter inside the body of a generic rule.
+newtype GRef = GRef T.Text
+  deriving (Show)
 
 deriving anyclass instance ToExpr Name
 

--- a/src/Codec/CBOR/Cuddle/CDDL/CBORGenerator.hs
+++ b/src/Codec/CBOR/Cuddle/CDDL/CBORGenerator.hs
@@ -8,6 +8,7 @@ module Codec.CBOR.Cuddle.CDDL.CBORGenerator (
 
   -- * Custom generators
   CBORGen,
+  GenConfig (..),
   GenEnv (..),
   HasGenerator (..),
   WrappedTerm (..),
@@ -16,6 +17,7 @@ module Codec.CBOR.Cuddle.CDDL.CBORGenerator (
   liftAntiGen,
   withAntiGen,
   withTwiddle,
+  withLocalGenBindings,
 
   -- * Custom validators
   Validator,
@@ -24,13 +26,15 @@ module Codec.CBOR.Cuddle.CDDL.CBORGenerator (
   ValidateEnv (..),
   HasValidator (..),
   runValidator,
+  withLocalValidateBindings,
 ) where
 
-import Codec.CBOR.Cuddle.CDDL (Name)
+import Codec.CBOR.Cuddle.CDDL (GRef (..), Name (..))
 import Codec.CBOR.Cuddle.CDDL.CTree (CTree, CTreeRoot (..), XXCTree)
 import Codec.CBOR.Term (Term)
-import Control.Monad.Reader (MonadReader (..), ReaderT (..), asks, mapReaderT)
+import Control.Monad.Reader (MonadReader (..), ReaderT (..), asks, local, mapReaderT)
 import Data.Kind (Type)
+import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
 import Data.Text (Text)
 import Data.Text qualified as T
@@ -42,7 +46,13 @@ import Test.QuickCheck.GenT (MonadGen (..))
 class MonadCddl m where
   type Phase m :: Type
 
+  -- | Look up a top-level rule by name.
   lookupCddl :: Name -> m (Maybe (CTree (Phase m)))
+
+  -- | Look up the rule bound to a generic parameter at the enclosing rule.
+  -- Returns 'Nothing' outside of a custom generator/validator that was
+  -- attached to a generic rule.
+  lookupGRef :: GRef -> m (Maybe (CTree (Phase m)))
 
 type data GenPhase
 type data ValidatorPhase
@@ -51,9 +61,19 @@ data instance XXCTree ValidatorPhase
   = VRuleRef Name
   | VValidator (WrappedTerm -> Validator ()) (CTree ValidatorPhase)
 
+-- | User-supplied configuration for the generator monad. Set once at the
+-- top level when calling 'runCBORGen'.
+data GenConfig = GenConfig
+  { gcRoot :: CTreeRoot GenPhase
+  , gcTwiddle :: !Bool
+  }
+  deriving (Generic)
+
+-- | Runtime environment for the generator monad: the user-supplied
+-- 'GenConfig' plus the bindings active at the current point.
 data GenEnv = GenEnv
-  { geRoot :: CTreeRoot GenPhase
-  , geTwiddle :: !Bool
+  { geConfig :: GenConfig
+  , geLocal :: Map Name (CTree GenPhase)
   }
   deriving (Generic)
 
@@ -71,21 +91,35 @@ instance MonadGen CBORGen where
 liftAntiGen :: AntiGen a -> CBORGen a
 liftAntiGen m = CBORGen . ReaderT $ const m
 
-runCBORGen :: GenEnv -> CBORGen a -> AntiGen a
-runCBORGen env (CBORGen m) = runReaderT m env
+runCBORGen :: GenConfig -> CBORGen a -> AntiGen a
+runCBORGen cfg (CBORGen m) =
+  runReaderT m GenEnv {geConfig = cfg, geLocal = Map.empty}
 
 instance MonadCddl CBORGen where
   type Phase CBORGen = GenPhase
 
   lookupCddl n = do
-    CTreeRoot root <- asks geRoot
+    CTreeRoot root <- asks (gcRoot . geConfig)
     pure $ Map.lookup n root
+
+  lookupGRef (GRef t) = do
+    binds <- asks geLocal
+    pure $ Map.lookup (Name t) binds
 
 withAntiGen :: (AntiGen a -> AntiGen b) -> CBORGen a -> CBORGen b
 withAntiGen f (CBORGen m) = CBORGen $ ReaderT $ \env -> f (runReaderT m env)
 
 withTwiddle :: Bool -> CBORGen a -> CBORGen a
-withTwiddle t = local (\x -> x {geTwiddle = t})
+withTwiddle t =
+  local (\env -> env {geConfig = (geConfig env) {gcTwiddle = t}})
+
+-- | Run an action with the given local generic bindings installed.
+-- Used to wrap custom generators attached to generic rules so that
+-- 'lookupGRef' resolves to the type bound at the enclosing rule.
+withLocalGenBindings ::
+  Map Name (CTree GenPhase) -> CBORGen a -> CBORGen a
+withLocalGenBindings binds =
+  local (\env -> env {geLocal = binds `Map.union` geLocal env})
 
 data instance XXCTree GenPhase
   = GenRef Name
@@ -111,7 +145,10 @@ data CustomValidatorResult
   | CustomValidatorFailure Text
   deriving (Generic, Show, Eq)
 
-newtype ValidateEnv = ValidateEnv {veRoot :: CTreeRoot ValidatorPhase}
+data ValidateEnv = ValidateEnv
+  { veRoot :: CTreeRoot ValidatorPhase
+  , veLocal :: Map Name (CTree ValidatorPhase)
+  }
 
 newtype Validator a = Validator (ReaderT ValidateEnv (Either Text) a)
   deriving (Functor, Applicative, Monad, MonadReader ValidateEnv)
@@ -125,11 +162,21 @@ instance MonadCddl Validator where
     CTreeRoot root <- asks veRoot
     pure $ Map.lookup n root
 
+  lookupGRef (GRef t) = do
+    binds <- asks veLocal
+    pure $ Map.lookup (Name t) binds
+
 instance MonadFail Validator where
   fail msg = Validator . ReaderT $ \_ -> Left $ T.pack msg
 
+-- | Run an action with the given local generic bindings installed.
+withLocalValidateBindings ::
+  Map Name (CTree ValidatorPhase) -> Validator a -> Validator a
+withLocalValidateBindings binds =
+  local (\env -> env {veLocal = binds `Map.union` veLocal env})
+
 runValidator ::
   Validator () -> CTreeRoot ValidatorPhase -> CustomValidatorResult
-runValidator (Validator m) cddl =
+runValidator (Validator (ReaderT f)) cddl =
   either CustomValidatorFailure (const CustomValidatorSuccess) $
-    runReaderT m ValidateEnv {veRoot = cddl}
+    f ValidateEnv {veRoot = cddl, veLocal = Map.empty}

--- a/src/Codec/CBOR/Cuddle/CDDL/CBORGenerator.hs
+++ b/src/Codec/CBOR/Cuddle/CDDL/CBORGenerator.hs
@@ -2,38 +2,58 @@
 {-# LANGUAGE TypeFamilies #-}
 
 module Codec.CBOR.Cuddle.CDDL.CBORGenerator (
-  CBORGen (..),
+  MonadCddl (..),
+  GenPhase,
+  ValidatorPhase,
+
+  -- * Custom generators
+  CBORGen,
   GenEnv (..),
   HasGenerator (..),
   WrappedTerm (..),
-  CBORValidator (..),
-  HasValidator (..),
-  GenPhase,
   XXCTree (..),
-  CustomValidatorResult (..),
-  liftAntiGen,
   runCBORGen,
-  lookupCddl,
+  liftAntiGen,
   withAntiGen,
   withTwiddle,
+
+  -- * Custom validators
+  Validator,
+  TermValidator,
+  CustomValidatorResult (..),
+  ValidateEnv (..),
+  HasValidator (..),
+  runValidator,
 ) where
 
 import Codec.CBOR.Cuddle.CDDL (Name)
 import Codec.CBOR.Cuddle.CDDL.CTree (CTree, CTreeRoot (..), XXCTree)
 import Codec.CBOR.Term (Term)
 import Control.Monad.Reader (MonadReader (..), ReaderT (..), asks, mapReaderT)
+import Data.Kind (Type)
 import Data.Map.Strict qualified as Map
 import Data.Text (Text)
+import Data.Text qualified as T
 import GHC.Generics (Generic)
 import Optics.Core (Lens')
 import Test.AntiGen (AntiGen)
 import Test.QuickCheck.GenT (MonadGen (..))
 
+class MonadCddl m where
+  type Phase m :: Type
+
+  lookupCddl :: Name -> m (Maybe (CTree (Phase m)))
+
 type data GenPhase
+type data ValidatorPhase
+
+data instance XXCTree ValidatorPhase
+  = VRuleRef Name
+  | VValidator (WrappedTerm -> Validator ()) (CTree ValidatorPhase)
 
 data GenEnv = GenEnv
   { geRoot :: CTreeRoot GenPhase
-  , geTwiddle :: Bool
+  , geTwiddle :: !Bool
   }
   deriving (Generic)
 
@@ -54,10 +74,12 @@ liftAntiGen m = CBORGen . ReaderT $ const m
 runCBORGen :: GenEnv -> CBORGen a -> AntiGen a
 runCBORGen env (CBORGen m) = runReaderT m env
 
-lookupCddl :: Name -> CBORGen (Maybe (CTree GenPhase))
-lookupCddl n = do
-  CTreeRoot root <- asks geRoot
-  pure $ Map.lookup n root
+instance MonadCddl CBORGen where
+  type Phase CBORGen = GenPhase
+
+  lookupCddl n = do
+    CTreeRoot root <- asks geRoot
+    pure $ Map.lookup n root
 
 withAntiGen :: (AntiGen a -> AntiGen b) -> CBORGen a -> CBORGen b
 withAntiGen f (CBORGen m) = CBORGen $ ReaderT $ \env -> f (runReaderT m env)
@@ -82,11 +104,32 @@ class HasGenerator a where
   generatorL :: Lens' a (Maybe (CBORGen WrappedTerm))
 
 class HasValidator a where
-  validatorL :: Lens' a (Maybe CBORValidator)
+  validatorL :: Lens' a (Maybe (WrappedTerm -> Validator ()))
 
 data CustomValidatorResult
   = CustomValidatorSuccess
   | CustomValidatorFailure Text
   deriving (Generic, Show, Eq)
 
-newtype CBORValidator = CBORValidator (Term -> CustomValidatorResult)
+newtype ValidateEnv = ValidateEnv {veRoot :: CTreeRoot ValidatorPhase}
+
+newtype Validator a = Validator (ReaderT ValidateEnv (Either Text) a)
+  deriving (Functor, Applicative, Monad, MonadReader ValidateEnv)
+
+type TermValidator = WrappedTerm -> Validator ()
+
+instance MonadCddl Validator where
+  type Phase Validator = ValidatorPhase
+
+  lookupCddl n = do
+    CTreeRoot root <- asks veRoot
+    pure $ Map.lookup n root
+
+instance MonadFail Validator where
+  fail msg = Validator . ReaderT $ \_ -> Left $ T.pack msg
+
+runValidator ::
+  Validator () -> CTreeRoot ValidatorPhase -> CustomValidatorResult
+runValidator (Validator m) cddl =
+  either CustomValidatorFailure (const CustomValidatorSuccess) $
+    runReaderT m ValidateEnv {veRoot = cddl}

--- a/src/Codec/CBOR/Cuddle/CDDL/CTreePhase.hs
+++ b/src/Codec/CBOR/Cuddle/CDDL/CTreePhase.hs
@@ -12,7 +12,7 @@ module Codec.CBOR.Cuddle.CDDL.CTreePhase (
 ) where
 
 import Codec.CBOR.Cuddle.CDDL (XCddl, XRule, XTerm, XXTopLevel, XXType2)
-import Codec.CBOR.Cuddle.CDDL.CBORGenerator (CBORGen, CBORValidator, WrappedTerm)
+import Codec.CBOR.Cuddle.CDDL.CBORGenerator (CBORGen, TermValidator, WrappedTerm)
 import Data.Default.Class (Default)
 import Data.Hashable (Hashable)
 import GHC.Generics (Generic)
@@ -29,7 +29,8 @@ data instance XXTopLevel CTreePhase
 data instance XCddl CTreePhase = CTreeXCddl
   deriving (Generic, Show, Eq, Ord)
 
-data instance XRule CTreePhase = CTreeXRule (Maybe (CBORGen WrappedTerm)) (Maybe CBORValidator)
+data instance XRule CTreePhase
+  = CTreeXRule (Maybe (CBORGen WrappedTerm)) (Maybe TermValidator)
   deriving (Generic)
 
 data instance XXType2 CTreePhase

--- a/src/Codec/CBOR/Cuddle/CDDL/Resolve.hs
+++ b/src/Codec/CBOR/Cuddle/CDDL/Resolve.hs
@@ -80,6 +80,8 @@ import Data.Map.Strict qualified as Map
 import Data.Text qualified as T
 import GHC.Generics (Generic)
 import Optics.Core
+import Prettyprinter (Pretty (..), encloseSep, layoutCompact)
+import Prettyprinter.Render.Text (renderStrict)
 
 data ProvidedParameters a = ProvidedParameters
   { parameters :: [Name]
@@ -403,6 +405,11 @@ deriving instance Show (CTree.Node i) => Show (DistRef i)
 
 instance Hashable (CTree.Node i) => Hashable (DistRef i)
 
+instance Pretty (XXCTree i) => Pretty (DistRef i) where
+  pretty (GenericRef n) = pretty n
+  pretty (RuleRef rule []) = pretty rule
+  pretty (RuleRef rule args) = pretty rule <> encloseSep "<" ">" "," (pretty <$> args)
+
 data instance XXCTree DistReferenced
   = DRef (DistRef DistReferenced)
   | DGenerator (CBORGen WrappedTerm) (CTree DistReferenced)
@@ -411,7 +418,8 @@ data instance XXCTree DistReferenced
 type data DistReferencedNoGen
 
 newtype instance XXCTree DistReferencedNoGen = DHRef (DistRef DistReferencedNoGen)
-  deriving (Eq, Hashable)
+  deriving (Eq, Hashable, Show)
+  deriving newtype (Pretty)
 
 resolveRef ::
   BindingEnv OrReferenced OrReferenced ->
@@ -551,10 +559,11 @@ throwNR = throw @"nameResolution"
 -- | Synthesize a monomorphic rule definition, returning the name
 synthMono :: Name -> [CTree DistReferenced] -> MonoM Name
 synthMono origName args =
-  let dropGenerator = fmap $ mapIndex @_ @_ @DistReferencedNoGen
-      fresh =
-        -- % is not a valid CBOR name, so this should avoid conflict
-        origName <> "%" <> Name (T.pack (show . hash $ dropGenerator args))
+  let dropGenerator = fmap $ mapIndex @_ @DistReferenced @DistReferencedNoGen
+      argsName = Name (T.intercalate "," $ renderStrict . layoutCompact . pretty <$> dropGenerator args)
+      -- We use % to mark a monomorphised generic rule, '%' is not allowed in
+      -- CDDL names, so there should be no conflicts
+      fresh = "%" <> origName <> "<" <> argsName <> ">"
    in do
         -- Lookup the original name in the global bindings
         globalBinds <- ask @"global"

--- a/src/Codec/CBOR/Cuddle/CDDL/Resolve.hs
+++ b/src/Codec/CBOR/Cuddle/CDDL/Resolve.hs
@@ -72,6 +72,8 @@ import Codec.CBOR.Cuddle.CDDL.CBORGenerator (
   ValidatorPhase,
   WrappedTerm,
   XXCTree (..),
+  withLocalGenBindings,
+  withLocalValidateBindings,
  )
 import Codec.CBOR.Cuddle.CDDL.CTreePhase (CTreePhase, XRule (..))
 import Codec.CBOR.Cuddle.IndexMappable (IndexMappable (..))
@@ -205,9 +207,7 @@ buildRefCTree rules = PartialCTreeRoot $ toCTreeRule <$> rules
   where
     toCTreeRule :: CDDLMapEntry -> ProvidedParameters (CTree OrReferenced)
     toCTreeRule CDDLMapEntry {..} =
-      fmap
-        (applyValidator . applyGenerator . toCTreeTOG)
-        cmeProvidedParameters
+      applyValidator . applyGenerator . toCTreeTOG <$> cmeProvidedParameters
       where
         applyGenerator = case cmeCustomGenerator of
           Just g -> CTreeE . OGenerator g
@@ -593,8 +593,18 @@ resolveGenericRef (DRef (GenericRef n)) = do
   case Map.lookup n localBinds of
     Just node -> pure node
     Nothing -> throwNR $ UnboundReference n
-resolveGenericRef (DGenerator g x) = CTreeE . MGenerator g <$> resolveGenericCTree x
-resolveGenericRef (DValidator v x) = CTreeE . MValidator v <$> resolveGenericCTree x
+resolveGenericRef (DGenerator g x) = do
+  binds <- ask @"local"
+  body <- resolveGenericCTree x
+  let bindsGen = mapIndex @CTree @MonoReferenced @GenPhase <$> binds
+      g' = withLocalGenBindings bindsGen g
+  pure . CTreeE $ MGenerator g' body
+resolveGenericRef (DValidator v x) = do
+  binds <- ask @"local"
+  body <- resolveGenericCTree x
+  let bindsVal = mapIndex @CTree @MonoReferenced @ValidatorPhase <$> binds
+      v' = withLocalValidateBindings bindsVal . v
+  pure . CTreeE $ MValidator v' body
 
 resolveGenericCTree ::
   CTree DistReferenced ->

--- a/src/Codec/CBOR/Cuddle/CDDL/Resolve.hs
+++ b/src/Codec/CBOR/Cuddle/CDDL/Resolve.hs
@@ -67,8 +67,9 @@ import Data.List (foldl')
 #endif
 import Codec.CBOR.Cuddle.CDDL.CBORGenerator (
   CBORGen,
-  CBORValidator,
   GenPhase,
+  TermValidator,
+  ValidatorPhase,
   WrappedTerm,
   XXCTree (..),
  )
@@ -98,7 +99,7 @@ newtype PartialCTreeRoot i = PartialCTreeRoot (Map.Map Name (ProvidedParameters 
 data CDDLMapEntry = CDDLMapEntry
   { cmeProvidedParameters :: ProvidedParameters (TypeOrGroup CTreePhase)
   , cmeCustomGenerator :: Maybe (CBORGen WrappedTerm)
-  , cmeCustomValidator :: Maybe CBORValidator
+  , cmeCustomValidator :: Maybe TermValidator
   }
   deriving (Generic)
 
@@ -160,7 +161,7 @@ data instance XXCTree OrReferenced
   = -- | Reference to another node with possible generic arguments supplied
     OrRef Name [CTree OrReferenced]
   | OGenerator (CBORGen WrappedTerm) (CTree OrReferenced)
-  | OValidator CBORValidator (CTree OrReferenced)
+  | OValidator TermValidator (CTree OrReferenced)
 
 type data OrReferencedSimple
 
@@ -170,7 +171,7 @@ data instance XXCTree OrReferencedSimple = DGOrRef Name [CTree OrReferencedSimpl
 instance IndexMappable CTree OrReferenced OrReferencedSimple where
   mapIndex = foldCTree mapExt mapIndex
     where
-      mapExt (OrRef n xs) = CTreeE . DGOrRef n $ mapIndex <$> xs
+      mapExt (OrRef n xs) = CTreeE $ DGOrRef n (mapIndex <$> xs)
       mapExt (OGenerator _ x) = mapIndex x
       mapExt (OValidator _ x) = mapIndex x
 
@@ -178,10 +179,20 @@ instance IndexMappable CTree MonoReferenced GenPhase where
   mapIndex = foldCTree mapExt mapIndex
     where
       mapExt (MRuleRef n) = CTreeE $ GenRef n
-      mapExt (MGenerator g x) = CTreeE . GenGenerator g $ mapIndex x
+      mapExt (MGenerator g x) = CTreeE $ GenGenerator g (mapIndex x)
       mapExt (MValidator _ x) = mapIndex x
 
 instance IndexMappable CTreeRoot MonoReferenced GenPhase where
+  mapIndex (CTreeRoot m) = CTreeRoot $ mapIndex <$> m
+
+instance IndexMappable CTree MonoReferenced ValidatorPhase where
+  mapIndex = foldCTree mapExt mapIndex
+    where
+      mapExt (MRuleRef n) = CTreeE $ VRuleRef n
+      mapExt (MGenerator _ x) = mapIndex x
+      mapExt (MValidator v x) = CTreeE $ VValidator v (mapIndex x)
+
+instance IndexMappable CTreeRoot MonoReferenced ValidatorPhase where
   mapIndex (CTreeRoot m) = CTreeRoot $ mapIndex <$> m
 
 -- | Build a CTree incorporating references.
@@ -395,7 +406,7 @@ instance Hashable (CTree.Node i) => Hashable (DistRef i)
 data instance XXCTree DistReferenced
   = DRef (DistRef DistReferenced)
   | DGenerator (CBORGen WrappedTerm) (CTree DistReferenced)
-  | DValidator CBORValidator (CTree DistReferenced)
+  | DValidator TermValidator (CTree DistReferenced)
 
 type data DistReferencedNoGen
 
@@ -450,7 +461,7 @@ type data MonoReferenced
 data instance XXCTree MonoReferenced
   = MRuleRef Name
   | MGenerator (CBORGen WrappedTerm) (CTree MonoReferenced)
-  | MValidator CBORValidator (CTree MonoReferenced)
+  | MValidator TermValidator (CTree MonoReferenced)
 
 type MonoEnv = BindingEnv DistReferenced MonoReferenced
 

--- a/src/Codec/CBOR/Cuddle/Huddle.hs
+++ b/src/Codec/CBOR/Cuddle/Huddle.hs
@@ -83,7 +83,7 @@ module Codec.CBOR.Cuddle.Huddle (
   tag,
 
   -- * Generics
-  GRef (..),
+  GRef,
   GRuleDef (..),
   GRuleCall (..),
   binding,
@@ -107,7 +107,14 @@ module Codec.CBOR.Cuddle.Huddle (
 )
 where
 
-import Codec.CBOR.Cuddle.CDDL (CDDL, GenericParameter (..), HasName (..), Name (..), XRule)
+import Codec.CBOR.Cuddle.CDDL (
+  CDDL,
+  GRef (..),
+  GenericParameter (..),
+  HasName (..),
+  Name (..),
+  XRule,
+ )
 import Codec.CBOR.Cuddle.CDDL qualified as C
 import Codec.CBOR.Cuddle.CDDL.CBORGenerator (
   CBORGen,
@@ -993,9 +1000,6 @@ tag mi = Tagged (Just mi)
 --------------------------------------------------------------------------------
 -- Generics
 --------------------------------------------------------------------------------
-
-newtype GRef = GRef T.Text
-  deriving (Show)
 
 freshName :: Int -> GRef
 freshName ix =

--- a/src/Codec/CBOR/Cuddle/Huddle.hs
+++ b/src/Codec/CBOR/Cuddle/Huddle.hs
@@ -83,7 +83,7 @@ module Codec.CBOR.Cuddle.Huddle (
   tag,
 
   -- * Generics
-  GRef,
+  GRef (..),
   GRuleDef (..),
   GRuleCall (..),
   binding,

--- a/src/Codec/CBOR/Cuddle/Huddle.hs
+++ b/src/Codec/CBOR/Cuddle/Huddle.hs
@@ -91,8 +91,6 @@ module Codec.CBOR.Cuddle.Huddle (
   callToDef,
 
   -- * Generators
-  withAntiGen,
-  withGenerator,
   withCBORGen,
 
   -- * Validators
@@ -112,22 +110,16 @@ where
 import Codec.CBOR.Cuddle.CDDL (CDDL, GenericParameter (..), HasName (..), Name (..), XRule)
 import Codec.CBOR.Cuddle.CDDL qualified as C
 import Codec.CBOR.Cuddle.CDDL.CBORGenerator (
-  CBORGen (..),
-  CBORValidator (..),
-  CustomValidatorResult,
-  GenEnv (..),
-  GenPhase,
+  CBORGen,
   HasGenerator (..),
   HasValidator (..),
+  TermValidator,
   WrappedTerm,
  )
-import Codec.CBOR.Cuddle.CDDL.CTree (CTreeRoot)
 import Codec.CBOR.Cuddle.CDDL.CtlOp qualified as CtlOp
 import Codec.CBOR.Cuddle.Comments (Comment, HasComment (..))
 import Codec.CBOR.Cuddle.Comments qualified as C
-import Codec.CBOR.Term (Term)
 import Control.Monad (when)
-import Control.Monad.Reader (ReaderT (..))
 import Control.Monad.State (MonadState (get), State, execState, modify)
 import Data.ByteString (ByteString)
 import Data.ByteString.Base16 qualified as Base16
@@ -148,9 +140,6 @@ import GHC.Exts (IsList (Item, fromList, toList))
 import GHC.Generics (Generic)
 import Optics.Core (lens, view, (%), (%~), (&))
 import Optics.Core qualified as L
-import Test.AntiGen (AntiGen)
-import Test.QuickCheck.Gen (Gen)
-import Test.QuickCheck.GenT (MonadGen (liftGen))
 import Prelude hiding ((/))
 
 type data HuddleStage
@@ -164,7 +153,7 @@ newtype instance C.XCddl HuddleStage = HuddleXCddl [C.Comment]
 data instance C.XRule HuddleStage = HuddleXRule
   { hxrComment :: C.Comment
   , hxrGenerator :: Maybe (CBORGen WrappedTerm)
-  , hxrValidator :: Maybe CBORValidator
+  , hxrValidator :: Maybe TermValidator
   }
   deriving (Generic)
 
@@ -1377,23 +1366,10 @@ toCDDL' HuddleConfig {..} hdl =
           C.GenericParameters $
             fmap (\(GRef t) -> GenericParameter (C.Name t) $ HuddleXTerm mempty) (args gr)
 
--- | Use a custom `QuickCheck` generator to generate the term. Will override
--- the generator passed via `withAntiGen`
-withGenerator :: HasGenerator a => (CTreeRoot GenPhase -> Gen WrappedTerm) -> a -> a
-withGenerator f = L.set generatorL (Just . CBORGen . ReaderT $ \GenEnv {geRoot} -> liftGen $ f geRoot)
-{-# DEPRECATED withGenerator "Use withCBORGen instead" #-}
-
--- | Use a custom `AntiGen` generator to generate the term. Will override
--- the custom generator passed via `withGenerator`. The advantage of using
--- `AntiGen` generator is that it can also be used to generate negative examples.
-withAntiGen :: HasGenerator a => (CTreeRoot GenPhase -> AntiGen WrappedTerm) -> a -> a
-withAntiGen f = L.set generatorL (Just . CBORGen . ReaderT $ \GenEnv {geRoot} -> f geRoot)
-{-# DEPRECATED withAntiGen "Use withCBORGen instead" #-}
-
 -- | Use a custom `CBORGen` generator to generate the term. Will override
 -- the custom generator passed via `withGenerator`.
 withCBORGen :: HasGenerator a => CBORGen WrappedTerm -> a -> a
-withCBORGen gen = L.set generatorL (Just gen)
+withCBORGen gen = L.set generatorL $ Just gen
 
-withValidator :: HasValidator a => (Term -> CustomValidatorResult) -> a -> a
-withValidator p = L.set validatorL . Just $ CBORValidator p
+withValidator :: HasValidator a => TermValidator -> a -> a
+withValidator p = L.set validatorL $ Just p

--- a/src/Codec/CBOR/Cuddle/IndexMappable.hs
+++ b/src/Codec/CBOR/Cuddle/IndexMappable.hs
@@ -201,7 +201,7 @@ instance
   where
   mapIndex (GrpChoice gs e) = GrpChoice (mapIndex <$> gs) $ mapIndex e
 
--- ParserStage -> PrettyStage
+-- ParserStage ~ PrettyStage
 
 instance IndexMappable XCddl ParserStage PrettyStage where
   mapIndex (ParserXCddl c) = PrettyXCddl c
@@ -277,7 +277,7 @@ instance IndexMappable XTerm HuddleStage PrettyStage where
 instance IndexMappable XRule HuddleStage PrettyStage where
   mapIndex (HuddleXRule c _ _) = PrettyXRule c
 
--- ParserStage -> ParserStage
+-- ParserStage ~ ParserStage
 
 instance IndexMappable XCddl ParserStage ParserStage
 

--- a/src/Codec/CBOR/Cuddle/Pretty.hs
+++ b/src/Codec/CBOR/Cuddle/Pretty.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeData #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE ViewPatterns #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
@@ -19,7 +20,8 @@ module Codec.CBOR.Cuddle.Pretty (
 ) where
 
 import Codec.CBOR.Cuddle.CDDL
-import Codec.CBOR.Cuddle.CDDL.CTree (PTerm (..))
+import Codec.CBOR.Cuddle.CDDL.CTree (CTree, PTerm (..), XXCTree)
+import Codec.CBOR.Cuddle.CDDL.CTree qualified as CT
 import Codec.CBOR.Cuddle.CDDL.CtlOp (CtlOp)
 import Codec.CBOR.Cuddle.Comments (CollectComments (..), Comment, HasComment (..), unComment)
 import Codec.CBOR.Cuddle.Pretty.Columnar (
@@ -280,3 +282,26 @@ instance Pretty PTerm where
 renderCDDL :: LayoutOptions -> CDDL PrettyStage -> Text
 renderCDDL opts =
   PT.renderStrict . removeTrailingWhitespace . layoutPretty opts . pretty
+
+instance Pretty (XXCTree p) => Pretty (CTree p) where
+  pretty = \case
+    CT.Literal v -> pretty v
+    CT.Postlude v -> pretty v
+    CT.Range lo hi ClOpen -> pretty lo <+> "..." <+> pretty hi
+    CT.Range lo hi Closed -> pretty lo <+> ".." <+> pretty hi
+    CT.KV k v _ -> pretty k <+> "==>" <+> pretty v
+    CT.CTreeE x -> pretty x
+    CT.Occur v oi ->
+      case oi of
+        OIOptional -> "?" <+> pretty v
+        OIZeroOrMore -> "*" <+> pretty v
+        OIOneOrMore -> "+" <+> pretty v
+        OIBounded lo hi -> foldMap pretty lo <> "*" <> foldMap pretty hi <+> pretty v
+    CT.Map m -> encloseSep "{" "}" "," $ pretty <$> m
+    CT.Array e -> list $ pretty <$> e
+    CT.Choice c -> group . vsep . punctuate "//" $ pretty <$> toList c
+    CT.Group g -> tupled $ pretty <$> g
+    CT.Control op tgt ctl -> pretty tgt <+> pretty op <+> pretty ctl
+    CT.Enum e -> "&" <> pretty e
+    CT.Unwrap x -> "~" <> pretty x
+    CT.Tag t x -> "#6." <> pretty t <> "(" <> pretty x <> ")"

--- a/test/Test/Codec/CBOR/Cuddle/CDDL/Examples/Huddle.hs
+++ b/test/Test/Codec/CBOR/Cuddle/CDDL/Examples/Huddle.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE OverloadedStrings #-}
 
@@ -27,8 +28,11 @@ module Test.Codec.CBOR.Cuddle.CDDL.Examples.Huddle (
   mapNestedValueExample,
   deeplyNestedRefExample,
   taggedUintExample,
+  tagRangeExample,
 ) where
 
+import Codec.CBOR.Cuddle.CBOR.Gen (generateFromGRef)
+import Codec.CBOR.Cuddle.CBOR.Validator (validateFromGRef)
 import Codec.CBOR.Cuddle.CDDL (Name)
 import Codec.CBOR.Cuddle.CDDL.CBORGenerator (WrappedTerm (..))
 import Codec.CBOR.Cuddle.Huddle (
@@ -40,12 +44,14 @@ import Codec.CBOR.Cuddle.Huddle (
   a,
   arr,
   asKey,
+  binding,
   collectFrom,
   idx,
   mp,
   opt,
   tag,
   withCBORGen,
+  withValidator,
   (...),
   (=:=),
   (==>),
@@ -53,7 +59,7 @@ import Codec.CBOR.Cuddle.Huddle (
 import Codec.CBOR.Cuddle.Huddle qualified as H
 import Codec.CBOR.Term qualified as C
 import Data.Word (Word64)
-import Test.QuickCheck.GenT (MonadGen (..))
+import Test.QuickCheck.GenT (MonadGen (..), frequency)
 
 huddleRangeArray :: Huddle
 huddleRangeArray =
@@ -313,3 +319,38 @@ taggedUintExample =
   collectFrom
     [ HIRule $ "root" =:= tag 42 VBytes
     ]
+
+-- | @foo<a> = #6.1280(a) / #6.1400(a)@ with a custom generator that picks
+-- any tag in @1280..1400@ (broader than what the schema literally allows)
+-- and a custom validator that accepts the same range. Exercised at two
+-- different generic instantiations to make sure the bound type is
+-- resolved correctly per call.
+tagRangeExample :: Huddle
+tagRangeExample =
+  collectFrom
+    [ HIRule $
+        "root" =:= arr [a (fooTagRange VUInt), a (fooTagRange VNInt)]
+    ]
+  where
+    fooTagRange :: H.IsType0 t0 => t0 -> H.GRuleCall
+    fooTagRange = binding $ \x ->
+      withCBORGen (generator x)
+        . withValidator (validator x)
+        $ "foo" =:= tag 1280 x H./ tag 1400 x
+      where
+        generator x = do
+          tagN <-
+            frequency
+              [ (1, pure 1280)
+              , (1, pure 1400)
+              , (4, choose (1281, 1399))
+              ]
+          generateFromGRef x >>= \case
+            S inner -> pure $ S (C.TTagged tagN inner)
+            _ -> error "tagRangeExample: generic argument must be a single term"
+
+        validator x = \case
+          S (C.TTagged t inner)
+            | t >= 1280 && t <= 1400 -> validateFromGRef x inner
+            | otherwise -> fail $ "Tag out of range 1280..1400: " <> show t
+          wt -> fail $ "Expected a tagged term, got: " <> show wt

--- a/test/Test/Codec/CBOR/Cuddle/CDDL/GeneratorSpec.hs
+++ b/test/Test/Codec/CBOR/Cuddle/CDDL/GeneratorSpec.hs
@@ -30,6 +30,7 @@ import Test.Codec.CBOR.Cuddle.CDDL.Examples.Huddle (
   refTermExample,
   sizeBytesExample,
   sizeTextExample,
+  tagRangeExample,
   taggedUintExample,
  )
 import Test.Codec.CBOR.Cuddle.CDDL.Validator (expectInvalid, genAndValidateRule)
@@ -99,6 +100,7 @@ spec = do
       genAndValidateHuddle "sizeBytes" sizeBytesExample
       genAndValidateHuddle "rangeList" rangeListExample
       genAndValidateHuddle "rangeMap" rangeMapExample
+      genAndValidateHuddle "tagRange" tagRangeExample
       xdescribe "Generator cannot reliably produce unique keys for maps" $ do
         genAndValidateHuddle "optionalMapExample" optionalMapExample
 
@@ -139,6 +141,20 @@ spec = do
             TBytes "\x01\x02\x03\xff" -> True
             TBytesI "\x01\x02\x03\xff" -> True
             _ -> False
+      tagRangeExampleCddl <- tryResolveHuddle tagRangeExample
+      prop "tagRange generator covers edges and middle" $ do
+        res <- generateCDDL $ mapIndex tagRangeExampleCddl
+        let tags = case res of
+              TList xs -> [t | TTagged t _ <- xs]
+              TListI xs -> [t | TTagged t _ <- xs]
+              _ -> []
+            classifyTag t p =
+              classify (t == 1280 || t == 1400) "edge tag (1280 or 1400)" $
+                classify (t > 1280 && t < 1400) "middle tag (1281..1399)" p
+            base =
+              counterexample ("tags: " <> show tags) $
+                all (\t -> t >= 1280 && t <= 1400) tags
+        pure $ foldr classifyTag (property base) tags
 
   describe "Tagged bytes zapping" $ do
     taggedBytesCddl <- tryResolveHuddle taggedUintExample

--- a/test/Test/Codec/CBOR/Cuddle/CDDL/GeneratorSpec.hs
+++ b/test/Test/Codec/CBOR/Cuddle/CDDL/GeneratorSpec.hs
@@ -7,7 +7,7 @@ module Test.Codec.CBOR.Cuddle.CDDL.GeneratorSpec (spec) where
 import Codec.CBOR.Cuddle.CBOR.Gen (GenPhase, generateFromName)
 import Codec.CBOR.Cuddle.CBOR.Validator (validateCBOR)
 import Codec.CBOR.Cuddle.CDDL (Name)
-import Codec.CBOR.Cuddle.CDDL.CBORGenerator (GenEnv (..), runCBORGen)
+import Codec.CBOR.Cuddle.CDDL.CBORGenerator (GenConfig (..), runCBORGen)
 import Codec.CBOR.Cuddle.CDDL.CTree (CTreeRoot (..))
 import Codec.CBOR.Cuddle.CDDL.Resolve (MonoReferenced, MonoSimple, fullResolveCDDL)
 import Codec.CBOR.Cuddle.Huddle (Huddle, toCDDL)
@@ -40,12 +40,12 @@ import Test.QuickCheck (Gen, Property, Testable (..), classify, counterexample)
 import Text.Pretty.Simple (pShow)
 
 generateCDDL :: CTreeRoot GenPhase -> Gen Term
-generateCDDL cddl = runAntiGen . runCBORGen env $ generateFromName "root"
+generateCDDL cddl = runAntiGen . runCBORGen cfg $ generateFromName "root"
   where
-    env =
-      GenEnv
-        { geRoot = cddl
-        , geTwiddle = True
+    cfg =
+      GenConfig
+        { gcRoot = cddl
+        , gcTwiddle = True
         }
 
 tryResolveHuddle :: HasCallStack => Huddle -> SpecM () (CTreeRoot MonoReferenced)
@@ -57,12 +57,12 @@ tryResolveHuddle huddle = do
 expectZapInvalidates :: CTreeRoot MonoReferenced -> Name -> Property
 expectZapInvalidates cddl name = property $ do
   let
-    env =
-      GenEnv
-        { geRoot = mapIndex cddl
-        , geTwiddle = True
+    cfg =
+      GenConfig
+        { gcRoot = mapIndex cddl
+        , gcTwiddle = True
         }
-  res@ZapResult {zrValue} <- zapAntiGenResult 1 . runCBORGen env $ generateFromName name
+  res@ZapResult {zrValue} <- zapAntiGenResult 1 . runCBORGen cfg $ generateFromName name
   let
     bs = toStrictByteString $ encodeTerm zrValue
     validationRes = validateCBOR bs name $ mapIndex cddl
@@ -142,14 +142,14 @@ spec = do
 
   describe "Tagged bytes zapping" $ do
     taggedBytesCddl <- tryResolveHuddle taggedUintExample
-    let env =
-          GenEnv
-            { geRoot = mapIndex taggedBytesCddl
-            , geTwiddle = True
+    let cfg =
+          GenConfig
+            { gcRoot = mapIndex taggedBytesCddl
+            , gcTwiddle = True
             }
     prop "labels zapped result" $ do
       ZapResult {zrValue} <-
-        zapAntiGenResult 1 . runCBORGen env $ generateFromName "root"
+        zapAntiGenResult 1 . runCBORGen cfg $ generateFromName "root"
       let
         isBytes TBytes {} = True
         isBytes TBytesI {} = True

--- a/test/Test/Codec/CBOR/Cuddle/CDDL/Validator.hs
+++ b/test/Test/Codec/CBOR/Cuddle/CDDL/Validator.hs
@@ -23,7 +23,7 @@ import Codec.CBOR.Cuddle.CBOR.Validator.Trace (
  )
 import Codec.CBOR.Cuddle.CDDL (Name (..))
 import Codec.CBOR.Cuddle.CDDL.CBORGenerator (
-  GenEnv (..),
+  GenConfig (..),
   TermValidator,
   WrappedTerm (..),
   runCBORGen,
@@ -104,12 +104,12 @@ genAndValidateRule :: String -> Name -> CTreeRoot MonoReferenced -> Spec
 genAndValidateRule description name resolvedCddl =
   prop description $ do
     let
-      genEnv =
-        GenEnv
-          { geRoot = mapIndex resolvedCddl
-          , geTwiddle = True
+      genCfg =
+        GenConfig
+          { gcRoot = mapIndex resolvedCddl
+          , gcTwiddle = True
           }
-    cborTerm <- runAntiGen . runCBORGen genEnv $ generateFromName name
+    cborTerm <- runAntiGen . runCBORGen genCfg $ generateFromName name
     let
       generatedCbor = toStrictByteString $ encodeTerm cborTerm
       res = validateCBOR generatedCbor name (mapIndex resolvedCddl)

--- a/test/Test/Codec/CBOR/Cuddle/CDDL/Validator.hs
+++ b/test/Test/Codec/CBOR/Cuddle/CDDL/Validator.hs
@@ -22,7 +22,12 @@ import Codec.CBOR.Cuddle.CBOR.Validator.Trace (
   prettyValidationTrace,
  )
 import Codec.CBOR.Cuddle.CDDL (Name (..))
-import Codec.CBOR.Cuddle.CDDL.CBORGenerator (CustomValidatorResult (..), GenEnv (..), runCBORGen)
+import Codec.CBOR.Cuddle.CDDL.CBORGenerator (
+  GenEnv (..),
+  TermValidator,
+  WrappedTerm (..),
+  runCBORGen,
+ )
 import Codec.CBOR.Cuddle.CDDL.CTree (CTreeRoot (..))
 import Codec.CBOR.Cuddle.CDDL.CTree qualified as CTree
 import Codec.CBOR.Cuddle.CDDL.Postlude (appendPostlude)
@@ -281,15 +286,15 @@ expectInvalid (Evidenced SValid t) =
       <> renderStrict (layoutPretty defaultLayoutOptions $ prettyValidationTrace defaultTraceOptions t)
 expectInvalid _ = pure ()
 
-stringValidator :: Term -> CustomValidatorResult
-stringValidator (TString _) = CustomValidatorSuccess
-stringValidator (TStringI _) = CustomValidatorSuccess
-stringValidator t = CustomValidatorFailure $ "Expected a string, got\n" <> T.pack (show t)
+stringValidator :: TermValidator
+stringValidator (S (TString _)) = pure ()
+stringValidator (S (TStringI _)) = pure ()
+stringValidator t = fail $ "Expected a string, got\n" <> show t
 
-bytesValidator :: Term -> CustomValidatorResult
-bytesValidator (TBytes _) = CustomValidatorSuccess
-bytesValidator (TBytesI _) = CustomValidatorSuccess
-bytesValidator t = CustomValidatorFailure $ "Expected bytes, got\n" <> T.pack (show t)
+bytesValidator :: TermValidator
+bytesValidator (S (TBytes _)) = pure ()
+bytesValidator (S (TBytesI _)) = pure ()
+bytesValidator t = fail $ "Expected bytes, got\n" <> show t
 
 spec :: Spec
 spec = describe "Validator" $ do


### PR DESCRIPTION
## Summary

- Custom generators and validators on generic rules can now refer to their generic argument: looking up a `GRef` resolves to the type bound at the enclosing rule.
- Adds `generateFromGRef` and `validateFromGRef` (plus `validateFromName`) so closures attached to generic rules can delegate to whatever type the generic was instantiated with.
- Moves `GRef` from `Codec.CBOR.Cuddle.Huddle` to `Codec.CBOR.Cuddle.CDDL` so the lookup helpers can live alongside their monads. `Huddle` re-exports it without the constructor.
- `runCBORValidator` now takes a `CTreeRoot ValidatorPhase` directly instead of a `ValidateEnv`.
- Added `MonadCddl` typeclass which has methods for looking up rules from the root CDDL.
- `GenEnv` and `ValidateEnv` gain `geLocal` / `veLocal` fields holding the active generic bindings; populated by `synthMono` wrapping the captured custom generator/validator at monomorphization time.

## How it works

Monomorphization (`Resolve.synthMono`) builds a `localBinds :: Map Name (CTree _)` mapping each generic parameter (e.g. `a0`) to its bound CTree. Previously the body got substituted with these bindings but the opaque custom generator/validator closures didn't, so calling `generateFromName "a0"` from inside a custom closure failed with `Unbound reference: a0`.

`resolveGenericRef` now wraps the captured `g`/`v` closures with `withLocalGenBindings` / `withLocalValidateBindings` so the closure pushes its binding map onto `geLocal` / `veLocal` for the duration of its run. The new `lookupGRef` consults that map; `generateFromGRef` and `validateFromGRef` build on top.