### PR TITLE
Refactor validator to improve error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 * Unify `showSimple` into a single polymorphic helper in `Codec.CBOR.Cuddle.CDDL.Resolve`
 * Export `IsChoosable (toChoice)`
 * Add `choiceFromList` to fold a `NonEmpty` list into a `Choice` using `(/)`
+* `validateCBOR` returns `Either ValidatorInputError (Evidenced ValidationTrace)`
+* Add `ValidatorInputError`
+* Add `displayValidatorInputError`
 
 ## 1.7.0.0
 

--- a/bin/Main.hs
+++ b/bin/Main.hs
@@ -446,7 +446,8 @@ parseFromFile p file = runParser p file <$> T.readFile file
 runValidateCBOR :: BS.ByteString -> Name -> CTreeRoot ValidatorPhase -> TraceOptions -> IO ()
 runValidateCBOR bs rule cddl traceOpts =
   case validateCBOR bs rule cddl of
-    Evidenced validity trc -> do
+    Left err -> putStrLnErr (displayValidatorInputError err) >> exitFailure
+    Right (Evidenced validity trc) -> do
       T.putStrLn . Ansi.renderStrict . layoutPretty defaultLayoutOptions $
         prettyValidationTrace traceOpts trc
       putStrLn mempty

--- a/cuddle.cabal
+++ b/cuddle.cabal
@@ -88,6 +88,7 @@ library
     regex-tdfa >=1.3.2,
     scientific >=0.3.7,
     text >=2.0.2,
+    transformers >=0.6,
     tree-diff >=0.3,
 
   hs-source-dirs: src

--- a/src/Codec/CBOR/Cuddle/CBOR/Validator.hs
+++ b/src/Codec/CBOR/Cuddle/CBOR/Validator.hs
@@ -10,6 +10,8 @@ module Codec.CBOR.Cuddle.CBOR.Validator (
   ValidatorPhase,
   ValidatorInputError (..),
   displayValidatorInputError,
+  ValidatorError (..),
+  displayValidatorError,
 ) where
 
 import Codec.CBOR.Cuddle.CBOR.Validator.Trace (
@@ -24,6 +26,7 @@ import Codec.CBOR.Cuddle.CBOR.Validator.Trace (
   isValid,
   mapTrace,
  )
+import Codec.CBOR.Cuddle.CBOR.Validator.Trace qualified as Trace
 import Codec.CBOR.Cuddle.CDDL hiding (CDDL, Group, Rule)
 import Codec.CBOR.Cuddle.CDDL.CTree
 import Codec.CBOR.Cuddle.CDDL.CtlOp
@@ -33,26 +36,32 @@ import Codec.CBOR.Cuddle.CDDL.Custom.Validator (
   TermValidator,
   ValidateEnv (..),
   Validator,
+  ValidatorError (..),
   ValidatorPhase,
   XXCTree (..),
+  displayValidatorError,
   runValidator,
+  runValidatorM,
  )
-import Codec.CBOR.Cuddle.CDDL.Resolve (showSimple)
 import Codec.CBOR.Cuddle.IndexMappable (IndexMappable (..))
 import Codec.CBOR.Read (DeserialiseFailure, deserialiseFromBytes)
 import Codec.CBOR.Term
+import Control.Monad (guard)
+import Control.Monad.Error.Class (MonadError (..))
 import Control.Monad.Reader (asks)
+import Control.Monad.Trans.Class (lift)
+import Control.Monad.Trans.Maybe (MaybeT (..), runMaybeT)
 import Data.Bifunctor (Bifunctor (..))
 import Data.Bits hiding (And)
 import Data.ByteString qualified as BS
 import Data.ByteString.Lazy qualified as BSL
-import Data.Function (on, (&))
+import Data.Function (on)
 import Data.IntSet qualified as IS
 import Data.List (maximumBy)
 import Data.List.NonEmpty (NonEmpty (..))
 import Data.List.NonEmpty qualified as NE
 import Data.Map.Strict qualified as Map
-import Data.Maybe
+import Data.Maybe (catMaybes, fromJust)
 import Data.Text qualified as T
 import Data.Text.Encoding (encodeUtf8)
 import Data.Text.Lazy qualified as TL
@@ -65,14 +74,16 @@ import Text.Regex.TDFA
 -- Main entry point
 
 -- | Errors that prevent validation from running at all: the input could not be
--- decoded as CBOR, decoded successfully but had trailing garbage, or the
--- caller asked us to validate against a top-level rule name not defined in the
--- CDDL. These are distinct from schema-level mismatches, which are reported
--- through 'Evidenced' 'ValidationTrace'.
+-- decoded as CBOR, decoded successfully but had trailing garbage, the caller
+-- asked us to validate against a top-level rule name not defined in the CDDL,
+-- or the CDDL itself was malformed in a way the validator could not handle.
+-- These are distinct from schema-level mismatches, which are reported through
+-- 'Evidenced' 'ValidationTrace'.
 data ValidatorInputError
   = CBORDecodeFailure DeserialiseFailure
   | LeftoverBytesAfterTerm BS.ByteString
   | UnknownTopLevelRule Name
+  | MalformedCDDL ValidatorError
   deriving (Show)
 
 -- | Human-readable rendering of a 'ValidatorInputError'.
@@ -81,6 +92,7 @@ displayValidatorInputError = \case
   CBORDecodeFailure e -> "Could not decode input as CBOR: " <> show e
   LeftoverBytesAfterTerm rest -> "Leftover bytes after CBOR term: " <> show rest
   UnknownTopLevelRule (Name n) -> "No such top-level rule in the CDDL: " <> T.unpack n
+  MalformedCDDL e -> "Malformed CDDL: " <> displayValidatorError e
 
 validateCBOR ::
   BS.ByteString ->
@@ -95,7 +107,7 @@ validateCBOR bs rule cddl@(CTreeRoot tree) =
     Right (_, term) ->
       case Map.lookup rule tree of
         Nothing -> Left $ UnknownTopLevelRule rule
-        Just r -> Right $ validateTerm cddl term r
+        Just r -> first MalformedCDDL $ runValidatorM (validateTerm term r) cddl
 
 -- | Validate a CBOR 'Term' against a top-level rule from inside a custom
 -- validator.
@@ -104,7 +116,7 @@ validateFromName ::
 validateFromName n term = do
   mRule <- lookupCddl n
   case mRule of
-    Nothing -> fail $ "Unbound name: " <> show n
+    Nothing -> throwError $ InvalidReference n
     Just rule -> validateAgainst term rule
 
 -- | Validate a CBOR 'Term' against the type bound to the given generic
@@ -115,13 +127,12 @@ validateFromGRef ::
 validateFromGRef ref term = do
   mRule <- lookupGRef ref
   case mRule of
-    Nothing -> fail $ "Unbound generic reference: " <> show ref
+    Nothing -> throwError $ InvalidGenericReference ref
     Just rule -> validateAgainst term rule
 
 validateAgainst :: Term -> CTree ValidatorPhase -> Validator ()
 validateAgainst term rule = do
-  cddl <- asks veRoot
-  let res = validateTerm cddl term rule
+  res <- validateTerm term rule
   if isValid res
     then pure ()
     else fail $ "Validation failed for term: " <> show term
@@ -132,34 +143,33 @@ validateAgainst term rule = do
 -- | Core function that validates a CBOR term to a particular rule of the CDDL
 -- spec
 validateTerm ::
-  CTreeRoot ValidatorPhase ->
   Term ->
   CTree ValidatorPhase ->
-  Evidenced ValidationTrace
-validateTerm cddl term rule
+  Validator (Evidenced ValidationTrace)
+validateTerm term rule
   | CTreeE (VRuleRef n) <- rule =
-      dereferenceAndValidate cddl n (validateTerm cddl term)
+      dereferenceAndValidate n (validateTerm term)
   | CTreeE (VValidator v _) <- rule =
-      runCustomValidator cddl (SingleTerm term) v
+      runCustomValidator (SingleTerm term) v
   | otherwise =
       case term of
-        TInt i -> validateInteger cddl (fromIntegral i) rule
-        TInteger i -> validateInteger cddl i rule
-        TBytes b -> validateBytes cddl b rule
-        TBytesI b -> validateBytes cddl (BSL.toStrict b) rule
-        TString s -> validateText cddl s rule
-        TStringI s -> validateText cddl (TL.toStrict s) rule
-        TList ts -> validateList cddl ts rule
-        TListI ts -> validateList cddl ts rule
-        TMap ts -> validateMap cddl ts rule
-        TMapI ts -> validateMap cddl ts rule
-        TTagged w t -> validateTagged cddl w t rule
-        TBool b -> validateBool cddl b rule
-        TNull -> validateNull cddl rule
-        TSimple s -> validateSimple cddl s rule
-        THalf h -> validateHalf cddl h rule
-        TFloat h -> validateFloat cddl h rule
-        TDouble d -> validateDouble cddl d rule
+        TInt i -> validateInteger (fromIntegral i) rule
+        TInteger i -> validateInteger i rule
+        TBytes b -> validateBytes b rule
+        TBytesI b -> validateBytes (BSL.toStrict b) rule
+        TString s -> validateText s rule
+        TStringI s -> validateText (TL.toStrict s) rule
+        TList ts -> validateList ts rule
+        TListI ts -> validateList ts rule
+        TMap ts -> validateMap ts rule
+        TMapI ts -> validateMap ts rule
+        TTagged w t -> validateTagged w t rule
+        TBool b -> validateBool b rule
+        TNull -> validateNull rule
+        TSimple s -> validateSimple s rule
+        THalf h -> validateHalf h rule
+        TFloat h -> validateFloat h rule
+        TDouble d -> validateDouble d rule
 
 terminal :: CTree ValidatorPhase -> Evidenced ValidationTrace
 terminal = evidence . TerminalRule . mapIndex
@@ -167,14 +177,14 @@ terminal = evidence . TerminalRule . mapIndex
 -- | Run a custom validator on a term. This is used by type-specific validators
 -- when they encounter a 'VValidator' node after dereferencing a rule reference.
 runCustomValidator ::
-  CTreeRoot ValidatorPhase ->
   RuleTerm ->
   TermValidator ->
-  Evidenced ValidationTrace
-runCustomValidator cddl term validator =
-  case runValidator (validator term) cddl of
-    CustomValidatorSuccess -> evidence CustomSuccess
-    CustomValidatorFailure err -> evidence $ CustomFailure err
+  Validator (Evidenced ValidationTrace)
+runCustomValidator term validator = do
+  root <- asks veRoot
+  case runValidator (validator term) root of
+    CustomValidatorSuccess -> pure $ evidence Trace.CustomSuccess
+    CustomValidatorFailure err -> pure $ evidence $ Trace.CustomFailure err
 
 unapplicable :: CTree ValidatorPhase -> Evidenced ValidationTrace
 unapplicable = evidence . UnapplicableRule . mapIndex
@@ -195,168 +205,152 @@ unapplicable = evidence . UnapplicableRule . mapIndex
 -- Ints, so we convert everything to Integer.
 validateInteger ::
   HasCallStack =>
-  CTreeRoot ValidatorPhase ->
   Integer ->
   CTree ValidatorPhase ->
-  Evidenced ValidationTrace
-validateInteger cddl i rule =
+  Validator (Evidenced ValidationTrace)
+validateInteger i rule =
   case rule of
-    CTreeE (VRuleRef n) -> dereferenceAndValidate cddl n $ validateInteger cddl i
-    CTreeE (VValidator v _) -> runCustomValidator cddl (SingleTerm $ TInteger i) v
-    -- echo "C24101" | xxd -r -p - example.cbor
-    -- echo "foo = int" > a.cddl
-    -- cddl a.cddl validate example.cbor
-    --
-    -- but
-    --
-    -- echo "C249010000000000000000"| xxd -r -p - example.cbor
-    -- echo "foo = int" > a.cddl
-    -- cddl a.cddl validate example.cbor
-    --
-    -- and they are both bigints?
-
+    CTreeE (VRuleRef n) -> dereferenceAndValidate n $ validateInteger i
+    CTreeE (VValidator v _) -> runCustomValidator (SingleTerm $ TInteger i) v
     -- a = any
-    Postlude PTAny -> terminal rule
+    Postlude PTAny -> pure $ terminal rule
     -- a = int
     Postlude PTInt
-      | i >= nintMin && i <= uintMax -> terminal rule
+      | i >= nintMin && i <= uintMax -> pure $ terminal rule
     -- a = uint
     Postlude PTUInt
-      | i >= 0 && i <= uintMax -> terminal rule
+      | i >= 0 && i <= uintMax -> pure $ terminal rule
     -- a = nint
     Postlude PTNInt
-      | i >= nintMin && i <= -1 -> terminal rule
+      | i >= nintMin && i <= -1 -> pure $ terminal rule
     -- a = x
-    Literal (Value (VUInt i') _) | i == fromIntegral i' -> terminal rule
+    Literal (Value (VUInt i') _) | i == fromIntegral i' -> pure $ terminal rule
     -- a = -x
-    Literal (Value (VNInt i') _) | -i == fromIntegral i' -> terminal rule
+    Literal (Value (VNInt i') _) | -i == fromIntegral i' -> pure $ terminal rule
     -- a = <big number>
-    Literal (Value (VBignum i') _) | i == i' -> terminal rule
+    Literal (Value (VBignum i') _) | i == i' -> pure $ terminal rule
     -- a = foo .ctrl bar
-    Control op tgt ctrl -> ctrlDispatch (validateInteger cddl i) op tgt ctrl (controlInteger cddl i)
+    Control op tgt ctrl -> ctrlDispatch (validateInteger i) op tgt ctrl (controlInteger i)
     -- a = foo / bar
-    Choice opts -> validateChoice (validateInteger cddl i) opts
+    Choice opts -> validateChoice (validateInteger i) opts
     -- a = x..y
     Range low high bound ->
       case (low, high) of
         (Literal (Value (VUInt (fromIntegral -> n)) _), Literal (Value (VUInt (fromIntegral -> m)) _))
-          | n <= i && range bound i m -> terminal rule
-          | otherwise -> unapplicable rule
+          | n <= i && range bound i m -> pure $ terminal rule
+          | otherwise -> pure $ unapplicable rule
         (Literal (Value (VNInt (fromIntegral -> n)) _), Literal (Value (VUInt (fromIntegral -> m)) _))
-          | -n <= i && range bound i m -> terminal rule
-          | otherwise -> unapplicable rule
+          | -n <= i && range bound i m -> pure $ terminal rule
+          | otherwise -> pure $ unapplicable rule
         (Literal (Value (VNInt (fromIntegral -> n)) _), Literal (Value (VNInt (fromIntegral -> m)) _))
-          | -n <= i && range bound i (-m) -> terminal rule
-          | otherwise -> unapplicable rule
-        (Literal (Value VUInt {} _), Literal (Value VNInt {} _)) -> error "range types mismatch"
+          | -n <= i && range bound i (-m) -> pure $ terminal rule
+          | otherwise -> pure $ unapplicable rule
         (Literal (Value (VBignum n) _), Literal (Value (VUInt (fromIntegral -> m)) _))
-          | n <= i && range bound i m -> terminal rule
-          | otherwise -> unapplicable rule
+          | n <= i && range bound i m -> pure $ terminal rule
+          | otherwise -> pure $ unapplicable rule
         (Literal (Value (VBignum n) _), Literal (Value (VNInt (fromIntegral -> m)) _))
-          | n <= i && range bound i (-m) -> terminal rule
-          | otherwise -> unapplicable rule
+          | n <= i && range bound i (-m) -> pure $ terminal rule
+          | otherwise -> pure $ unapplicable rule
         (Literal (Value (VUInt (fromIntegral -> n)) _), Literal (Value (VBignum m) _))
-          | n <= i && range bound i m -> terminal rule
-          | otherwise -> unapplicable rule
+          | n <= i && range bound i m -> pure $ terminal rule
+          | otherwise -> pure $ unapplicable rule
         (Literal (Value (VNInt (fromIntegral -> n)) _), Literal (Value (VBignum m) _))
-          | (-n) <= i && range bound i m -> terminal rule
-          | otherwise -> unapplicable rule
+          | (-n) <= i && range bound i m -> pure $ terminal rule
+          | otherwise -> pure $ unapplicable rule
         (CTreeE (VRuleRef n), _) ->
-          dereferenceAndValidate cddl n $ \lo -> validateInteger cddl i (Range lo high bound)
+          dereferenceAndValidate n $ \lo -> validateInteger i (Range lo high bound)
         (_, CTreeE (VRuleRef n)) ->
-          dereferenceAndValidate cddl n $ \hi -> validateInteger cddl i (Range low hi bound)
-        (lo, hi) -> error $ "Unable to validate range: (" <> showSimple lo <> ", " <> showSimple hi <> ")"
+          dereferenceAndValidate n $ \hi -> validateInteger i (Range low hi bound)
+        _ -> throwError IncompatibleRangeTypes
     -- a = &(x, y, z)
     Enum g ->
       case g of
-        CTreeE (VRuleRef n) -> dereferenceAndValidate cddl n $ validateInteger cddl i
-        Group g' -> validateInteger cddl i (Choice (NE.fromList g'))
-        _ -> error "Not yet implemented"
+        CTreeE (VRuleRef n) -> dereferenceAndValidate n $ validateInteger i
+        Group g' -> validateInteger i (Choice (NE.fromList g'))
+        _ -> throwError InvalidType
     -- a = x: y
     -- Note KV cannot appear on its own, but we will use this when validating
     -- lists.
-    KV _ v _ -> validateInteger cddl i v
+    KV _ v _ -> validateInteger i v
     Tag 2 x -> validateBigInt x
     Tag 3 x -> validateBigInt x
-    _ -> unapplicable rule
+    _ -> pure $ unapplicable rule
   where
     validateBigInt x = case x of
-      CTreeE (VRuleRef n) -> dereferenceAndValidate cddl n validateBigInt
-      Postlude PTBytes -> terminal rule
+      CTreeE (VRuleRef n) -> dereferenceAndValidate n validateBigInt
+      Postlude PTBytes -> pure $ terminal rule
       Control op tgt@(Postlude PTBytes) ctrl ->
-        ctrlDispatch (validateBytes cddl bs) op tgt ctrl (controlBytes cddl bs)
+        ctrlDispatch (validateBytes bs) op tgt ctrl (controlBytes bs)
         where
           -- TODO figure out a way to turn Integer into bytes or figure out why
           -- tagged bigints are decoded as integers in the first place
           bs = mempty
-      _ -> unapplicable rule
+      _ -> pure $ unapplicable rule
 
 -- | Controls for an Integer
 controlInteger ::
   HasCallStack =>
-  CTreeRoot ValidatorPhase ->
   Integer ->
   CtlOp ->
   CTree ValidatorPhase ->
-  Bool
-controlInteger cddl i op (CTreeE (VRuleRef n)) =
-  controlInteger cddl i op $ dereference cddl n
-controlInteger _ i Size ctrl =
-  case ctrl of
+  Validator Bool
+controlInteger i op (CTreeE (VRuleRef n)) =
+  controlInteger i op =<< dereference n
+controlInteger i Size ctrl =
+  pure $ case ctrl of
     Literal (Value (VUInt sz) _) -> 0 <= i && i < 256 ^ sz
     _ -> False
-controlInteger cddl i Bits ctrl = do
-  let
-    indices = case ctrl of
-      Literal (Value (VUInt i') _) -> [i']
-      Choice nodes -> getIndicesOfChoice cddl nodes
-      Range ff tt incl -> getIndicesOfRange cddl ff tt incl
-      Enum g -> getIndicesOfEnum cddl g
-      _ -> error "Not yet implemented"
-  go (IS.fromList (map fromIntegral indices)) i 0
+controlInteger i Bits ctrl = do
+  indices <- case ctrl of
+    Literal (Value (VUInt i') _) -> pure [i']
+    Choice nodes -> getIndicesOfChoice nodes
+    Range ff tt incl -> getIndicesOfRange ff tt incl
+    Enum g -> getIndicesOfEnum g
+    _ -> throwError $ InvalidController Bits
+  pure $ go (IS.fromList (map fromIntegral indices)) i 0
   where
     go _ 0 _ = True
     go indices n idx =
       let bitSet = testBit n 0
           allowed = not bitSet || IS.member idx indices
        in allowed && go indices (shiftR n 1) (idx + 1)
-controlInteger _ i Lt ctrl =
-  case ctrl of
+controlInteger i Lt ctrl =
+  pure $ case ctrl of
     Literal (Value (VUInt i') _) -> i < fromIntegral i'
     Literal (Value (VNInt i') _) -> i < -fromIntegral i'
     Literal (Value (VBignum i') _) -> i < i'
     _ -> False
-controlInteger _ i Gt ctrl =
-  case ctrl of
+controlInteger i Gt ctrl =
+  pure $ case ctrl of
     Literal (Value (VUInt i') _) -> i > fromIntegral i'
     Literal (Value (VNInt i') _) -> i > -fromIntegral i'
     Literal (Value (VBignum i') _) -> i > i'
     _ -> False
-controlInteger _ i Le ctrl =
-  case ctrl of
+controlInteger i Le ctrl =
+  pure $ case ctrl of
     Literal (Value (VUInt i') _) -> i <= fromIntegral i'
     Literal (Value (VNInt i') _) -> i <= -fromIntegral i'
     Literal (Value (VBignum i') _) -> i <= i'
     _ -> False
-controlInteger _ i Ge ctrl =
-  case ctrl of
+controlInteger i Ge ctrl =
+  pure $ case ctrl of
     Literal (Value (VUInt i') _) -> i >= fromIntegral i'
     Literal (Value (VNInt i') _) -> i >= -fromIntegral i'
     Literal (Value (VBignum i') _) -> i >= i'
     _ -> False
-controlInteger _ i Eq ctrl =
-  case ctrl of
+controlInteger i Eq ctrl =
+  pure $ case ctrl of
     Literal (Value (VUInt i') _) -> i == fromIntegral i'
     Literal (Value (VNInt i') _) -> i == -fromIntegral i'
     Literal (Value (VBignum i') _) -> i == i'
     _ -> False
-controlInteger _ i Ne ctrl =
-  case ctrl of
+controlInteger i Ne ctrl =
+  pure $ case ctrl of
     Literal (Value (VUInt i') _) -> i /= fromIntegral i'
     Literal (Value (VNInt i') _) -> i /= -fromIntegral i'
     Literal (Value (VBignum i') _) -> i /= i'
     _ -> False
-controlInteger _ _ _ ctrl = error $ "unexpected control: " <> showSimple ctrl
+controlInteger _ op _ = throwError $ UnsupportedControlOperator op
 
 --------------------------------------------------------------------------------
 -- Floating point (Float16, Float32, Float64)
@@ -367,312 +361,267 @@ controlInteger _ _ _ ctrl = error $ "unexpected control: " <> showSimple ctrl
 -- | Validating a `Float16`
 validateHalf ::
   HasCallStack =>
-  CTreeRoot ValidatorPhase ->
   Float ->
   CTree ValidatorPhase ->
-  Evidenced ValidationTrace
-validateHalf cddl f (CTreeE (VRuleRef n)) = dereferenceAndValidate cddl n $ validateHalf cddl f
-validateHalf cddl f (CTreeE (VValidator v _)) = runCustomValidator cddl (SingleTerm $ THalf f) v
-validateHalf cddl f rule =
+  Validator (Evidenced ValidationTrace)
+validateHalf f (CTreeE (VRuleRef n)) = dereferenceAndValidate n $ validateHalf f
+validateHalf f (CTreeE (VValidator v _)) = runCustomValidator (SingleTerm $ THalf f) v
+validateHalf f rule =
   case rule of
-    -- a = any
-    Postlude PTAny -> terminal rule
-    -- a = float16
-    Postlude PTHalf -> terminal rule
-    -- a = 0.5
-    Literal (Value (VFloat16 f') _) | f == f' -> terminal rule
-    -- a = foo / bar
-    Choice opts -> validateChoice (validateHalf cddl f) opts
-    -- a = foo .ctrl bar
-    Control op tgt ctrl -> ctrlDispatch (validateHalf cddl f) op tgt ctrl (controlHalf cddl f)
-    -- a = x..y
+    Postlude PTAny -> pure $ terminal rule
+    Postlude PTHalf -> pure $ terminal rule
+    Literal (Value (VFloat16 f') _) | f == f' -> pure $ terminal rule
+    Choice opts -> validateChoice (validateHalf f) opts
+    Control op tgt ctrl -> ctrlDispatch (validateHalf f) op tgt ctrl (controlHalf f)
     Range (CTreeE (VRuleRef n)) high bound ->
-      dereferenceAndValidate cddl n $ \lo -> validateHalf cddl f $ Range lo high bound
+      dereferenceAndValidate n $ \lo -> validateHalf f $ Range lo high bound
     Range low (CTreeE (VRuleRef n)) bound ->
-      dereferenceAndValidate cddl n $ \hi -> validateHalf cddl f $ Range low hi bound
+      dereferenceAndValidate n $ \hi -> validateHalf f $ Range low hi bound
     Range (Literal (Value (VFloat16 n) _)) (Literal (Value (VFloat16 m) _)) bound
-      | n <= f && range bound f m -> terminal rule
-    _ -> unapplicable rule
+      | n <= f && range bound f m -> pure $ terminal rule
+    _ -> pure $ unapplicable rule
 
 -- | Controls for `Float16`
 controlHalf ::
   HasCallStack =>
-  CTreeRoot ValidatorPhase ->
   Float ->
   CtlOp ->
   CTree ValidatorPhase ->
-  Bool
-controlHalf cddl f op (CTreeE (VRuleRef n)) =
-  controlHalf cddl f op $ dereference cddl n
-controlHalf _ f Eq ctrl =
-  case ctrl of
+  Validator Bool
+controlHalf f op (CTreeE (VRuleRef n)) =
+  controlHalf f op =<< dereference n
+controlHalf f Eq ctrl =
+  pure $ case ctrl of
     Literal (Value (VFloat16 f') _) -> f == f'
     _ -> False
-controlHalf _ f Ne ctrl =
-  case ctrl of
+controlHalf f Ne ctrl =
+  pure $ case ctrl of
     Literal (Value (VFloat16 f') _) -> f /= f'
     _ -> False
-controlHalf _ _ op _ = error $ "Not yet implemented for half: " <> show op
+controlHalf _ op _ = throwError $ InvalidController op
 
 -- | Validating a `Float32`
 validateFloat ::
   HasCallStack =>
-  CTreeRoot ValidatorPhase ->
   Float ->
   CTree ValidatorPhase ->
-  Evidenced ValidationTrace
-validateFloat cddl f (CTreeE (VRuleRef n)) =
-  dereferenceAndValidate cddl n $ validateFloat cddl f
-validateFloat cddl f (CTreeE (VValidator v _)) = runCustomValidator cddl (SingleTerm $ TFloat f) v
-validateFloat cddl f rule =
+  Validator (Evidenced ValidationTrace)
+validateFloat f (CTreeE (VRuleRef n)) =
+  dereferenceAndValidate n $ validateFloat f
+validateFloat f (CTreeE (VValidator v _)) = runCustomValidator (SingleTerm $ TFloat f) v
+validateFloat f rule =
   case rule of
-    -- a = any
-    Postlude PTAny -> terminal rule
-    -- a = float32
-    Postlude PTFloat -> terminal rule
-    -- a = 0.000000005
-    -- TODO: it is unclear if smaller floats should also validate
-    Literal (Value (VFloat32 f') _) | f == f' -> terminal rule
-    -- a = foo / bar
-    Choice opts -> validateChoice (validateFloat cddl f) opts
-    -- a = foo .ctrl bar
-    Control op tgt ctrl -> ctrlDispatch (validateFloat cddl f) op tgt ctrl (controlFloat cddl f)
-    -- a = x..y
-    -- TODO it is unclear if this should mix floating point types too
+    Postlude PTAny -> pure $ terminal rule
+    Postlude PTFloat -> pure $ terminal rule
+    Literal (Value (VFloat32 f') _) | f == f' -> pure $ terminal rule
+    Choice opts -> validateChoice (validateFloat f) opts
+    Control op tgt ctrl -> ctrlDispatch (validateFloat f) op tgt ctrl (controlFloat f)
     Range (CTreeE (VRuleRef n)) high bound ->
-      dereferenceAndValidate cddl n $ \lo -> validateFloat cddl f $ Range lo high bound
+      dereferenceAndValidate n $ \lo -> validateFloat f $ Range lo high bound
     Range low (CTreeE (VRuleRef n)) bound ->
-      dereferenceAndValidate cddl n $ \hi -> validateFloat cddl f $ Range low hi bound
+      dereferenceAndValidate n $ \hi -> validateFloat f $ Range low hi bound
     Range (Literal (Value nv _)) (Literal (Value mv _)) bound
       | VFloat16 n <- nv
       , VFloat16 m <- mv
       , n <= f && range bound f m ->
-          terminal rule
+          pure $ terminal rule
       | VFloat32 n <- nv
       , VFloat32 m <- mv
       , n <= f && range bound f m ->
-          terminal rule
-    _ -> unapplicable rule
+          pure $ terminal rule
+    _ -> pure $ unapplicable rule
 
 -- | Controls for `Float32`
 controlFloat ::
   HasCallStack =>
-  CTreeRoot ValidatorPhase ->
   Float ->
   CtlOp ->
   CTree ValidatorPhase ->
-  Bool
-controlFloat cddl f op (CTreeE (VRuleRef n)) =
-  controlFloat cddl f op $ dereference cddl n
-controlFloat _ f Eq ctrl =
-  case ctrl of
+  Validator Bool
+controlFloat f op (CTreeE (VRuleRef n)) =
+  controlFloat f op =<< dereference n
+controlFloat f Eq ctrl =
+  pure $ case ctrl of
     Literal (Value (VFloat16 f') _) -> f == f'
     Literal (Value (VFloat32 f') _) -> f == f'
     _ -> False
-controlFloat _ f Ne ctrl =
-  case ctrl of
+controlFloat f Ne ctrl =
+  pure $ case ctrl of
     Literal (Value (VFloat16 f') _) -> f /= f'
     Literal (Value (VFloat32 f') _) -> f /= f'
     _ -> False
-controlFloat _ _ op _ = error $ "Not yet implemented for float: " <> show op
+controlFloat _ op _ = throwError $ InvalidController op
 
 -- | Validating a `Float64`
 validateDouble ::
   HasCallStack =>
-  CTreeRoot ValidatorPhase ->
   Double ->
   CTree ValidatorPhase ->
-  Evidenced ValidationTrace
-validateDouble cddl f (CTreeE (VRuleRef n)) =
-  dereferenceAndValidate cddl n $ validateDouble cddl f
-validateDouble cddl f (CTreeE (VValidator v _)) = runCustomValidator cddl (SingleTerm $ TDouble f) v
-validateDouble cddl f rule =
+  Validator (Evidenced ValidationTrace)
+validateDouble f (CTreeE (VRuleRef n)) =
+  dereferenceAndValidate n $ validateDouble f
+validateDouble f (CTreeE (VValidator v _)) = runCustomValidator (SingleTerm $ TDouble f) v
+validateDouble f rule =
   case rule of
-    -- a = any
-    Postlude PTAny -> terminal rule
-    -- a = float64
-    Postlude PTDouble -> terminal rule
-    -- a = 0.0000000000000000000000000000000000000000000005
-    -- TODO: it is unclear if smaller floats should also validate
-    Literal (Value (VFloat64 f') _) | f == f' -> terminal rule
-    -- a = foo / bar
-    Choice opts -> validateChoice (validateDouble cddl f) opts
-    -- a = foo .ctrl bar
-    Control op tgt ctrl -> ctrlDispatch (validateDouble cddl f) op tgt ctrl (controlDouble cddl f)
-    -- a = x..y
-    -- TODO it is unclear if this should mix floating point types too
+    Postlude PTAny -> pure $ terminal rule
+    Postlude PTDouble -> pure $ terminal rule
+    Literal (Value (VFloat64 f') _) | f == f' -> pure $ terminal rule
+    Choice opts -> validateChoice (validateDouble f) opts
+    Control op tgt ctrl -> ctrlDispatch (validateDouble f) op tgt ctrl (controlDouble f)
     Range (CTreeE (VRuleRef n)) high bound ->
-      dereferenceAndValidate cddl n $ \lo -> validateDouble cddl f $ Range lo high bound
+      dereferenceAndValidate n $ \lo -> validateDouble f $ Range lo high bound
     Range low (CTreeE (VRuleRef n)) bound ->
-      dereferenceAndValidate cddl n $ \hi -> validateDouble cddl f $ Range low hi bound
+      dereferenceAndValidate n $ \hi -> validateDouble f $ Range low hi bound
     Range (Literal (Value nv _)) (Literal (Value mv _)) bound
       | VFloat16 n <- nv
       , VFloat16 m <- mv
       , float2Double n <= f && range bound f (float2Double m) ->
-          terminal rule
+          pure $ terminal rule
       | VFloat32 n <- nv
       , VFloat32 m <- mv
       , float2Double n <= f && range bound f (float2Double m) ->
-          terminal rule
+          pure $ terminal rule
       | VFloat64 n <- nv
       , VFloat64 m <- mv
       , n <= f && range bound f m ->
-          terminal rule
-    _ -> unapplicable rule
+          pure $ terminal rule
+    _ -> pure $ unapplicable rule
 
 -- | Controls for `Float64`
 controlDouble ::
   HasCallStack =>
-  CTreeRoot ValidatorPhase ->
   Double ->
   CtlOp ->
   CTree ValidatorPhase ->
-  Bool
-controlDouble cddl f op (CTreeE (VRuleRef n)) =
-  controlDouble cddl f op $ dereference cddl n
-controlDouble _ f Eq ctrl =
-  case ctrl of
+  Validator Bool
+controlDouble f op (CTreeE (VRuleRef n)) =
+  controlDouble f op =<< dereference n
+controlDouble f Eq ctrl =
+  pure $ case ctrl of
     Literal (Value (VFloat16 f') _) -> f == float2Double f'
     Literal (Value (VFloat32 f') _) -> f == float2Double f'
     Literal (Value (VFloat64 f') _) -> f == f'
     _ -> False
-controlDouble _ f Ne ctrl =
-  case ctrl of
+controlDouble f Ne ctrl =
+  pure $ case ctrl of
     Literal (Value (VFloat16 f') _) -> f /= float2Double f'
     Literal (Value (VFloat32 f') _) -> f /= float2Double f'
     Literal (Value (VFloat64 f') _) -> f /= f'
     _ -> False
-controlDouble _ _ op _ = error $ "Not yet implmented for double: " <> show op
+controlDouble _ op _ = throwError $ InvalidController op
 
 --------------------------------------------------------------------------------
 -- Bool
 
 -- | Validating a boolean
 validateBool ::
-  CTreeRoot ValidatorPhase ->
   Bool ->
   CTree ValidatorPhase ->
-  Evidenced ValidationTrace
-validateBool cddl b (CTreeE (VRuleRef n)) =
-  dereferenceAndValidate cddl n $ validateBool cddl b
-validateBool cddl b (CTreeE (VValidator v _)) = runCustomValidator cddl (SingleTerm $ TBool b) v
-validateBool cddl b rule =
+  Validator (Evidenced ValidationTrace)
+validateBool b (CTreeE (VRuleRef n)) =
+  dereferenceAndValidate n $ validateBool b
+validateBool b (CTreeE (VValidator v _)) = runCustomValidator (SingleTerm $ TBool b) v
+validateBool b rule =
   case rule of
-    -- a = any
-    Postlude PTAny -> terminal rule
-    -- a = bool
-    Postlude PTBool -> terminal rule
-    -- a = true
-    Literal (Value (VBool b') _) | b == b' -> terminal rule
-    -- a = foo .ctrl bar
-    Control op tgt ctrl -> ctrlDispatch (validateBool cddl b) op tgt ctrl (controlBool cddl b)
-    -- a = foo / bar
-    Choice opts -> validateChoice (validateBool cddl b) opts
-    _ -> unapplicable rule
+    Postlude PTAny -> pure $ terminal rule
+    Postlude PTBool -> pure $ terminal rule
+    Literal (Value (VBool b') _) | b == b' -> pure $ terminal rule
+    Control op tgt ctrl -> ctrlDispatch (validateBool b) op tgt ctrl (controlBool b)
+    Choice opts -> validateChoice (validateBool b) opts
+    _ -> pure $ unapplicable rule
 
 -- | Controls for `Bool`
 controlBool ::
   HasCallStack =>
-  CTreeRoot ValidatorPhase ->
   Bool ->
   CtlOp ->
   CTree ValidatorPhase ->
-  Bool
-controlBool cddl b op (CTreeE (VRuleRef n)) =
-  controlBool cddl b op $ dereference cddl n
-controlBool _ b Eq ctrl =
-  case ctrl of
+  Validator Bool
+controlBool b op (CTreeE (VRuleRef n)) =
+  controlBool b op =<< dereference n
+controlBool b Eq ctrl =
+  pure $ case ctrl of
     Literal (Value (VBool b') _) -> b == b'
     _ -> False
-controlBool _ b Ne ctrl =
-  case ctrl of
+controlBool b Ne ctrl =
+  pure $ case ctrl of
     Literal (Value (VBool b') _) -> b /= b'
     _ -> False
-controlBool _ _ op _ = error $ "Not yet implemented for bool: " <> show op
+controlBool _ op _ = throwError $ InvalidController op
 
 --------------------------------------------------------------------------------
 -- Simple
 
 -- | Validating a `TSimple`. It is unclear if this is used for anything else than `undefined`.
 validateSimple ::
-  CTreeRoot ValidatorPhase ->
   Word8 ->
   CTree ValidatorPhase ->
-  Evidenced ValidationTrace
-validateSimple cddl i (CTreeE (VRuleRef n)) =
-  dereferenceAndValidate cddl n $ validateSimple cddl i
-validateSimple cddl i (CTreeE (VValidator v _)) = runCustomValidator cddl (SingleTerm $ TSimple i) v
-validateSimple cddl 23 rule =
+  Validator (Evidenced ValidationTrace)
+validateSimple i (CTreeE (VRuleRef n)) =
+  dereferenceAndValidate n $ validateSimple i
+validateSimple i (CTreeE (VValidator v _)) = runCustomValidator (SingleTerm $ TSimple i) v
+validateSimple 23 rule =
   case rule of
-    -- a = any
-    Postlude PTAny -> terminal rule
-    -- a = undefined
-    Postlude PTUndefined -> terminal rule
-    -- a = foo / bar
-    Choice opts -> validateChoice (validateSimple cddl 23) opts
-    _ -> unapplicable rule
-validateSimple _ n _ = error $ "Found simple different to 23! please report this somewhere! Found: " <> show n
+    Postlude PTAny -> pure $ terminal rule
+    Postlude PTUndefined -> pure $ terminal rule
+    Choice opts -> validateChoice (validateSimple 23) opts
+    _ -> pure $ unapplicable rule
+validateSimple n _ =
+  error $ "Found simple different to 23! please report this somewhere! Found: " <> show n
 
 --------------------------------------------------------------------------------
 -- Null/nil
 
 -- | Validating nil
-validateNull :: CTreeRoot ValidatorPhase -> CTree ValidatorPhase -> Evidenced ValidationTrace
-validateNull cddl (CTreeE (VRuleRef n)) =
-  dereferenceAndValidate cddl n $ validateNull cddl
-validateNull cddl (CTreeE (VValidator v _)) = runCustomValidator cddl (SingleTerm TNull) v
-validateNull cddl rule =
+validateNull :: CTree ValidatorPhase -> Validator (Evidenced ValidationTrace)
+validateNull (CTreeE (VRuleRef n)) =
+  dereferenceAndValidate n validateNull
+validateNull (CTreeE (VValidator v _)) = runCustomValidator (SingleTerm TNull) v
+validateNull rule =
   case rule of
-    -- a = any
-    Postlude PTAny -> terminal rule
-    -- a = nil
-    Postlude PTNil -> terminal rule
-    Choice opts -> validateChoice (validateNull cddl) opts
-    _ -> unapplicable rule
+    Postlude PTAny -> pure $ terminal rule
+    Postlude PTNil -> pure $ terminal rule
+    Choice opts -> validateChoice validateNull opts
+    _ -> pure $ unapplicable rule
 
 --------------------------------------------------------------------------------
 -- Bytes
 
 -- | Validating a byte sequence
-validateBytes ::
-  CTreeRoot ValidatorPhase -> BS.ByteString -> CTree ValidatorPhase -> Evidenced ValidationTrace
-validateBytes cddl bs (CTreeE (VRuleRef n)) =
-  dereferenceAndValidate cddl n $ validateBytes cddl bs
-validateBytes cddl bs (CTreeE (VValidator v _)) = runCustomValidator cddl (SingleTerm $ TBytes bs) v
-validateBytes cddl bs rule =
+validateBytes :: BS.ByteString -> CTree ValidatorPhase -> Validator (Evidenced ValidationTrace)
+validateBytes bs (CTreeE (VRuleRef n)) =
+  dereferenceAndValidate n $ validateBytes bs
+validateBytes bs (CTreeE (VValidator v _)) = runCustomValidator (SingleTerm $ TBytes bs) v
+validateBytes bs rule =
   case rule of
-    -- a = any
-    Postlude PTAny -> terminal rule
-    -- a = bytes
-    Postlude PTBytes -> terminal rule
-    -- a = h'123456'
-    Literal (Value (VBytes bs') _) | bs == bs' -> terminal rule
-    -- a = foo .ctrl bar
-    Control op tgt ctrl -> ctrlDispatch (validateBytes cddl bs) op tgt ctrl (controlBytes cddl bs)
-    -- a = foo / bar
-    Choice opts -> validateChoice (validateBytes cddl bs) opts
-    _ -> unapplicable rule
+    Postlude PTAny -> pure $ terminal rule
+    Postlude PTBytes -> pure $ terminal rule
+    Literal (Value (VBytes bs') _) | bs == bs' -> pure $ terminal rule
+    Control op tgt ctrl -> ctrlDispatch (validateBytes bs) op tgt ctrl (controlBytes bs)
+    Choice opts -> validateChoice (validateBytes bs) opts
+    _ -> pure $ unapplicable rule
 
 -- | Controls for byte strings
 controlBytes ::
   HasCallStack =>
-  CTreeRoot ValidatorPhase ->
   BS.ByteString ->
   CtlOp ->
   CTree ValidatorPhase ->
-  Bool
-controlBytes cddl bs op (CTreeE (VRuleRef n)) =
-  controlBytes cddl bs op $ dereference cddl n
-controlBytes cddl bs op@Size ctrl =
+  Validator Bool
+controlBytes bs op (CTreeE (VRuleRef n)) =
+  controlBytes bs op =<< dereference n
+controlBytes bs op@Size ctrl =
   case ctrl of
-    Literal (Value (VUInt sz) _) -> fromIntegral (BS.length bs) == sz
-    Range (CTreeE (VRuleRef n)) high bound ->
-      dereference cddl n & \lo -> controlBytes cddl bs op $ Range lo high bound
-    Range low (CTreeE (VRuleRef n)) bound ->
-      dereference cddl n & \hi -> controlBytes cddl bs op $ Range low hi bound
+    Literal (Value (VUInt sz) _) -> pure $ fromIntegral (BS.length bs) == sz
+    Range (CTreeE (VRuleRef n)) high bound -> do
+      lo <- dereference n
+      controlBytes bs op $ Range lo high bound
+    Range low (CTreeE (VRuleRef n)) bound -> do
+      hi <- dereference n
+      controlBytes bs op $ Range low hi bound
     Range low high bound ->
       let i = BS.length bs
-       in case (low, high) of
+       in pure $ case (low, high) of
             (Literal (Value (VUInt (fromIntegral -> n)) _), Literal (Value (VUInt (fromIntegral -> m)) _)) ->
               boundPlacement i (Just n, Just m) bound == WithinBounds
             (Literal (Value (VNInt (fromIntegral -> n)) _), Literal (Value (VUInt (fromIntegral -> m)) _)) ->
@@ -680,17 +629,15 @@ controlBytes cddl bs op@Size ctrl =
             (Literal (Value (VNInt (fromIntegral -> n)) _), Literal (Value (VNInt (fromIntegral -> m)) _)) ->
               boundPlacement i (Just $ -n, Just $ -m) bound == WithinBounds
             _ -> False
-    _ -> False
-controlBytes cddl bs Bits ctrl = do
-  let
-    indices =
-      case ctrl of
-        Literal (Value (VUInt i') _) -> [i']
-        Choice nodes -> getIndicesOfChoice cddl nodes
-        Range ff tt incl -> getIndicesOfRange cddl ff tt incl
-        Enum g -> getIndicesOfEnum cddl g
-        _ -> error "Not yet implemented"
-  bitsControlCheck (map fromIntegral indices)
+    _ -> pure False
+controlBytes bs Bits ctrl = do
+  indices <- case ctrl of
+    Literal (Value (VUInt i') _) -> pure [i']
+    Choice nodes -> getIndicesOfChoice nodes
+    Range ff tt incl -> getIndicesOfRange ff tt incl
+    Enum g -> getIndicesOfEnum g
+    _ -> throwError $ InvalidController Bits
+  pure $ bitsControlCheck (map fromIntegral indices)
   where
     bitsControlCheck :: [Int] -> Bool
     bitsControlCheck allowedBits =
@@ -703,62 +650,58 @@ controlBytes cddl bs Bits ctrl = do
                   Just byte -> not (testBit byte bitIndex) || IS.member n allowedSet
                   Nothing -> True
        in all isAllowedBit [0 .. totalBits - 1]
-controlBytes cddl bs Cbor ctrl =
+controlBytes bs Cbor ctrl =
   case deserialiseFromBytes decodeTerm (BSL.fromStrict bs) of
-    Right (BSL.null -> True, term) -> isValid $ validateTerm cddl term ctrl
-    _ -> False
-controlBytes cddl bs Cborseq ctrl =
+    Right (BSL.null -> True, term) -> isValid <$> validateTerm term ctrl
+    _ -> pure False
+controlBytes bs Cborseq ctrl =
   case deserialiseFromBytes decodeTerm (BSL.fromStrict (BS.snoc (BS.cons 0x9f bs) 0xff)) of
-    Right (BSL.null -> True, TListI terms) -> isValid $ validateTerm cddl (TList terms) (Array [Occur ctrl OIZeroOrMore])
-    _ -> False
-controlBytes _ _ op _ = error $ "Not yet implmented for bytes: " <> show op
+    Right (BSL.null -> True, TListI terms) ->
+      isValid <$> validateTerm (TList terms) (Array [Occur ctrl OIZeroOrMore])
+    _ -> pure False
+controlBytes _ op _ = throwError $ InvalidController op
 
 --------------------------------------------------------------------------------
 -- Text
 
 -- | Validating text strings
 validateText ::
-  CTreeRoot ValidatorPhase ->
   T.Text ->
   CTree ValidatorPhase ->
-  Evidenced ValidationTrace
-validateText cddl txt (CTreeE (VRuleRef n)) =
-  dereferenceAndValidate cddl n $ validateText cddl txt
-validateText cddl txt (CTreeE (VValidator v _)) = runCustomValidator cddl (SingleTerm $ TString txt) v
-validateText cddl txt rule =
+  Validator (Evidenced ValidationTrace)
+validateText txt (CTreeE (VRuleRef n)) =
+  dereferenceAndValidate n $ validateText txt
+validateText txt (CTreeE (VValidator v _)) = runCustomValidator (SingleTerm $ TString txt) v
+validateText txt rule =
   case rule of
-    -- a = any
-    Postlude PTAny -> terminal rule
-    -- a = text
-    Postlude PTText -> terminal rule
-    -- a = "foo"
-    Literal (Value (VText txt') _) | txt == txt' -> terminal rule
-    -- a = foo .ctrl bar
-    Control op tgt ctrl -> ctrlDispatch (validateText cddl txt) op tgt ctrl (controlText cddl txt)
-    -- a = foo / bar
-    Choice opts -> validateChoice (validateText cddl txt) opts
-    _ -> unapplicable rule
+    Postlude PTAny -> pure $ terminal rule
+    Postlude PTText -> pure $ terminal rule
+    Literal (Value (VText txt') _) | txt == txt' -> pure $ terminal rule
+    Control op tgt ctrl -> ctrlDispatch (validateText txt) op tgt ctrl (controlText txt)
+    Choice opts -> validateChoice (validateText txt) opts
+    _ -> pure $ unapplicable rule
 
 -- | Controls for text strings
 controlText ::
   HasCallStack =>
-  CTreeRoot ValidatorPhase ->
   T.Text ->
   CtlOp ->
   CTree ValidatorPhase ->
-  Bool
-controlText cddl bs op (CTreeE (VRuleRef n)) =
-  controlText cddl bs op $ dereference cddl n
-controlText cddl bs op@Size ctrl =
+  Validator Bool
+controlText bs op (CTreeE (VRuleRef n)) =
+  controlText bs op =<< dereference n
+controlText bs op@Size ctrl =
   let bsSize = BS.length $ encodeUtf8 bs
    in case ctrl of
-        Literal (Value (VUInt (fromIntegral -> sz)) _) -> bsSize == sz
-        Range (CTreeE (VRuleRef n)) high bound ->
-          dereference cddl n & \lo -> controlText cddl bs op $ Range lo high bound
-        Range low (CTreeE (VRuleRef n)) bound ->
-          dereference cddl n & \hi -> controlText cddl bs op $ Range low hi bound
+        Literal (Value (VUInt (fromIntegral -> sz)) _) -> pure $ bsSize == sz
+        Range (CTreeE (VRuleRef n)) high bound -> do
+          lo <- dereference n
+          controlText bs op $ Range lo high bound
+        Range low (CTreeE (VRuleRef n)) bound -> do
+          hi <- dereference n
+          controlText bs op $ Range low hi bound
         Range ff tt bound ->
-          case (ff, tt) of
+          pure $ case (ff, tt) of
             (Literal (Value (VUInt (fromIntegral -> n)) _), Literal (Value (VUInt (fromIntegral -> m)) _)) ->
               n <= T.length bs && range bound bsSize m
             (Literal (Value (VNInt (fromIntegral -> n)) _), Literal (Value (VUInt (fromIntegral -> m)) _)) ->
@@ -766,37 +709,36 @@ controlText cddl bs op@Size ctrl =
             (Literal (Value (VNInt (fromIntegral -> n)) _), Literal (Value (VNInt (fromIntegral -> m)) _)) ->
               -n <= T.length bs && range bound bsSize (-m)
             _ -> False
-        _ -> error "Invalid control value in .size"
-controlText _ s Regexp ctrl =
+        _ -> throwError $ InvalidController op
+controlText s Regexp ctrl =
   case ctrl of
     Literal (Value (VText rxp) _) -> case s =~ rxp :: (T.Text, T.Text, T.Text) of
-      ("", s', "") -> s == s'
-      _ -> False
-    _ -> error "Invalid control value in .regexp"
-controlText _ _ op _ = error $ "Not yet implemented for text: " <> show op
+      ("", s', "") -> pure $ s == s'
+      _ -> pure False
+    _ -> throwError $ InvalidController Regexp
+controlText _ op _ = throwError $ UnsupportedControlOperator op
 
 --------------------------------------------------------------------------------
 -- Tagged values
 
 -- | Validating a `TTagged`
 validateTagged ::
-  CTreeRoot ValidatorPhase -> Word64 -> Term -> CTree ValidatorPhase -> Evidenced ValidationTrace
-validateTagged cddl tag term (CTreeE (VRuleRef n)) =
-  dereferenceAndValidate cddl n $ validateTagged cddl tag term
-validateTagged cddl tag term (CTreeE (VValidator v _)) = runCustomValidator cddl (SingleTerm $ TTagged tag term) v
-validateTagged cddl tag term rule =
+  Word64 -> Term -> CTree ValidatorPhase -> Validator (Evidenced ValidationTrace)
+validateTagged tag term (CTreeE (VRuleRef n)) =
+  dereferenceAndValidate n $ validateTagged tag term
+validateTagged tag term (CTreeE (VValidator v _)) = runCustomValidator (SingleTerm $ TTagged tag term) v
+validateTagged tag term rule =
   case rule of
-    Postlude PTAny -> terminal rule
+    Postlude PTAny -> pure $ terminal rule
     Tag tag' rule' ->
-      -- If the tag does not match, this is a direct fail
       if tag == tag'
-        then mapTrace (TagTrace tag) $ validateTerm cddl term rule'
-        else evidence $ InvalidTag tag' tag
-    Choice opts -> validateChoice (validateTagged cddl tag term) opts
-    _ -> unapplicable rule
+        then mapTrace (TagTrace tag) <$> validateTerm term rule'
+        else pure $ evidence $ InvalidTag tag' tag
+    Choice opts -> validateChoice (validateTagged tag term) opts
+    _ -> pure $ unapplicable rule
 
--- --------------------------------------------------------------------------------
--- -- Lists
+--------------------------------------------------------------------------------
+-- Lists
 
 isWithinBoundsInclusive :: Ord a => a -> Maybe a -> Maybe a -> Bool
 isWithinBoundsInclusive x lb ub = maybe True (x >=) lb && maybe True (x <=) ub
@@ -831,62 +773,68 @@ decrementBounds (lb, ub) = OIBounded (clampedPred <$> lb) (clampedPred <$> ub)
     clampedPred x = pred x
 
 validateList ::
-  CTreeRoot ValidatorPhase ->
   [Term] ->
   CTree ValidatorPhase ->
-  Evidenced ValidationTrace
-validateList cddl terms (CTreeE (VRuleRef n)) =
-  dereferenceAndValidate cddl n $ validateList cddl terms
-validateList cddl terms (CTreeE (VValidator v _)) = runCustomValidator cddl (SingleTerm $ TList terms) v
-validateList cddl terms rule =
+  Validator (Evidenced ValidationTrace)
+validateList terms (CTreeE (VRuleRef n)) =
+  dereferenceAndValidate n $ validateList terms
+validateList terms (CTreeE (VValidator v _)) = runCustomValidator (SingleTerm $ TList terms) v
+validateList terms rule =
   case rule of
-    Postlude PTAny -> terminal rule
-    Array rules -> mapTrace ListTrace . fst $ validate finalize [] terms rules
+    Postlude PTAny -> pure $ terminal rule
+    Array rules -> do
+      (ev, _) <- validate finalize [] terms rules
+      pure $ mapTrace ListTrace ev
       where
-        finalize _ [] = evidence ListValidationDone
-        finalize skipped (x : xs) =
-          let leftovers = x :| xs
-              unwrapOccur (Occur ct _) = ct
-              unwrapOccur ct = ct
-              attempts =
-                [ (mapIndex r, trc)
-                | r <- skipped
-                , Evidenced SInvalid trc <- [validateTerm cddl x (unwrapOccur r)]
-                , measureProgress trc > mempty
-                ]
-              bestAttempt = case attempts of
-                [] -> Nothing
-                _ -> Just $ maximumBy (compare `on` (measureProgress . snd)) attempts
-           in evidence $ ListValidationLeftoverTerms leftovers bestAttempt
-    Choice opts -> validateChoice (validateList cddl terms) opts
-    _ -> unapplicable rule
+        finalize _ [] = pure $ evidence ListValidationDone
+        finalize skipped (x : xs) = do
+          let tryRule r = runMaybeT $ do
+                Evidenced SInvalid trc <- lift $ validateTerm x (unwrapOccur r)
+                guard $ measureProgress trc > mempty
+                pure (mapIndex r, trc)
+          bestAttempt <- bestBy (measureProgress . snd) <$> traverse tryRule skipped
+          pure $ evidence $ ListValidationLeftoverTerms (x :| xs) bestAttempt
+    Choice opts -> validateChoice (validateList terms) opts
+    _ -> pure $ unapplicable rule
   where
     validate ::
-      ([CTree ValidatorPhase] -> [Term] -> Evidenced ListValidationTrace) ->
+      ([CTree ValidatorPhase] -> [Term] -> Validator (Evidenced ListValidationTrace)) ->
       [CTree ValidatorPhase] ->
       [Term] ->
       [CTree ValidatorPhase] ->
-      (Evidenced ListValidationTrace, [Term])
-    validate f skipped tss [] = (f skipped tss, tss)
+      Validator (Evidenced ListValidationTrace, [Term])
+    validate f skipped tss [] = do
+      ev <- f skipped tss
+      pure (ev, tss)
     validate f skipped [] (r : rs)
       | isOptional r = validate f skipped [] rs
-      | otherwise = (evidence . ListValidationUnappliedRule $ mapIndex r, [])
+      | otherwise = pure (evidence . ListValidationUnappliedRule $ mapIndex r, [])
     validate f skipped tss@(t : ts) (r : rs) =
-      let
-        consumeTerm ct g = case validateTerm cddl t ct of
-          Evidenced SValid trc -> first (mapTrace $ ListValidationConsume (mapIndex r) trc) $ g ts
-          Evidenced SInvalid trc -> (evidence $ ListValidationMissingRequired (mapIndex ct) trc, tss)
+      validateRule r
+      where
+        consumeTerm ct g = do
+          res <- validateTerm t ct
+          case res of
+            Evidenced SValid trc ->
+              first (mapTrace $ ListValidationConsume (mapIndex r) trc) <$> g ts
+            Evidenced SInvalid trc ->
+              pure (evidence $ ListValidationMissingRequired (mapIndex ct) trc, tss)
 
-        consumeGroup ns gp g = case validate (\_ _ -> evidence ListValidationDone) [] tss gp of
-          (Evidenced SValid trc, leftover) -> first (mapTrace $ ListValidationConsumeGroup (reverse ns) trc) $ g leftover
-          (Evidenced SInvalid trc, leftover) -> (evidence $ ListValidationBadGroup (reverse ns) trc, leftover)
+        consumeGroup ns gp g = do
+          (ev, leftover) <- validate (\_ _ -> pure $ evidence ListValidationDone) [] tss gp
+          case ev of
+            Evidenced SValid trc ->
+              first (mapTrace $ ListValidationConsumeGroup (reverse ns) trc) <$> g leftover
+            Evidenced SInvalid trc ->
+              pure (evidence $ ListValidationBadGroup (reverse ns) trc, leftover)
 
-        consume ct@(CTreeE (VRuleRef n)) g = go n []
+        consume ct@(CTreeE (VRuleRef n)) g = goRef n []
           where
-            go name ns =
-              case dereference cddl name of
+            goRef name ns = do
+              deref <- dereference name
+              case deref of
                 Group gp -> consumeGroup (name : ns) gp g
-                CTreeE (VRuleRef newName) -> go newName (name : ns)
+                CTreeE (VRuleRef newName) -> goRef newName (name : ns)
                 _ -> consumeTerm ct g
         consume (Group gp) g = consumeGroup [] gp g
         consume (KV _ v _) g = consume v g
@@ -897,76 +845,77 @@ validateList cddl terms rule =
         validateRule =
           \case
             Occur ct oi -> case oi of
-              OIOptional -> consume ct continue <> skipRule
-              OIZeroOrMore -> consume ct (rewriteRule r) <> skipRule
+              OIOptional -> liftA2 (<>) (consume ct continue) skipRule
+              OIZeroOrMore -> liftA2 (<>) (consume ct (rewriteRule r)) skipRule
               OIOneOrMore -> consume ct (rewriteRule (Occur ct OIZeroOrMore))
               OIBounded lb ub ->
                 let bounds = (lb, ub)
                  in case boundPlacement 1 bounds Closed of
                       BelowBounds -> consume ct (rewriteRule (Occur ct $ decrementBounds bounds))
-                      WithinBounds -> consume ct (rewriteRule (Occur ct $ decrementBounds bounds)) <> skipRule
+                      WithinBounds ->
+                        liftA2
+                          (<>)
+                          (consume ct (rewriteRule (Occur ct $ decrementBounds bounds)))
+                          skipRule
                       AboveBounds
                         | boundPlacement 0 (lb, ub) Closed == WithinBounds -> skipRule
-                        | otherwise -> error "Negative upper bound"
+                        | otherwise -> throwError InvalidRangeBounds
             _ -> consume r continue
-       in
-        validateRule r
 
 --------------------------------------------------------------------------------
 -- Maps
 
 validateMap ::
   HasCallStack =>
-  CTreeRoot ValidatorPhase ->
   [(Term, Term)] ->
   CTree ValidatorPhase ->
-  Evidenced ValidationTrace
-validateMap cddl terms (CTreeE (VRuleRef n)) =
-  dereferenceAndValidate cddl n $ validateMap cddl terms
-validateMap cddl terms (CTreeE (VValidator v _)) = runCustomValidator cddl (SingleTerm $ TMap terms) v
-validateMap cddl terms rule =
+  Validator (Evidenced ValidationTrace)
+validateMap terms (CTreeE (VRuleRef n)) =
+  dereferenceAndValidate n $ validateMap terms
+validateMap terms (CTreeE (VValidator v _)) = runCustomValidator (SingleTerm $ TMap terms) v
+validateMap terms rule =
   case rule of
-    Postlude PTAny -> terminal rule
-    Map rules -> mapTrace MapTrace $ validate [] terms rules
-    Choice opts -> validateChoice (validateMap cddl terms) opts
-    _ -> unapplicable rule
+    Postlude PTAny -> pure $ terminal rule
+    Map rules -> mapTrace MapTrace <$> validate [] terms rules
+    Choice opts -> validateChoice (validateMap terms) opts
+    _ -> pure $ unapplicable rule
   where
     validate ::
-      [CTree ValidatorPhase] -> [(Term, Term)] -> [CTree ValidatorPhase] -> Evidenced MapValidationTrace
-    validate _ [] [] = evidence MapValidationDone
-    validate exhausted (kv : _) [] =
+      [CTree ValidatorPhase] ->
+      [(Term, Term)] ->
+      [CTree ValidatorPhase] ->
+      Validator (Evidenced MapValidationTrace)
+    validate _ [] [] = pure $ evidence MapValidationDone
+    validate exhausted (kv : _) [] = do
+      let tryRule r = runMaybeT $ do
+            KV k v _ <- pure $ unwrapOccur r
+            Evidenced SValid kTrc <- lift $ validateTerm (fst kv) k
+            Evidenced SInvalid vTrc <- lift $ validateTerm (snd kv) v
+            let trc = MapValidationInvalidValue (mapIndex r) kTrc vTrc
+            guard $ measureProgress trc > mempty
+            pure (mapIndex r, trc)
+      bestAttempt <- bestBy (measureProgress . snd) <$> traverse tryRule exhausted
+      pure $ evidence $ MapValidationLeftoverKVs kv bestAttempt
+    validate exhausted [] rs =
+      case NE.nonEmpty $ filter (not . isOptional) (exhausted <> rs) of
+        Nothing -> pure $ evidence MapValidationDone
+        Just requiredRules ->
+          pure $ evidence $ MapValidationUnappliedRules (mapIndex <$> requiredRules)
+    validate exhausted kvs@((tk, tv) : leftover) (r : rs) =
       let
-        unwrapOccur (Occur ct _) = ct
-        unwrapOccur ct = ct
-        attempts =
-          [ (mapIndex r, MapValidationInvalidValue (mapIndex r) kTrc vTrc)
-          | r <- exhausted
-          , KV k v _ <- [unwrapOccur r]
-          , Evidenced SValid kTrc <- [validateTerm cddl (fst kv) k]
-          , Evidenced SInvalid vTrc <- [validateTerm cddl (snd kv) v]
-          , measureProgress (MapValidationInvalidValue (mapIndex r) kTrc vTrc) > mempty
-          ]
-        bestAttempt = case attempts of
-          [] -> Nothing
-          _ -> Just $ maximumBy (compare `on` (measureProgress . snd)) attempts
-       in
-        evidence $ MapValidationLeftoverKVs kv bestAttempt
-    validate [] [] rs =
-      case NE.nonEmpty $ filter (not . isOptional) rs of
-        Nothing -> evidence MapValidationDone
-        Just requiredRules -> evidence $ MapValidationUnappliedRules (mapIndex <$> requiredRules)
-    validate exhausted kvs (r : rs) =
-      let
-        consume (KV k v _) f = case kvs of
-          ((tk, tv) : leftover) ->
-            case validateTerm cddl tk k of
-              Evidenced SValid kTrc ->
-                case validateTerm cddl tv v of
-                  Evidenced SValid vTrc -> mapTrace (MapValidationConsume (mapIndex r) kTrc vTrc) $ f leftover
-                  Evidenced SInvalid vTrc -> evidence $ MapValidationInvalidValue (mapIndex r) kTrc vTrc
-              Evidenced SInvalid _ -> evidence $ MapValidationUnappliedRules (NE.singleton $ mapIndex r)
-          [] -> error "No remaining KV pairs"
-        consume x _ = error $ "Unexpected value in map: " <> showSimple x
+        consume (KV k v _) f = do
+          kRes <- validateTerm tk k
+          case kRes of
+            Evidenced SValid kTrc -> do
+              vRes <- validateTerm tv v
+              case vRes of
+                Evidenced SValid vTrc ->
+                  mapTrace (MapValidationConsume (mapIndex r) kTrc vTrc) <$> f leftover
+                Evidenced SInvalid vTrc ->
+                  pure $ evidence $ MapValidationInvalidValue (mapIndex r) kTrc vTrc
+            Evidenced SInvalid _ ->
+              pure $ evidence $ MapValidationUnappliedRules (NE.singleton $ mapIndex r)
+        consume _ _ = throwError InvalidMapElement
         postponeRule l = validate (r : exhausted) l rs
         dropRule l = validate exhausted l rs
         resetDropRule l = validate [] l (exhausted <> rs)
@@ -976,133 +925,136 @@ validateMap cddl terms rule =
           Occur ct oi ->
             case oi of
               OIOptional ->
-                consume ct resetDropRule <> postponeRule kvs
+                liftA2 (<>) (consume ct resetDropRule) (postponeRule kvs)
               OIZeroOrMore ->
-                consume ct (rewriteRule r) <> postponeRule kvs
+                liftA2 (<>) (consume ct (rewriteRule r)) (postponeRule kvs)
               OIOneOrMore ->
-                consume ct (rewriteRule (Occur ct OIZeroOrMore)) <> postponeRule kvs
+                liftA2 (<>) (consume ct (rewriteRule (Occur ct OIZeroOrMore))) (postponeRule kvs)
               OIBounded mlb mub
-                | Just lb <- mlb, Just ub <- mub, lb > ub -> error "Unsatisfiable range encountered"
+                | Just lb <- mlb, Just ub <- mub, lb > ub -> throwError InvalidRangeBounds
                 | otherwise -> case compare 0 <$> mub of
                     Just EQ -> dropRule kvs
-                    Just GT -> error "Unsatisfiable range encountered"
+                    Just GT -> throwError InvalidRangeBounds
                     _ ->
-                      consume ct (rewriteRule (Occur ct $ decrementBounds (mlb, mub)))
-                        <> postponeRule kvs
-          _ -> consume r resetDropRule <> postponeRule kvs
+                      liftA2
+                        (<>)
+                        (consume ct (rewriteRule (Occur ct $ decrementBounds (mlb, mub))))
+                        (postponeRule kvs)
+          _ -> liftA2 (<>) (consume r resetDropRule) (postponeRule kvs)
 
 --------------------------------------------------------------------------------
 -- Choices
 
 validateChoice ::
-  (CTree ValidatorPhase -> Evidenced ValidationTrace) ->
+  (CTree ValidatorPhase -> Validator (Evidenced ValidationTrace)) ->
   NE.NonEmpty (CTree ValidatorPhase) ->
-  Evidenced ValidationTrace
+  Validator (Evidenced ValidationTrace)
 validateChoice v = go 0
   where
-    go :: Int -> NE.NonEmpty (CTree ValidatorPhase) -> Evidenced ValidationTrace
+    go :: Int -> NE.NonEmpty (CTree ValidatorPhase) -> Validator (Evidenced ValidationTrace)
     go i (choice NE.:| xs) = do
-      case v choice of
-        Evidenced SValid trc -> evidence $ ChoiceBranch i trc
+      res <- v choice
+      case res of
+        Evidenced SValid trc -> pure . evidence $ ChoiceBranch i trc
         err -> case xs of
-          [] -> err
-          y : ys -> err <> go (succ i) (y NE.:| ys)
+          [] -> pure err
+          y : ys -> do
+            rest <- go (succ i) (y NE.:| ys)
+            pure $ err <> rest
 
 --------------------------------------------------------------------------------
 -- Control helpers
 
 -- | Validate both rules
 ctrlAnd ::
-  (CTree ValidatorPhase -> Evidenced ValidationTrace) ->
+  (CTree ValidatorPhase -> Validator (Evidenced ValidationTrace)) ->
   CTree ValidatorPhase ->
   CTree ValidatorPhase ->
-  Evidenced ValidationTrace
-ctrlAnd v tgt ctrl =
-  case v tgt of
+  Validator (Evidenced ValidationTrace)
+ctrlAnd v tgt ctrl = do
+  res <- v tgt
+  case res of
     (isValid -> True) -> v ctrl
-    err -> err
+    err -> pure err
 
 -- | Dispatch to the appropriate control
 ctrlDispatch ::
-  (CTree ValidatorPhase -> Evidenced ValidationTrace) ->
+  (CTree ValidatorPhase -> Validator (Evidenced ValidationTrace)) ->
   CtlOp ->
   CTree ValidatorPhase ->
   CTree ValidatorPhase ->
-  (CtlOp -> CTree ValidatorPhase -> Bool) ->
-  Evidenced ValidationTrace
+  (CtlOp -> CTree ValidatorPhase -> Validator Bool) ->
+  Validator (Evidenced ValidationTrace)
 ctrlDispatch v And tgt ctrl _ = ctrlAnd v tgt ctrl
 ctrlDispatch v Within tgt ctrl _ = ctrlAnd v tgt ctrl
-ctrlDispatch v op tgt ctrl vctrl =
-  case v tgt of
+ctrlDispatch v op tgt ctrl vctrl = do
+  lhs <- v tgt
+  rhs <- vctrl op ctrl
+  pure $ case lhs of
     Evidenced SValid trc
-      | vctrl op ctrl ->
-          evidence $ ControlTrace (ControlInfo op (mapIndex ctrl)) trc
-      | otherwise ->
-          evidence $ UnsatisfiedControl op (mapIndex ctrl)
+      | rhs -> evidence $ ControlTrace (ControlInfo op (mapIndex ctrl)) trc
+      | otherwise -> evidence $ UnsatisfiedControl op (mapIndex ctrl)
     err -> err
 
 --------------------------------------------------------------------------------
 -- Bits control
 
-getIndicesOfChoice :: CTreeRoot ValidatorPhase -> NE.NonEmpty (CTree ValidatorPhase) -> [Word64]
-getIndicesOfChoice cddl = concatMap go
+getIndicesOfChoice :: NE.NonEmpty (CTree ValidatorPhase) -> Validator [Word64]
+getIndicesOfChoice = fmap concat . traverse go
   where
+    go :: CTree ValidatorPhase -> Validator [Word64]
     go = \case
-      Literal (Value (VUInt v) _) -> [fromIntegral v]
+      Literal (Value (VUInt v) _) -> pure [fromIntegral v]
       KV _ v _ ->
         case v of
-          CTreeE (VRuleRef n) -> go $ dereference cddl n
-          Literal (Value (VUInt v') _) -> [fromIntegral v']
-          somethingElse ->
-            error $
-              "Malformed value in KV in choice in .bits: "
-                <> showSimple somethingElse
-      Range ff tt incl -> getIndicesOfRange cddl ff tt incl
-      Enum g -> getIndicesOfEnum cddl g
-      somethingElse ->
-        error $
-          "Malformed alternative in choice in .bits: "
-            <> showSimple somethingElse
+          CTreeE (VRuleRef n) -> go =<< dereference n
+          Literal (Value (VUInt v') _) -> pure [fromIntegral v']
+          _ -> throwError $ InvalidController Bits
+      Range ff tt incl -> getIndicesOfRange ff tt incl
+      Enum g -> getIndicesOfEnum g
+      _ -> throwError $ InvalidController Bits
 
 getIndicesOfRange ::
-  CTreeRoot ValidatorPhase -> CTree ValidatorPhase -> CTree ValidatorPhase -> RangeBound -> [Word64]
-getIndicesOfRange cddl (CTreeE (VRuleRef n)) tt incl =
-  dereference cddl n & \ff -> getIndicesOfRange cddl ff tt incl
-getIndicesOfRange cddl ff (CTreeE (VRuleRef n)) incl =
-  dereference cddl n & \tt -> getIndicesOfRange cddl ff tt incl
-getIndicesOfRange _ ff tt incl =
+  CTree ValidatorPhase -> CTree ValidatorPhase -> RangeBound -> Validator [Word64]
+getIndicesOfRange (CTreeE (VRuleRef n)) tt incl = do
+  ff <- dereference n
+  getIndicesOfRange ff tt incl
+getIndicesOfRange ff (CTreeE (VRuleRef n)) incl = do
+  tt <- dereference n
+  getIndicesOfRange ff tt incl
+getIndicesOfRange ff tt incl =
   case (ff, tt) of
     (Literal (Value (VUInt ff') _), Literal (Value (VUInt tt') _)) ->
-      case incl of
+      pure $ case incl of
         ClOpen -> init rng
         Closed -> rng
       where
         rng = [ff' .. tt']
-    (lo, hi) -> error $ "Malformed range in .bits: (" <> showSimple lo <> ", " <> showSimple hi <> ")"
+    _ -> throwError $ InvalidController Bits
 
-getIndicesOfEnum :: CTreeRoot ValidatorPhase -> CTree ValidatorPhase -> [Word64]
-getIndicesOfEnum cddl (CTreeE (VRuleRef n)) = getIndicesOfEnum cddl $ dereference cddl n
-getIndicesOfEnum cddl g =
+getIndicesOfEnum :: CTree ValidatorPhase -> Validator [Word64]
+getIndicesOfEnum (CTreeE (VRuleRef n)) = getIndicesOfEnum =<< dereference n
+getIndicesOfEnum g =
   case g of
-    Group g' -> getIndicesOfChoice cddl (fromJust $ NE.nonEmpty g')
-    somethingElse -> error $ "Malformed enum in .bits: " <> showSimple somethingElse
+    Group g' -> getIndicesOfChoice (fromJust $ NE.nonEmpty g')
+    _ -> throwError $ InvalidController Bits
 
 dereference ::
-  CTreeRoot ValidatorPhase ->
   Name ->
-  CTree ValidatorPhase
-dereference (CTreeRoot m) n =
-  case Map.lookup n m of
-    Just r -> r
-    Nothing -> error $ "Nonexistent rule referenced: " <> T.unpack (unName n)
+  Validator (CTree ValidatorPhase)
+dereference n = do
+  res <- lookupCddl n
+  case res of
+    Just r -> pure r
+    Nothing -> throwError $ InvalidReference n
 
 dereferenceAndValidate ::
-  CTreeRoot ValidatorPhase ->
   Name ->
-  (CTree ValidatorPhase -> Evidenced ValidationTrace) ->
-  Evidenced ValidationTrace
-dereferenceAndValidate cddl n f =
-  mapTrace (ReferenceRule n) . f $ dereference cddl n
+  (CTree ValidatorPhase -> Validator (Evidenced ValidationTrace)) ->
+  Validator (Evidenced ValidationTrace)
+dereferenceAndValidate n f = do
+  res <- dereference n
+  mapTrace (ReferenceRule n) <$> f res
 
 --------------------------------------------------------------------------------
 -- Utils
@@ -1110,3 +1062,12 @@ dereferenceAndValidate cddl n f =
 range :: Ord a => RangeBound -> a -> a -> Bool
 range Closed = (<=)
 range ClOpen = (<)
+
+-- | Strip a single layer of 'Occur' wrapping, if any.
+unwrapOccur :: CTree i -> CTree i
+unwrapOccur (Occur ct _) = ct
+unwrapOccur ct = ct
+
+-- | Pick the entry with the largest measure, or 'Nothing' if the input is empty.
+bestBy :: Ord b => (a -> b) -> [Maybe a] -> Maybe a
+bestBy measure = fmap (maximumBy (compare `on` measure)) . NE.nonEmpty . catMaybes

--- a/src/Codec/CBOR/Cuddle/CBOR/Validator.hs
+++ b/src/Codec/CBOR/Cuddle/CBOR/Validator.hs
@@ -8,6 +8,8 @@ module Codec.CBOR.Cuddle.CBOR.Validator (
   validateFromName,
   validateFromGRef,
   ValidatorPhase,
+  ValidatorInputError (..),
+  displayValidatorInputError,
 ) where
 
 import Codec.CBOR.Cuddle.CBOR.Validator.Trace (
@@ -37,7 +39,7 @@ import Codec.CBOR.Cuddle.CDDL.Custom.Validator (
  )
 import Codec.CBOR.Cuddle.CDDL.Resolve (showSimple)
 import Codec.CBOR.Cuddle.IndexMappable (IndexMappable (..))
-import Codec.CBOR.Read
+import Codec.CBOR.Read (DeserialiseFailure, deserialiseFromBytes)
 import Codec.CBOR.Term
 import Control.Monad.Reader (asks)
 import Data.Bifunctor (Bifunctor (..))
@@ -62,18 +64,38 @@ import Text.Regex.TDFA
 --------------------------------------------------------------------------------
 -- Main entry point
 
+-- | Errors that prevent validation from running at all: the input could not be
+-- decoded as CBOR, decoded successfully but had trailing garbage, or the
+-- caller asked us to validate against a top-level rule name not defined in the
+-- CDDL. These are distinct from schema-level mismatches, which are reported
+-- through 'Evidenced' 'ValidationTrace'.
+data ValidatorInputError
+  = CBORDecodeFailure DeserialiseFailure
+  | LeftoverBytesAfterTerm BS.ByteString
+  | UnknownTopLevelRule Name
+  deriving (Show)
+
+-- | Human-readable rendering of a 'ValidatorInputError'.
+displayValidatorInputError :: ValidatorInputError -> String
+displayValidatorInputError = \case
+  CBORDecodeFailure e -> "Could not decode input as CBOR: " <> show e
+  LeftoverBytesAfterTerm rest -> "Leftover bytes after CBOR term: " <> show rest
+  UnknownTopLevelRule (Name n) -> "No such top-level rule in the CDDL: " <> T.unpack n
+
 validateCBOR ::
-  HasCallStack =>
   BS.ByteString ->
   Name ->
   CTreeRoot ValidatorPhase ->
-  Evidenced ValidationTrace
+  Either ValidatorInputError (Evidenced ValidationTrace)
 validateCBOR bs rule cddl@(CTreeRoot tree) =
   case deserialiseFromBytes decodeTerm (BSL.fromStrict bs) of
-    Left e -> error $ show e
-    Right (rest, term)
-      | BSL.null rest -> validateTerm cddl term (tree Map.! rule)
-      | otherwise -> error $ "Leftover bytes in CBOR: " <> show rest
+    Left e -> Left $ CBORDecodeFailure e
+    Right (rest, _)
+      | not (BSL.null rest) -> Left . LeftoverBytesAfterTerm $ BSL.toStrict rest
+    Right (_, term) ->
+      case Map.lookup rule tree of
+        Nothing -> Left $ UnknownTopLevelRule rule
+        Just r -> Right $ validateTerm cddl term r
 
 -- | Validate a CBOR 'Term' against a top-level rule from inside a custom
 -- validator.

--- a/src/Codec/CBOR/Cuddle/CBOR/Validator.hs
+++ b/src/Codec/CBOR/Cuddle/CBOR/Validator.hs
@@ -560,14 +560,12 @@ validateSimple ::
 validateSimple i (CTreeE (VRuleRef n)) =
   dereferenceAndValidate n $ validateSimple i
 validateSimple i (CTreeE (VValidator v _)) = runCustomValidator (SingleTerm $ TSimple i) v
-validateSimple 23 rule =
+validateSimple n rule =
   case rule of
     Postlude PTAny -> pure $ terminal rule
-    Postlude PTUndefined -> pure $ terminal rule
-    Choice opts -> validateChoice (validateSimple 23) opts
+    Postlude PTUndefined | n == 23 -> pure $ terminal rule
+    Choice opts -> validateChoice (validateSimple n) opts
     _ -> pure $ unapplicable rule
-validateSimple n _ =
-  error $ "Found simple different to 23! please report this somewhere! Found: " <> show n
 
 --------------------------------------------------------------------------------
 -- Null/nil

--- a/src/Codec/CBOR/Cuddle/CDDL/Custom/Validator.hs
+++ b/src/Codec/CBOR/Cuddle/CDDL/Custom/Validator.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE TypeData #-}
 {-# LANGUAGE TypeFamilies #-}
 
@@ -5,18 +6,23 @@ module Codec.CBOR.Cuddle.CDDL.Custom.Validator (
   TermValidator,
   ValidatorPhase,
   Validator,
+  ValidatorError (..),
+  displayValidatorError,
   CustomValidatorResult (..),
   XXCTree (..),
   HasValidator (..),
   ValidateEnv (..),
   withLocalValidateBindings,
   runValidator,
+  runValidatorM,
 ) where
 
 import Codec.CBOR.Cuddle.CDDL (GRef (..), Name (..))
 import Codec.CBOR.Cuddle.CDDL.CTree (CTree, CTreeRoot (..))
+import Codec.CBOR.Cuddle.CDDL.CtlOp (CtlOp)
 import Codec.CBOR.Cuddle.CDDL.Custom.Core (MonadCddl (..), RuleTerm)
 import Codec.CBOR.Cuddle.CDDL.Custom.Generator (XXCTree)
+import Control.Monad.Error.Class (MonadError (..))
 import Control.Monad.Reader (MonadReader (..), ReaderT (..), asks)
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
@@ -34,6 +40,34 @@ data instance XXCTree ValidatorPhase
 class HasValidator a where
   validatorL :: Lens' a (Maybe TermValidator)
 
+-- | Errors that signal a malformed CDDL or an unsupported construct
+-- encountered while validating. Distinct from validation traces, which
+-- report ordinary schema mismatches.
+data ValidatorError
+  = InvalidType
+  | UnsupportedControlOperator CtlOp
+  | InvalidController CtlOp
+  | IncompatibleRangeTypes
+  | InvalidRangeBounds
+  | InvalidMapElement
+  | InvalidReference Name
+  | InvalidGenericReference GRef
+  | -- | Generic failure raised from 'MonadFail'
+    CustomFailure Text
+  deriving (Show)
+
+displayValidatorError :: ValidatorError -> String
+displayValidatorError = \case
+  InvalidType -> "Invalid type"
+  UnsupportedControlOperator op -> "Unsupported control operator: " <> show op
+  InvalidController op -> "Invalid controller for operator: " <> show op
+  IncompatibleRangeTypes -> "Incompatible range endpoint types"
+  InvalidRangeBounds -> "Invalid range bounds"
+  InvalidMapElement -> "Invalid map element"
+  InvalidGenericReference (GRef n) -> "Unbound local reference: " <> T.unpack n
+  InvalidReference (Name n) -> "Unbound name: " <> T.unpack n
+  CustomFailure msg -> T.unpack msg
+
 data CustomValidatorResult
   = CustomValidatorSuccess
   | CustomValidatorFailure Text
@@ -44,8 +78,8 @@ data ValidateEnv = ValidateEnv
   , veLocal :: Map Name (CTree ValidatorPhase)
   }
 
-newtype Validator a = Validator (ReaderT ValidateEnv (Either Text) a)
-  deriving (Functor, Applicative, Monad, MonadReader ValidateEnv)
+newtype Validator a = Validator (ReaderT ValidateEnv (Either ValidatorError) a)
+  deriving (Functor, Applicative, Monad, MonadReader ValidateEnv, MonadError ValidatorError)
 
 type TermValidator = RuleTerm -> Validator ()
 
@@ -61,7 +95,7 @@ instance MonadCddl Validator where
     pure $ Map.lookup (Name t) binds
 
 instance MonadFail Validator where
-  fail msg = Validator . ReaderT $ \_ -> Left $ T.pack msg
+  fail = throwError . CustomFailure . T.pack
 
 -- | Run an action with the given local generic bindings installed.
 withLocalValidateBindings ::
@@ -70,7 +104,13 @@ withLocalValidateBindings binds =
   local (\env -> env {veLocal = binds `Map.union` veLocal env})
 
 runValidator ::
-  Validator () -> CTreeRoot ValidatorPhase -> CustomValidatorResult
-runValidator (Validator m) cddl =
-  either CustomValidatorFailure (const CustomValidatorSuccess) $
-    runReaderT m ValidateEnv {veRoot = cddl, veLocal = Map.empty}
+  Validator a -> CTreeRoot ValidatorPhase -> CustomValidatorResult
+runValidator v cddl =
+  case runValidatorM v cddl of
+    Right _ -> CustomValidatorSuccess
+    Left err -> CustomValidatorFailure . T.pack $ displayValidatorError err
+
+runValidatorM ::
+  Validator a -> CTreeRoot ValidatorPhase -> Either ValidatorError a
+runValidatorM (Validator m) cddl =
+  runReaderT m ValidateEnv {veRoot = cddl, veLocal = Map.empty}

--- a/test/Test/Codec/CBOR/Cuddle/CDDL/Validator.hs
+++ b/test/Test/Codec/CBOR/Cuddle/CDDL/Validator.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE OverloadedStrings #-}
 
@@ -12,6 +13,8 @@ module Test.Codec.CBOR.Cuddle.CDDL.Validator (
 
 import Codec.CBOR.Cuddle.CBOR.Gen (generateFromName)
 import Codec.CBOR.Cuddle.CBOR.Validator (
+  ValidatorInputError,
+  displayValidatorInputError,
   validateCBOR,
  )
 import Codec.CBOR.Cuddle.CBOR.Validator.Trace (
@@ -260,7 +263,7 @@ validateHuddle ::
   Huddle ->
   Name ->
   Term ->
-  Evidenced ValidationTrace
+  Either ValidatorInputError (Evidenced ValidationTrace)
 validateHuddle huddle name term = do
   let
     resolvedCddl = case fullResolveCDDL . mapCDDLDropExt $ toCDDL huddle of
@@ -269,19 +272,32 @@ validateHuddle huddle name term = do
     bs = toStrictByteString $ encodeTerm term
   validateCBOR bs name (mapIndex resolvedCddl)
 
-expectValid :: Evidenced ValidationTrace -> Expectation
-expectValid (Evidenced SValid _) = pure ()
-expectValid (Evidenced SInvalid t) =
-  expectationFailure . T.unpack $
-    "Expected a success, got failure:\n"
-      <> renderStrict (layoutPretty defaultLayoutOptions $ prettyValidationTrace defaultTraceOptions t)
+-- | Unwrap a 'validateCBOR' result, failing the test if the input could not
+-- even be decoded or referenced an unknown rule.
+unwrapValidatorInput ::
+  Either ValidatorInputError (Evidenced ValidationTrace) ->
+  IO (Evidenced ValidationTrace)
+unwrapValidatorInput (Right ev) = pure ev
+unwrapValidatorInput (Left err) =
+  expectationFailure (displayValidatorInputError err) >> error "unreachable"
 
-expectInvalid :: Evidenced ValidationTrace -> Expectation
-expectInvalid (Evidenced SValid t) =
-  expectationFailure . T.unpack $
-    "Expected a failure, but got success:\n"
-      <> renderStrict (layoutPretty defaultLayoutOptions $ prettyValidationTrace defaultTraceOptions t)
-expectInvalid _ = pure ()
+expectValid :: Either ValidatorInputError (Evidenced ValidationTrace) -> Expectation
+expectValid r =
+  unwrapValidatorInput r >>= \case
+    Evidenced SValid _ -> pure ()
+    Evidenced SInvalid t ->
+      expectationFailure . T.unpack $
+        "Expected a success, got failure:\n"
+          <> renderStrict (layoutPretty defaultLayoutOptions $ prettyValidationTrace defaultTraceOptions t)
+
+expectInvalid :: Either ValidatorInputError (Evidenced ValidationTrace) -> Expectation
+expectInvalid r =
+  unwrapValidatorInput r >>= \case
+    Evidenced SValid t ->
+      expectationFailure . T.unpack $
+        "Expected a failure, but got success:\n"
+          <> renderStrict (layoutPretty defaultLayoutOptions $ prettyValidationTrace defaultTraceOptions t)
+    Evidenced SInvalid _ -> pure ()
 
 stringValidator :: TermValidator
 stringValidator (SingleTerm (TString _)) = pure ()

--- a/test/Test/Codec/CBOR/Cuddle/CDDL/Validator/Golden.hs
+++ b/test/Test/Codec/CBOR/Cuddle/CDDL/Validator/Golden.hs
@@ -3,7 +3,7 @@
 
 module Test.Codec.CBOR.Cuddle.CDDL.Validator.Golden (spec) where
 
-import Codec.CBOR.Cuddle.CBOR.Validator (validateCBOR)
+import Codec.CBOR.Cuddle.CBOR.Validator (displayValidatorInputError, validateCBOR)
 import Codec.CBOR.Cuddle.CBOR.Validator.Trace (
   defaultTraceOptions,
   foldEvidenced,
@@ -111,12 +111,13 @@ validatorPrettyGolden testName huddle n term =
     treeRoot =
       fromRight (error "Failed to resolve CDDL") . fullResolveCDDL . mapCDDLDropExt $
         toCDDL huddle
-    str =
-      Ansi.renderStrict
-        . layoutPretty defaultLayoutOptions
-        . foldEvidenced (prettyValidationTrace defaultTraceOptions)
-        . validateCBOR bs n
-        $ mapIndex treeRoot
+    str = case validateCBOR bs n (mapIndex treeRoot) of
+      Left err -> T.pack $ displayValidatorInputError err
+      Right ev ->
+        Ansi.renderStrict
+          . layoutPretty defaultLayoutOptions
+          . foldEvidenced (prettyValidationTrace defaultTraceOptions)
+          $ ev
 
 spec :: Spec
 spec = describe "golden" $ do


### PR DESCRIPTION
This PR refactors the Validator module to use the `Validator` monad. This lets us get rid of all the `cddl` passing and `error` calls in the code.