### PR TITLE
Make `validateCBOR` return `Either ValidateCBORError (Evidenced ValidationTrace)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.8.0.0
 
+* Change `validateCBOR` return type to `Either ValidateCBORError (Evidenced ValidationTrace)`
 * Remove `ToExpr` instances from all types
 * Rename `MonoSimple` to `MonoSimplePhase`
 * Remove `GenSimple` and `ValidatorPhaseSimple`; use `MonoSimplePhase` instead

--- a/bin/Main.hs
+++ b/bin/Main.hs
@@ -446,7 +446,10 @@ parseFromFile p file = runParser p file <$> T.readFile file
 runValidateCBOR :: BS.ByteString -> Name -> CTreeRoot ValidatorPhase -> TraceOptions -> IO ()
 runValidateCBOR bs rule cddl traceOpts =
   case validateCBOR bs rule cddl of
-    Evidenced validity trc -> do
+    Left err -> do
+      putStrLnErr $ "CBOR validation failed:\n" <> show err
+      exitFailure
+    Right (Evidenced validity trc) -> do
       T.putStrLn . Ansi.renderStrict . layoutPretty defaultLayoutOptions $
         prettyValidationTrace traceOpts trc
       putStrLn mempty

--- a/src/Codec/CBOR/Cuddle/CBOR/Validator.hs
+++ b/src/Codec/CBOR/Cuddle/CBOR/Validator.hs
@@ -8,6 +8,7 @@ module Codec.CBOR.Cuddle.CBOR.Validator (
   validateFromName,
   validateFromGRef,
   ValidatorPhase,
+  ValidateCBORError (..),
 ) where
 
 import Codec.CBOR.Cuddle.CBOR.Validator.Trace (
@@ -59,21 +60,28 @@ import GHC.Float
 import GHC.Stack (HasCallStack)
 import Text.Regex.TDFA
 
+data ValidateCBORError
+  = DecodingFailed DeserialiseFailure
+  | LeftoverBytes BSL.ByteString
+  | RuleDoesNotExist Name
+  deriving (Show, Eq)
+
 --------------------------------------------------------------------------------
 -- Main entry point
-
 validateCBOR ::
   HasCallStack =>
   BS.ByteString ->
   Name ->
   CTreeRoot ValidatorPhase ->
-  Evidenced ValidationTrace
-validateCBOR bs rule cddl@(CTreeRoot tree) =
+  Either ValidateCBORError (Evidenced ValidationTrace)
+validateCBOR bs ruleName cddl@(CTreeRoot tree) =
   case deserialiseFromBytes decodeTerm (BSL.fromStrict bs) of
-    Left e -> error $ show e
+    Left e -> Left $ DecodingFailed e
     Right (rest, term)
-      | BSL.null rest -> validateTerm cddl term (tree Map.! rule)
-      | otherwise -> error $ "Leftover bytes in CBOR: " <> show rest
+      | BSL.null rest -> case tree Map.!? ruleName of
+          Just rule -> Right $ validateTerm cddl term rule
+          Nothing -> Left $ RuleDoesNotExist ruleName
+      | otherwise -> Left $ LeftoverBytes rest
 
 -- | Validate a CBOR 'Term' against a top-level rule from inside a custom
 -- validator.

--- a/test/Test/Codec/CBOR/Cuddle/CDDL/GeneratorSpec.hs
+++ b/test/Test/Codec/CBOR/Cuddle/CDDL/GeneratorSpec.hs
@@ -5,7 +5,6 @@
 module Test.Codec.CBOR.Cuddle.CDDL.GeneratorSpec (spec) where
 
 import Codec.CBOR.Cuddle.CBOR.Gen (GenPhase, generateFromName)
-import Codec.CBOR.Cuddle.CBOR.Validator (validateCBOR)
 import Codec.CBOR.Cuddle.CDDL (Name)
 import Codec.CBOR.Cuddle.CDDL.CTree (CTreeRoot (..))
 import Codec.CBOR.Cuddle.CDDL.Custom.Generator (GenConfig (..), runCBORGen)
@@ -33,7 +32,7 @@ import Test.Codec.CBOR.Cuddle.CDDL.Examples.Huddle (
   tagRangeExample,
   taggedUintExample,
  )
-import Test.Codec.CBOR.Cuddle.CDDL.Validator (expectInvalid, genAndValidateRule)
+import Test.Codec.CBOR.Cuddle.CDDL.Validator (expectInvalid, genAndValidateRule, validateCBOR_)
 import Test.Hspec (HasCallStack, Spec, describe, runIO, shouldSatisfy, xdescribe)
 import Test.Hspec.Core.Spec (SpecM)
 import Test.Hspec.QuickCheck (prop)
@@ -66,7 +65,7 @@ expectZapInvalidates cddl name = property $ do
   res@ZapResult {zrValue} <- zapAntiGenResult 1 . runCBORGen cfg $ generateFromName name
   let
     bs = toStrictByteString $ encodeTerm zrValue
-    validationRes = validateCBOR bs name $ mapIndex cddl
+    validationRes = validateCBOR_ bs name $ mapIndex cddl
     failMsg =
       unlines
         [ case deserialiseFromBytes decodeTerm (LBS.fromStrict bs) of
@@ -184,4 +183,4 @@ spec = do
         . classify tagChanged "tag changed"
         . classify innerValueZapped "inner value zapped"
         $ expectInvalid
-          (validateCBOR (toStrictByteString $ encodeTerm zrValue) "root" $ mapIndex taggedBytesCddl)
+          (validateCBOR_ (toStrictByteString $ encodeTerm zrValue) "root" $ mapIndex taggedBytesCddl)

--- a/test/Test/Codec/CBOR/Cuddle/CDDL/Validator.hs
+++ b/test/Test/Codec/CBOR/Cuddle/CDDL/Validator.hs
@@ -8,10 +8,12 @@ module Test.Codec.CBOR.Cuddle.CDDL.Validator (
   expectInvalid,
   genAndValidateCddl,
   genAndValidateRule,
+  validateCBOR_,
 ) where
 
 import Codec.CBOR.Cuddle.CBOR.Gen (generateFromName)
 import Codec.CBOR.Cuddle.CBOR.Validator (
+  ValidatorPhase,
   validateCBOR,
  )
 import Codec.CBOR.Cuddle.CBOR.Validator.Trace (
@@ -96,6 +98,14 @@ import Test.QuickCheck (
  )
 import Text.Megaparsec (runParser)
 
+validateCBOR_ ::
+  HasCallStack =>
+  BS.ByteString ->
+  Name ->
+  CTreeRoot ValidatorPhase ->
+  Evidenced ValidationTrace
+validateCBOR_ bs n cddl = either (\e -> error $ "validateCBOR failed:\n" <> show e) id $ validateCBOR bs n cddl
+
 -- | Test that a specific rule in a resolved CDDL generates valid values
 genAndValidateRule :: String -> Name -> CTreeRoot MonoReferenced -> Spec
 genAndValidateRule description name resolvedCddl =
@@ -109,7 +119,7 @@ genAndValidateRule description name resolvedCddl =
     cborTerm <- runAntiGen . runCBORGen genCfg $ generateFromName name
     let
       generatedCbor = toStrictByteString $ encodeTerm cborTerm
-      res = validateCBOR generatedCbor name (mapIndex resolvedCddl)
+      res = validateCBOR_ generatedCbor name (mapIndex resolvedCddl)
       extraInfo =
         unlines
           [ "CBOR term:"
@@ -267,7 +277,7 @@ validateHuddle huddle name term = do
       Right root -> root
       Left err -> error $ show err
     bs = toStrictByteString $ encodeTerm term
-  validateCBOR bs name (mapIndex resolvedCddl)
+  validateCBOR_ bs name (mapIndex resolvedCddl)
 
 expectValid :: Evidenced ValidationTrace -> Expectation
 expectValid (Evidenced SValid _) = pure ()
@@ -340,19 +350,19 @@ spec = describe "Validator" $ do
            in either (error . show) id . fullResolveCDDL . appendPostlude $ mapCDDLDropExt cddl
       it "Validates a bignum >= 2^64 against biguint" $
         expectValid $
-          validateCBOR bignumCBOR "a" (mapIndex $ resolveCDDL "a = biguint")
+          validateCBOR_ bignumCBOR "a" (mapIndex $ resolveCDDL "a = biguint")
       it "Validates a bignum >= 2^64 against bigint" $
         expectValid $
-          validateCBOR bignumCBOR "a" (mapIndex $ resolveCDDL "a = bigint")
+          validateCBOR_ bignumCBOR "a" (mapIndex $ resolveCDDL "a = bigint")
       it "Validates a bignum >= 2^64 against integer" $
         expectValid $
-          validateCBOR bignumCBOR "a" (mapIndex $ resolveCDDL "a = integer")
+          validateCBOR_ bignumCBOR "a" (mapIndex $ resolveCDDL "a = integer")
       it "Rejects a bignum >= 2^64 against int" $
         expectInvalid $
-          validateCBOR bignumCBOR "a" (mapIndex $ resolveCDDL "a = int")
+          validateCBOR_ bignumCBOR "a" (mapIndex $ resolveCDDL "a = int")
       it "Rejects a bignum >= 2^64 against uint" $
         expectInvalid $
-          validateCBOR bignumCBOR "a" (mapIndex $ resolveCDDL "a = uint")
+          validateCBOR_ bignumCBOR "a" (mapIndex $ resolveCDDL "a = uint")
 
   describe "Custom validator" $ do
     describe "Positive" $ do

--- a/test/Test/Codec/CBOR/Cuddle/CDDL/Validator/Golden.hs
+++ b/test/Test/Codec/CBOR/Cuddle/CDDL/Validator/Golden.hs
@@ -3,7 +3,6 @@
 
 module Test.Codec.CBOR.Cuddle.CDDL.Validator.Golden (spec) where
 
-import Codec.CBOR.Cuddle.CBOR.Validator (validateCBOR)
 import Codec.CBOR.Cuddle.CBOR.Validator.Trace (
   defaultTraceOptions,
   foldEvidenced,
@@ -38,6 +37,7 @@ import Test.Codec.CBOR.Cuddle.CDDL.Examples.Huddle (
   mapNoMatchingKeyExample,
   refTermExample,
  )
+import Test.Codec.CBOR.Cuddle.CDDL.Validator (validateCBOR_)
 import Test.Hspec (Spec, describe, it)
 import Test.Hspec.Golden (Golden (..))
 
@@ -115,7 +115,7 @@ validatorPrettyGolden testName huddle n term =
       Ansi.renderStrict
         . layoutPretty defaultLayoutOptions
         . foldEvidenced (prettyValidationTrace defaultTraceOptions)
-        . validateCBOR bs n
+        . validateCBOR_ bs n
         $ mapIndex treeRoot
 
 spec :: Spec


### PR DESCRIPTION
This PR makes `validateCBOR` return an `Either` with CBOR errors instead of failing with `error`.