### PR TITLE
Unify simple phases into `MonoSimplePhase`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.8.0.0
 
+* Rename `MonoSimple` to `MonoSimplePhase`
+* Remove `GenSimple` and `ValidatorPhaseSimple`; use `MonoSimplePhase` instead
 * Export `IsChoosable (toChoice)`
 * Add `choiceFromList` to fold a `NonEmpty` list into a `Choice` using `(/)`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Rename `MonoSimple` to `MonoSimplePhase`
 * Remove `GenSimple` and `ValidatorPhaseSimple`; use `MonoSimplePhase` instead
+* Unify `showSimple` into a single polymorphic helper in `Codec.CBOR.Cuddle.CDDL.Resolve`
 * Export `IsChoosable (toChoice)`
 * Add `choiceFromList` to fold a `NonEmpty` list into a `Choice` using `(/)`
 

--- a/example/Main.hs
+++ b/example/Main.hs
@@ -8,7 +8,7 @@ module Main (main) where
 import Codec.CBOR.Cuddle.CBOR.Gen (generateFromName)
 import Codec.CBOR.Cuddle.CDDL (Name (..))
 import Codec.CBOR.Cuddle.CDDL.Custom.Generator (GenConfig (..), runCBORGen)
-import Codec.CBOR.Cuddle.CDDL.Resolve (MonoSimple, fullResolveCDDL)
+import Codec.CBOR.Cuddle.CDDL.Resolve (MonoSimplePhase, fullResolveCDDL)
 import Codec.CBOR.Cuddle.Huddle (toCDDL)
 import Codec.CBOR.Cuddle.IndexMappable (IndexMappable (..), mapCDDLDropExt)
 import Codec.CBOR.Cuddle.Parser (pCDDL)
@@ -38,7 +38,7 @@ main = do
           putStrLn "--------------------------------------------------------------------------------"
           case fullResolveCDDL (mapCDDLDropExt res) of
             Left nre -> putStrLn $ "Resolution error: " <> show nre
-            Right resolved -> print (mapIndex @_ @_ @MonoSimple resolved)
+            Right resolved -> print (mapIndex @_ @_ @MonoSimplePhase resolved)
     [fn, name] -> do
       putStrLn "--------------------------------------------------------------------------------"
       putStrLn " Generating a term"

--- a/src/Codec/CBOR/Cuddle/CBOR/Gen.hs
+++ b/src/Codec/CBOR/Cuddle/CBOR/Gen.hs
@@ -49,8 +49,7 @@ import Codec.CBOR.Cuddle.CDDL.Custom.Generator (
   liftAntiGen,
   withAntiGen,
  )
-import Codec.CBOR.Cuddle.CDDL.Resolve (MonoSimplePhase, XXCTree (..))
-import Codec.CBOR.Cuddle.IndexMappable (IndexMappable (..))
+import Codec.CBOR.Cuddle.CDDL.Resolve (XXCTree (..), showSimple)
 import Codec.CBOR.Term (Term (..))
 import Codec.CBOR.Term qualified as CBOR
 import Codec.CBOR.Write qualified as CBOR
@@ -281,9 +280,6 @@ singleTermList [] = Just []
 singleTermList (SingleTerm x : xs) = (x :) <$> singleTermList xs
 singleTermList (PairTerm _ y : xs) = (y :) <$> singleTermList xs
 singleTermList _ = Nothing
-
-showSimple :: CTree GenPhase -> String
-showSimple = show . mapIndex @_ @_ @MonoSimplePhase
 
 -- | Remove all negative generators from the `AntiGen`.
 dropNegativeGen :: AntiGen a -> AntiGen a

--- a/src/Codec/CBOR/Cuddle/CBOR/Gen.hs
+++ b/src/Codec/CBOR/Cuddle/CBOR/Gen.hs
@@ -18,7 +18,6 @@ module Codec.CBOR.Cuddle.CBOR.Gen (
   generateFromName,
   generateFromGRef,
   GenPhase,
-  GenSimple,
   XXCTree (..),
 ) where
 
@@ -35,7 +34,6 @@ import Codec.CBOR.Cuddle.CDDL (
 import Codec.CBOR.Cuddle.CDDL.CTree (
   CTree (..),
   PTerm (..),
-  foldCTree,
   nintMin,
   uintMax,
  )
@@ -51,7 +49,7 @@ import Codec.CBOR.Cuddle.CDDL.Custom.Generator (
   liftAntiGen,
   withAntiGen,
  )
-import Codec.CBOR.Cuddle.CDDL.Resolve (XXCTree (..))
+import Codec.CBOR.Cuddle.CDDL.Resolve (MonoSimplePhase, XXCTree (..))
 import Codec.CBOR.Cuddle.IndexMappable (IndexMappable (..))
 import Codec.CBOR.Term (Term (..))
 import Codec.CBOR.Term qualified as CBOR
@@ -121,21 +119,6 @@ arbitrary = liftGen QC.arbitrary
 
 scale :: MonadGen m => (Int -> Int) -> m a -> m a
 scale f m = sized $ \n -> resize (f n) m
-
---------------------------------------------------------------------------------
--- MonoSimple
---------------------------------------------------------------------------------
-
-type data GenSimple
-
-newtype instance XXCTree GenSimple = GenSimpleRef Name
-  deriving (Show)
-
-instance IndexMappable CTree GenPhase GenSimple where
-  mapIndex = foldCTree mapExt mapIndex
-    where
-      mapExt (GenRef n) = CTreeE $ GenSimpleRef n
-      mapExt (GenGenerator _ x) = mapIndex x
 
 --------------------------------------------------------------------------------
 -- Generator infrastructure
@@ -300,7 +283,7 @@ singleTermList (PairTerm _ y : xs) = (y :) <$> singleTermList xs
 singleTermList _ = Nothing
 
 showSimple :: CTree GenPhase -> String
-showSimple = show . mapIndex @_ @_ @GenSimple
+showSimple = show . mapIndex @_ @_ @MonoSimplePhase
 
 -- | Remove all negative generators from the `AntiGen`.
 dropNegativeGen :: AntiGen a -> AntiGen a

--- a/src/Codec/CBOR/Cuddle/CBOR/Validator.hs
+++ b/src/Codec/CBOR/Cuddle/CBOR/Validator.hs
@@ -18,7 +18,6 @@ import Codec.CBOR.Cuddle.CBOR.Validator.Trace (
   MapValidationTrace (..),
   SValidity (..),
   ValidationTrace (..),
-  XXCTree (..),
   evidence,
   isValid,
   mapTrace,
@@ -34,6 +33,7 @@ import Codec.CBOR.Cuddle.CDDL.Custom.Validator (
   ValidateEnv (..),
   Validator,
   ValidatorPhase,
+  XXCTree (..),
   runValidator,
  )
 import Codec.CBOR.Cuddle.IndexMappable (IndexMappable (..))

--- a/src/Codec/CBOR/Cuddle/CBOR/Validator.hs
+++ b/src/Codec/CBOR/Cuddle/CBOR/Validator.hs
@@ -21,7 +21,6 @@ import Codec.CBOR.Cuddle.CBOR.Validator.Trace (
   evidence,
   isValid,
   mapTrace,
-  showSimple,
  )
 import Codec.CBOR.Cuddle.CDDL hiding (CDDL, Group, Rule)
 import Codec.CBOR.Cuddle.CDDL.CTree
@@ -36,6 +35,7 @@ import Codec.CBOR.Cuddle.CDDL.Custom.Validator (
   XXCTree (..),
   runValidator,
  )
+import Codec.CBOR.Cuddle.CDDL.Resolve (showSimple)
 import Codec.CBOR.Cuddle.IndexMappable (IndexMappable (..))
 import Codec.CBOR.Read
 import Codec.CBOR.Term

--- a/src/Codec/CBOR/Cuddle/CBOR/Validator/Trace.hs
+++ b/src/Codec/CBOR/Cuddle/CBOR/Validator/Trace.hs
@@ -10,8 +10,6 @@
 {-# LANGUAGE UndecidableInstances #-}
 
 module Codec.CBOR.Cuddle.CBOR.Validator.Trace (
-  ValidatorPhaseSimple,
-  XXCTree (..),
   SValidity (..),
   Validity (..),
   ValidationTrace (..),
@@ -34,10 +32,10 @@ module Codec.CBOR.Cuddle.CBOR.Validator.Trace (
 ) where
 
 import Codec.CBOR.Cuddle.CDDL (Name (..))
-import Codec.CBOR.Cuddle.CDDL.CTree (CTree (..), CTreeRoot (..), Node, XXCTree, foldCTree)
+import Codec.CBOR.Cuddle.CDDL.CTree (CTree (..))
 import Codec.CBOR.Cuddle.CDDL.CtlOp (CtlOp)
 import Codec.CBOR.Cuddle.CDDL.Custom.Validator (ValidatorPhase)
-import Codec.CBOR.Cuddle.CDDL.Resolve (XXCTree (..))
+import Codec.CBOR.Cuddle.CDDL.Resolve (MonoSimplePhase)
 import Codec.CBOR.Cuddle.IndexMappable (IndexMappable (..))
 import Codec.CBOR.Term (Term)
 import Data.Foldable (Foldable (..))
@@ -63,37 +61,14 @@ import Prettyprinter.Render.Terminal (AnsiStyle, Color (..), color, italicized)
 import Prettyprinter.Render.Terminal qualified as Ansi
 
 --------------------------------------------------------------------------------
--- ValidatorPhase
-
-type data ValidatorPhaseSimple
-
-newtype instance XXCTree ValidatorPhaseSimple = VRuleRefSimple Name
-
-instance Pretty (XXCTree ValidatorPhaseSimple) where
-  pretty (VRuleRefSimple n) = pretty n
-
-instance IndexMappable CTreeRoot ValidatorPhase ValidatorPhaseSimple where
-  mapIndex (CTreeRoot m) = CTreeRoot $ mapIndex <$> m
-
-instance IndexMappable CTree ValidatorPhase ValidatorPhaseSimple where
-  mapIndex = foldCTree mapExt mapIndex
-    where
-      mapExt (VRuleRef n) = CTreeE $ VRuleRefSimple n
-      mapExt (VValidator _ x) = mapIndex x
+-- Validation result
 
 showSimple ::
-  ( IndexMappable a ValidatorPhase ValidatorPhaseSimple
-  , Show (a ValidatorPhaseSimple)
+  ( IndexMappable a ValidatorPhase MonoSimplePhase
+  , Show (a MonoSimplePhase)
   ) =>
   a ValidatorPhase -> String
-showSimple = show . mapIndex @_ @_ @ValidatorPhaseSimple
-
-deriving instance Eq (Node ValidatorPhaseSimple)
-
-deriving instance Show (Node ValidatorPhaseSimple)
-
---------------------------------------------------------------------------------
--- Validation result
+showSimple = show . mapIndex @_ @_ @MonoSimplePhase
 
 type data Validity
   = IsValid
@@ -116,7 +91,7 @@ instance TestEquality SValidity where
 
 data ControlInfo = ControlInfo
   { ciOp :: CtlOp
-  , ciRule :: CTree ValidatorPhaseSimple
+  , ciRule :: CTree MonoSimplePhase
   }
   deriving (Show)
 
@@ -124,13 +99,13 @@ instance Pretty ControlInfo where
   pretty ControlInfo {..} = pretty ciOp <+> pretty ciRule
 
 data ValidationTrace (v :: Validity) where
-  UnapplicableRule :: CTree ValidatorPhaseSimple -> ValidationTrace IsInvalid
-  TerminalRule :: CTree ValidatorPhaseSimple -> ValidationTrace IsValid
+  UnapplicableRule :: CTree MonoSimplePhase -> ValidationTrace IsInvalid
+  TerminalRule :: CTree MonoSimplePhase -> ValidationTrace IsValid
   ControlTrace :: ControlInfo -> ValidationTrace IsValid -> ValidationTrace IsValid
   ReferenceRule :: Name -> ValidationTrace v -> ValidationTrace v
   CustomFailure :: Text -> ValidationTrace IsInvalid
   CustomSuccess :: ValidationTrace IsValid
-  UnsatisfiedControl :: CtlOp -> CTree ValidatorPhaseSimple -> ValidationTrace IsInvalid
+  UnsatisfiedControl :: CtlOp -> CTree MonoSimplePhase -> ValidationTrace IsInvalid
   ChoiceBranch :: Int -> ValidationTrace IsValid -> ValidationTrace IsValid
   ListTrace :: ListValidationTrace v -> ValidationTrace v
   MapTrace :: MapValidationTrace v -> ValidationTrace v
@@ -143,18 +118,18 @@ data ListValidationTrace (v :: Validity) where
   ListValidationDone :: ListValidationTrace IsValid
   ListValidationLeftoverTerms ::
     NonEmpty Term ->
-    Maybe (CTree ValidatorPhaseSimple, ValidationTrace IsInvalid) ->
+    Maybe (CTree MonoSimplePhase, ValidationTrace IsInvalid) ->
     ListValidationTrace IsInvalid
   ListValidationUnappliedRule ::
-    CTree ValidatorPhaseSimple ->
+    CTree MonoSimplePhase ->
     ListValidationTrace IsInvalid
   ListValidationConsume ::
-    CTree ValidatorPhaseSimple ->
+    CTree MonoSimplePhase ->
     ValidationTrace IsValid ->
     ListValidationTrace v ->
     ListValidationTrace v
   ListValidationMissingRequired ::
-    CTree ValidatorPhaseSimple ->
+    CTree MonoSimplePhase ->
     ValidationTrace IsInvalid ->
     ListValidationTrace IsInvalid
   ListValidationConsumeGroup ::
@@ -173,16 +148,16 @@ data MapValidationTrace (v :: Validity) where
   MapValidationDone :: MapValidationTrace IsValid
   MapValidationLeftoverKVs ::
     (Term, Term) ->
-    Maybe (CTree ValidatorPhaseSimple, MapValidationTrace IsInvalid) ->
+    Maybe (CTree MonoSimplePhase, MapValidationTrace IsInvalid) ->
     MapValidationTrace IsInvalid
-  MapValidationUnappliedRules :: NonEmpty (CTree ValidatorPhaseSimple) -> MapValidationTrace IsInvalid
+  MapValidationUnappliedRules :: NonEmpty (CTree MonoSimplePhase) -> MapValidationTrace IsInvalid
   MapValidationInvalidValue ::
-    CTree ValidatorPhaseSimple ->
+    CTree MonoSimplePhase ->
     ValidationTrace IsValid ->
     ValidationTrace IsInvalid ->
     MapValidationTrace IsInvalid
   MapValidationConsume ::
-    CTree ValidatorPhaseSimple ->
+    CTree MonoSimplePhase ->
     ValidationTrace IsValid ->
     ValidationTrace IsValid ->
     MapValidationTrace v ->

--- a/src/Codec/CBOR/Cuddle/CBOR/Validator/Trace.hs
+++ b/src/Codec/CBOR/Cuddle/CBOR/Validator/Trace.hs
@@ -21,7 +21,6 @@ module Codec.CBOR.Cuddle.CBOR.Validator.Trace (
   TraceOptions (..),
   Progress (..),
   defaultTraceOptions,
-  showSimple,
   isValid,
   prettyValidationTrace,
   showValidationTrace,
@@ -34,9 +33,7 @@ module Codec.CBOR.Cuddle.CBOR.Validator.Trace (
 import Codec.CBOR.Cuddle.CDDL (Name (..))
 import Codec.CBOR.Cuddle.CDDL.CTree (CTree (..))
 import Codec.CBOR.Cuddle.CDDL.CtlOp (CtlOp)
-import Codec.CBOR.Cuddle.CDDL.Custom.Validator (ValidatorPhase)
 import Codec.CBOR.Cuddle.CDDL.Resolve (MonoSimplePhase)
-import Codec.CBOR.Cuddle.IndexMappable (IndexMappable (..))
 import Codec.CBOR.Term (Term)
 import Data.Foldable (Foldable (..))
 import Data.Function (on)
@@ -62,13 +59,6 @@ import Prettyprinter.Render.Terminal qualified as Ansi
 
 --------------------------------------------------------------------------------
 -- Validation result
-
-showSimple ::
-  ( IndexMappable a ValidatorPhase MonoSimplePhase
-  , Show (a MonoSimplePhase)
-  ) =>
-  a ValidatorPhase -> String
-showSimple = show . mapIndex @_ @_ @MonoSimplePhase
 
 type data Validity
   = IsValid

--- a/src/Codec/CBOR/Cuddle/CDDL/Resolve.hs
+++ b/src/Codec/CBOR/Cuddle/CDDL/Resolve.hs
@@ -36,6 +36,7 @@ module Codec.CBOR.Cuddle.CDDL.Resolve (
   NameResolutionFailure (..),
   MonoReferenced,
   MonoSimplePhase,
+  showSimple,
   XXCTree (..),
 )
 where
@@ -518,6 +519,16 @@ instance IndexMappable CTree ValidatorPhase MonoSimplePhase where
 
 instance IndexMappable CTreeRoot ValidatorPhase MonoSimplePhase where
   mapIndex (CTreeRoot m) = CTreeRoot $ mapIndex <$> m
+
+-- | Project any phase that maps to 'MonoSimplePhase' down to a `Show`able
+-- representation. Used for debug output by `Gen`, `Validator`, etc.
+showSimple ::
+  forall a phase.
+  ( IndexMappable a phase MonoSimplePhase
+  , Show (a MonoSimplePhase)
+  ) =>
+  a phase -> String
+showSimple = show . mapIndex @_ @_ @MonoSimplePhase
 
 -- | Monad to run the monomorphisation process. We need some additional
 -- capabilities for this, so 'Either' doesn't fully cut it anymore.

--- a/src/Codec/CBOR/Cuddle/CDDL/Resolve.hs
+++ b/src/Codec/CBOR/Cuddle/CDDL/Resolve.hs
@@ -35,7 +35,7 @@ module Codec.CBOR.Cuddle.CDDL.Resolve (
   fullResolveCDDL,
   NameResolutionFailure (..),
   MonoReferenced,
-  MonoSimple,
+  MonoSimplePhase,
   XXCTree (..),
 )
 where
@@ -479,20 +479,45 @@ type MonoEnv = BindingEnv DistReferenced MonoReferenced
 -- | We introduce additional bindings in the state
 type MonoState = Map.Map Name (CTree MonoReferenced)
 
-type data MonoSimple
+-- | A simplified phase reachable from any of the function-bearing post-mono
+-- phases ('MonoReferenced', 'GenPhase', 'ValidatorPhase'). It strips the
+-- generator/validator extensions so the tree can be `Show`n, `Eq`-compared,
+-- and pretty-printed for debug output.
+type data MonoSimplePhase
 
-instance IndexMappable CTree MonoReferenced MonoSimple where
+newtype instance XXCTree MonoSimplePhase = MSimpleRef Name
+  deriving (Generic, Show, Eq)
+
+instance Pretty (XXCTree MonoSimplePhase) where
+  pretty (MSimpleRef n) = pretty n
+
+instance IndexMappable CTree MonoReferenced MonoSimplePhase where
   mapIndex = foldCTree mapExt mapIndex
     where
       mapExt (MRuleRef n) = CTreeE $ MSimpleRef n
       mapExt (MGenerator _ x) = mapIndex x
       mapExt (MValidator _ x) = mapIndex x
 
-instance IndexMappable CTreeRoot MonoReferenced MonoSimple where
+instance IndexMappable CTreeRoot MonoReferenced MonoSimplePhase where
   mapIndex (CTreeRoot m) = CTreeRoot $ mapIndex <$> m
 
-newtype instance XXCTree MonoSimple = MSimpleRef Name
-  deriving (Generic, Show, Eq)
+instance IndexMappable CTree GenPhase MonoSimplePhase where
+  mapIndex = foldCTree mapExt mapIndex
+    where
+      mapExt (GenRef n) = CTreeE $ MSimpleRef n
+      mapExt (GenGenerator _ x) = mapIndex x
+
+instance IndexMappable CTreeRoot GenPhase MonoSimplePhase where
+  mapIndex (CTreeRoot m) = CTreeRoot $ mapIndex <$> m
+
+instance IndexMappable CTree ValidatorPhase MonoSimplePhase where
+  mapIndex = foldCTree mapExt mapIndex
+    where
+      mapExt (VRuleRef n) = CTreeE $ MSimpleRef n
+      mapExt (VValidator _ x) = mapIndex x
+
+instance IndexMappable CTreeRoot ValidatorPhase MonoSimplePhase where
+  mapIndex (CTreeRoot m) = CTreeRoot $ mapIndex <$> m
 
 -- | Monad to run the monomorphisation process. We need some additional
 -- capabilities for this, so 'Either' doesn't fully cut it anymore.

--- a/test/Test/Codec/CBOR/Cuddle/CDDL/GeneratorSpec.hs
+++ b/test/Test/Codec/CBOR/Cuddle/CDDL/GeneratorSpec.hs
@@ -9,7 +9,7 @@ import Codec.CBOR.Cuddle.CBOR.Validator (validateCBOR)
 import Codec.CBOR.Cuddle.CDDL (Name)
 import Codec.CBOR.Cuddle.CDDL.CTree (CTreeRoot (..))
 import Codec.CBOR.Cuddle.CDDL.Custom.Generator (GenConfig (..), runCBORGen)
-import Codec.CBOR.Cuddle.CDDL.Resolve (MonoReferenced, MonoSimple, fullResolveCDDL)
+import Codec.CBOR.Cuddle.CDDL.Resolve (MonoReferenced, MonoSimplePhase, fullResolveCDDL)
 import Codec.CBOR.Cuddle.Huddle (Huddle, toCDDL)
 import Codec.CBOR.Cuddle.IndexMappable (IndexMappable (..), mapCDDLDropExt)
 import Codec.CBOR.Pretty (prettyHexEnc)
@@ -80,7 +80,7 @@ expectZapInvalidates cddl name = property $ do
 zapInvalidatesHuddle :: String -> Huddle -> Spec
 zapInvalidatesHuddle n huddle = do
   cddl <- tryResolveHuddle huddle
-  prop n . counterexample (TL.unpack . pShow $ mapIndex @_ @_ @MonoSimple cddl) $
+  prop n . counterexample (TL.unpack . pShow $ mapIndex @_ @_ @MonoSimplePhase cddl) $
     expectZapInvalidates cddl "root"
 
 -- | Test that generated values are valid for a Huddle schema


### PR DESCRIPTION
Previously we had `GenPhaseSimple` and `ValidatorPhaseSimple`, which dropped the generator/validator to make it possible to pretty print the CDDL. However both of these phases are basically identical to `MonoSimple`, so this PR renames `MonoSimple` to `MonoSimplePhase` and then uses that instead of `GenPhaseSimple` and `ValidatorPhaseSimple`. 

I also made `showSimple` work with any phase that can be indexmapped to `MonoSimplePhase`.