### PR TITLE
Switch from `cborg`'s `Term` to `CBORTerm`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,18 @@
 # Changelog for `cuddle`
 
-## 1.8.1.0
+## 1.9.0.0
 
+* Change `ListValidationLeftoverTerms` and `MapValidationLeftoverKVs` to hold `CBORTerm` instead of `Term`
+* Add `Codec.CBOR.Cuddle.CBOR.Term`
+* Add `NInt`
+* Change `generateFromName` and `generateFromGRef` to return `CBORTerm` instead of `Term`
+* Change `RuleTerm` to use `CBORTerm` instead of `Term`
+* Add `Range`, `exclusive`, `inclusive`, `isInRange`, `unIntegerLiteral`, `unDoubleLiteral`
+* Rename `Range` constructor of `CTree` to `CRange`, now takes a `Range` argument
+* Change `VNInt` to have an `NInt` field instead of `Word64`
+* Change `VFloat16` to have a `Half` field instead of `Float`
+* Change `LNInt` to have a `NInt` field instead of `Word64`
+* Add `Codec.CBOR.Cuddle.Orphans`
 * Fix map generator so that it does not generate duplicate keys
 * Add `MapValidationDuplicateKeys`; validator now checks for duplicate elements
 * Add `Codec.CBOR.Cuddle.CBOR.Canonical`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Change `ListValidationLeftoverTerms` and `MapValidationLeftoverKVs` to hold `CBORTerm` instead of `Term`
 * Add `Codec.CBOR.Cuddle.CBOR.Term`
-* Add `NInt`
+* Add `Codec.CBOR.Cuddle.CBOR.NInt`
 * Change `generateFromName` and `generateFromGRef` to return `CBORTerm` instead of `Term`
 * Change `RuleTerm` to use `CBORTerm` instead of `Term`
 * Add `Range`, `exclusive`, `inclusive`, `isInRange`, `unIntegerLiteral`, `unDoubleLiteral`

--- a/bin/Main.hs
+++ b/bin/Main.hs
@@ -7,6 +7,7 @@
 module Main (main) where
 
 import Codec.CBOR.Cuddle.CBOR.Gen (generateFromName)
+import Codec.CBOR.Cuddle.CBOR.Term (CBORTerm, decodeCBORTerm, encodeCBORTerm)
 import Codec.CBOR.Cuddle.CBOR.Validator
 import Codec.CBOR.Cuddle.CBOR.Validator.Trace (
   Evidenced (..),
@@ -27,7 +28,6 @@ import Codec.CBOR.Cuddle.Pretty (PrettyStage, renderCDDL)
 import Codec.CBOR.FlatTerm (toFlatTerm)
 import Codec.CBOR.Pretty (prettyHexEnc)
 import Codec.CBOR.Read (deserialiseFromBytes)
-import Codec.CBOR.Term (Term, decodeTerm, encodeTerm)
 import Codec.CBOR.Write (toStrictByteString)
 import Control.Monad (unless)
 import Data.ByteString (ByteString)
@@ -342,13 +342,13 @@ tryParseFromFile cddlFile =
       exitFailure
     Right res -> pure res
 
-formatTerm :: Term -> CBOROutputFormat -> ByteString
+formatTerm :: CBORTerm -> CBOROutputFormat -> ByteString
 formatTerm term = \case
   AsTerm -> encodeUtf8 . T.pack $ show term
-  AsFlatTerm -> encodeUtf8 . T.pack . show . toFlatTerm $ encodeTerm term
-  AsBinary -> toStrictByteString $ encodeTerm term
-  AsHex -> Base16.encode . toStrictByteString $ encodeTerm term
-  AsDiagnostic -> encodeUtf8 . T.pack . prettyHexEnc $ encodeTerm term
+  AsFlatTerm -> encodeUtf8 . T.pack . show . toFlatTerm $ encodeCBORTerm term
+  AsBinary -> toStrictByteString $ encodeCBORTerm term
+  AsHex -> Base16.encode . toStrictByteString $ encodeCBORTerm term
+  AsDiagnostic -> encodeUtf8 . T.pack . prettyHexEnc $ encodeCBORTerm term
 
 runGen :: Int -> Int -> Gen a -> a
 runGen seed size gen = unGen gen (mkQCGen seed) size
@@ -422,7 +422,7 @@ run = \case
         runValidateCBOR cbor (Name vcItemName) (mapIndex mt) vcTraceOpts
   FormatCBOR FormatCBOROpts {..} cborFile -> do
     contents <- tryReadCBOR dcInputFormat cborFile
-    term <- case deserialiseFromBytes decodeTerm (LBS.fromStrict contents) of
+    term <- case deserialiseFromBytes decodeCBORTerm (LBS.fromStrict contents) of
       Right (leftover, term) -> do
         unless (LBS.null leftover) . putStrLnErr $
           "Warning: " <> show (LBS.length leftover) <> " leftover bytes after decoding"

--- a/cuddle.cabal
+++ b/cuddle.cabal
@@ -160,6 +160,7 @@ test-suite cuddle-test
     data-default-class,
     filepath,
     generic-random,
+    half,
     hspec >=2.11,
     hspec-core,
     hspec-golden,

--- a/cuddle.cabal
+++ b/cuddle.cabal
@@ -131,6 +131,7 @@ test-suite cuddle-test
   other-modules:
     Paths_cuddle
     Test.Codec.CBOR.Cuddle.CBOR.Canonical
+    Test.Codec.CBOR.Cuddle.CBOR.Term
     Test.Codec.CBOR.Cuddle.CDDL.Examples
     Test.Codec.CBOR.Cuddle.CDDL.Examples.Huddle
     Test.Codec.CBOR.Cuddle.CDDL.Gen

--- a/cuddle.cabal
+++ b/cuddle.cabal
@@ -55,6 +55,7 @@ library
     Codec.CBOR.Cuddle.Comments
     Codec.CBOR.Cuddle.Huddle
     Codec.CBOR.Cuddle.IndexMappable
+    Codec.CBOR.Cuddle.Orphans
     Codec.CBOR.Cuddle.Parser
     Codec.CBOR.Cuddle.Parser.Lexer
     Codec.CBOR.Cuddle.Pretty

--- a/cuddle.cabal
+++ b/cuddle.cabal
@@ -40,6 +40,7 @@ library
   exposed-modules:
     Codec.CBOR.Cuddle.CBOR.Canonical
     Codec.CBOR.Cuddle.CBOR.Gen
+    Codec.CBOR.Cuddle.CBOR.Term
     Codec.CBOR.Cuddle.CBOR.Validator
     Codec.CBOR.Cuddle.CBOR.Validator.Trace
     Codec.CBOR.Cuddle.CDDL

--- a/cuddle.cabal
+++ b/cuddle.cabal
@@ -40,6 +40,7 @@ library
   exposed-modules:
     Codec.CBOR.Cuddle.CBOR.Canonical
     Codec.CBOR.Cuddle.CBOR.Gen
+    Codec.CBOR.Cuddle.CBOR.NInt
     Codec.CBOR.Cuddle.CBOR.Term
     Codec.CBOR.Cuddle.CBOR.Validator
     Codec.CBOR.Cuddle.CBOR.Validator.Trace
@@ -132,6 +133,7 @@ test-suite cuddle-test
   other-modules:
     Paths_cuddle
     Test.Codec.CBOR.Cuddle.CBOR.Canonical
+    Test.Codec.CBOR.Cuddle.CBOR.NInt
     Test.Codec.CBOR.Cuddle.CBOR.Term
     Test.Codec.CBOR.Cuddle.CDDL.Examples
     Test.Codec.CBOR.Cuddle.CDDL.Examples.Huddle

--- a/src/Codec/CBOR/Cuddle/CBOR/Canonical.hs
+++ b/src/Codec/CBOR/Cuddle/CBOR/Canonical.hs
@@ -2,7 +2,6 @@
 
 module Codec.CBOR.Cuddle.CBOR.Canonical (
   CanonicalTerm (..),
-  NInt,
   toCanonical,
 ) where
 

--- a/src/Codec/CBOR/Cuddle/CBOR/Canonical.hs
+++ b/src/Codec/CBOR/Cuddle/CBOR/Canonical.hs
@@ -10,6 +10,7 @@ module Codec.CBOR.Cuddle.CBOR.Canonical (
   nintMin,
 ) where
 
+import Codec.CBOR.Cuddle.CBOR.Term (NInt, fromNInt, nintMin, toNInt, uintMax)
 import Codec.CBOR.Term (Term (..))
 import Data.Bifunctor (bimap)
 import Data.ByteString (ByteString)
@@ -22,29 +23,6 @@ import Data.Text.Lazy qualified as TL
 import Data.Word (Word64, Word8)
 import GHC.Generics (Generic)
 import Numeric.Half (Half, toHalf)
-import Test.QuickCheck (Arbitrary (..))
-
--- | A negative integer in the range @[-2^64, -1]@: exactly the values
--- representable by CBOR major type 1 (RFC 8949 §3.1). The range is wider
--- than 'Int64' on the negative side, so it can't be stored as a plain
--- signed integer.
-newtype NInt = NInt Word64
-  deriving (Eq, Ord, Bounded)
-
-instance Show NInt where
-  showsPrec p x =
-    showParen (p > 10) $ showString "toNInt " . showsPrec 11 (fromNInt x)
-
-instance Arbitrary NInt where
-  arbitrary = NInt <$> arbitrary
-
-toNInt :: Integer -> Maybe NInt
-toNInt x
-  | x >= nintMin && x < 0 = Just . NInt . fromInteger $ x - nintMin
-  | otherwise = Nothing
-
-fromNInt :: NInt -> Integer
-fromNInt (NInt n) = nintMin + toInteger n
 
 -- | Convert a `cborg` @Term@ to a @CanonicalTerm@.
 --
@@ -96,7 +74,7 @@ toCanonical = \case
 integerToCanonical :: Integer -> CanonicalTerm
 integerToCanonical n
   | n >= 0, n <= uintMax = CTInt $ fromInteger n
-  | n < 0, n >= nintMin = CTNInt . NInt . fromInteger $ n - nintMin
+  | n < 0, Just nn <- toNInt n = CTNInt nn
   | n > uintMax = CTTagged 2 . CTBytes $ unsignedToBytes n
   | otherwise = CTTagged 3 . CTBytes . unsignedToBytes $ -1 - n
 
@@ -145,11 +123,3 @@ data CanonicalTerm
   | CTFloat !Float
   | CTDouble !Double
   deriving (Generic, Eq, Ord, Show)
-
--- Bounds
-
-uintMax :: Integer
-uintMax = 2 ^ (64 :: Int) - 1
-
-nintMin :: Integer
-nintMin = -(2 ^ (64 :: Int))

--- a/src/Codec/CBOR/Cuddle/CBOR/Canonical.hs
+++ b/src/Codec/CBOR/Cuddle/CBOR/Canonical.hs
@@ -3,26 +3,29 @@
 module Codec.CBOR.Cuddle.CBOR.Canonical (
   CanonicalTerm (..),
   NInt,
-  toNInt,
-  fromNInt,
   toCanonical,
-  uintMax,
-  nintMin,
 ) where
 
-import Codec.CBOR.Cuddle.CBOR.Term (NInt, fromNInt, nintMin, toNInt, uintMax)
-import Codec.CBOR.Term (Term (..))
+import Codec.CBOR.Cuddle.CBOR.Term (
+  CBORTerm (..),
+  NInt,
+  bytesToUnsigned,
+  fromNInt,
+  toNInt,
+  uintMax,
+  unsignedToBytes,
+ )
 import Data.Bifunctor (bimap)
 import Data.ByteString (ByteString)
-import Data.ByteString qualified as BS
 import Data.ByteString.Lazy qualified as BSL
+import Data.ByteString.Lazy qualified as LBS
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
 import Data.Text (Text)
-import Data.Text.Lazy qualified as TL
+import Data.Text.Lazy qualified as LT
 import Data.Word (Word64, Word8)
 import GHC.Generics (Generic)
-import Numeric.Half (Half, toHalf)
+import Numeric.Half (Half)
 
 -- | Convert a `cborg` @Term@ to a @CanonicalTerm@.
 --
@@ -31,30 +34,27 @@ import Numeric.Half (Half, toHalf)
 -- This only arises in the niche case of a duplicate-keyed map nested in a
 -- position the validator does not otherwise reject (e.g. a map used as a map
 -- key). If you hit this, please open an issue.
-toCanonical :: Term -> CanonicalTerm
+toCanonical :: CBORTerm -> CanonicalTerm
 toCanonical = \case
-  TInt i -> integerToCanonical $ toInteger i
-  TInteger n -> integerToCanonical n
-  TBytes bs -> CTBytes bs
-  TBytesI bs -> CTBytes $ BSL.toStrict bs
-  TString s -> CTString s
-  TStringI s -> CTString $ TL.toStrict s
-  TList ts -> mkList ts
-  TListI ts -> mkList ts
-  TMap kvs -> mkMap kvs
-  TMapI kvs -> mkMap kvs
-  TTagged 2 inner
+  TermUInt i -> integerToCanonical $ toInteger i
+  TermNInt i -> integerToCanonical $ fromNInt i
+  TermBytes bs -> CTBytes bs
+  TermBytesI bss -> CTBytes . mconcat $ LBS.toStrict <$> bss
+  TermString t -> CTString t
+  TermStringI ts -> CTString . mconcat $ LT.toStrict <$> ts
+  TermArray xs -> mkList xs
+  TermArrayI xs -> mkList xs
+  TermMap kvs -> mkMap kvs
+  TermMapI kvs -> mkMap kvs
+  TermTag 2 inner
     | Just bs <- tagBytes inner -> integerToCanonical $ bytesToUnsigned bs
-  TTagged 3 inner
+  TermTag 3 inner
     | Just bs <- tagBytes inner -> integerToCanonical $ -1 - bytesToUnsigned bs
-  TTagged w t -> CTTagged w $ toCanonical t
-  TBool False -> CTSimple 20
-  TBool True -> CTSimple 21
-  TNull -> CTSimple 22
-  TSimple w -> CTSimple w
-  THalf f -> CTHalf $ toHalf f
-  TFloat f -> CTFloat f
-  TDouble d -> CTDouble d
+  TermTag t inner -> CTTagged t $ toCanonical inner
+  TermSimple i -> CTSimple i
+  TermHalf x -> CTHalf x
+  TermFloat x -> CTFloat x
+  TermDouble x -> CTDouble x
   where
     mkMap kvs =
       let pairs = bimap toCanonical toCanonical <$> kvs
@@ -67,8 +67,8 @@ toCanonical = \case
                 \not currently supported. Please open an issue at \
                 \https://github.com/input-output-hk/cuddle/issues"
     mkList ts = CTList $ toCanonical <$> ts
-    tagBytes (TBytes bs) = Just bs
-    tagBytes (TBytesI bs) = Just $ BSL.toStrict bs
+    tagBytes (TermBytes bs) = Just bs
+    tagBytes (TermBytesI bs) = Just . BSL.toStrict $ mconcat bs
     tagBytes _ = Nothing
 
 integerToCanonical :: Integer -> CanonicalTerm
@@ -77,15 +77,6 @@ integerToCanonical n
   | n < 0, Just nn <- toNInt n = CTNInt nn
   | n > uintMax = CTTagged 2 . CTBytes $ unsignedToBytes n
   | otherwise = CTTagged 3 . CTBytes . unsignedToBytes $ -1 - n
-
-bytesToUnsigned :: ByteString -> Integer
-bytesToUnsigned = BS.foldl' (\acc b -> acc * 256 + toInteger b) 0
-
-unsignedToBytes :: Integer -> ByteString
-unsignedToBytes = BS.pack . reverse . go
-  where
-    go 0 = []
-    go n = let (d, r) = divMod n 256 in fromInteger r : go d
 
 -- | A canonical representation of CBOR data items. Two 'CanonicalTerm's
 -- compare equal exactly when the underlying CBOR items are equivalent

--- a/src/Codec/CBOR/Cuddle/CBOR/Canonical.hs
+++ b/src/Codec/CBOR/Cuddle/CBOR/Canonical.hs
@@ -5,13 +5,10 @@ module Codec.CBOR.Cuddle.CBOR.Canonical (
   toCanonical,
 ) where
 
+import Codec.CBOR.Cuddle.CBOR.NInt (NInt, fromNInt, toNInt, uintMax)
 import Codec.CBOR.Cuddle.CBOR.Term (
   CBORTerm (..),
-  NInt,
   bytesToUnsigned,
-  fromNInt,
-  toNInt,
-  uintMax,
   unsignedToBytes,
  )
 import Data.Bifunctor (bimap)

--- a/src/Codec/CBOR/Cuddle/CBOR/Gen.hs
+++ b/src/Codec/CBOR/Cuddle/CBOR/Gen.hs
@@ -47,8 +47,8 @@ import Codec.CBOR.Cuddle.CDDL.CTree (
   CTree (..),
   PTerm (..),
   Range (..),
-  unFloatLiteral,
-  unIntLiteral,
+  unDoubleLiteral,
+  unIntegerLiteral,
  )
 import Codec.CBOR.Cuddle.CDDL.CTree qualified as CTree
 import Codec.CBOR.Cuddle.CDDL.CtlOp qualified as CtlOp
@@ -504,8 +504,8 @@ genRange from to bounds
   | CTreeE (GenRef n) <- to = do
       to' <- resolveRef n
       genRange from to' bounds
-  | Just lo <- unIntLiteral from
-  , Just hi <- unIntLiteral to
+  | Just lo <- unIntegerLiteral from
+  , Just hi <- unIntegerLiteral to
   , lo <= hi = do
       val <-
         case bounds of
@@ -517,8 +517,8 @@ genRange from to bounds
         <$> if val >= 0
           then twiddleUInt $ fromInteger val
           else twiddleNInt . fromJust $ toNInt val
-  | Just lo <- unFloatLiteral from
-  , Just hi <- unFloatLiteral to
+  | Just lo <- unDoubleLiteral from
+  , Just hi <- unDoubleLiteral to
   , lo <= hi = do
       val <- choose (lo, hi)
       SingleTerm

--- a/src/Codec/CBOR/Cuddle/CBOR/Gen.hs
+++ b/src/Codec/CBOR/Cuddle/CBOR/Gen.hs
@@ -645,7 +645,8 @@ valueVariantToTerm (VUInt i) = pure $ TermUInt i
 valueVariantToTerm (VNInt i) = pure $ TermNInt i
 valueVariantToTerm (VBignum i)
   | i >= 0 = TermTag 2 <$> twiddleBytes (unsignedToBytes i)
-  | otherwise = TermTag 3 <$> twiddleBytes (unsignedToBytes (-i))
+  -- RFC 8949 §3.4.3: tag 3 content n denotes -1 - n
+  | otherwise = TermTag 3 <$> twiddleBytes (unsignedToBytes (-1 - i))
 valueVariantToTerm (VFloat16 i) = pure $ TermHalf i
 valueVariantToTerm (VFloat32 i) = pure $ TermFloat i
 valueVariantToTerm (VFloat64 i) = pure $ TermDouble i

--- a/src/Codec/CBOR/Cuddle/CBOR/Gen.hs
+++ b/src/Codec/CBOR/Cuddle/CBOR/Gen.hs
@@ -509,7 +509,9 @@ genRange from to bounds
   , lo <= hi = do
       val <-
         case bounds of
-          ClOpen -> genBetween (lo, pred hi)
+          ClOpen
+            | lo < hi -> genBetween (lo, pred hi)
+            | otherwise -> error "Encountered an empty range"
           Closed -> genBetween (lo, hi)
       SingleTerm
         <$> if val >= 0

--- a/src/Codec/CBOR/Cuddle/CBOR/Gen.hs
+++ b/src/Codec/CBOR/Cuddle/CBOR/Gen.hs
@@ -456,6 +456,12 @@ genRange ::
   RangeBound ->
   CBORGen RuleTerm
 genRange from to bounds
+  | CTreeE (GenRef n) <- from = do
+      from' <- resolveRef n
+      genRange from' to bounds
+  | CTreeE (GenRef n) <- to = do
+      to' <- resolveRef n
+      genRange from to' bounds
   | Just lo <- unIntLiteral from
   , Just hi <- unIntLiteral to
   , lo <= hi = do

--- a/src/Codec/CBOR/Cuddle/CBOR/Gen.hs
+++ b/src/Codec/CBOR/Cuddle/CBOR/Gen.hs
@@ -468,9 +468,7 @@ genRange from to bounds
       val <-
         case bounds of
           ClOpen -> genBetween (lo, pred hi)
-          Closed
-            | lo < hi -> genBetween (lo, hi)
-            | otherwise -> error "Empty range encountered"
+          Closed -> genBetween (lo, hi)
       pure . SingleTerm $
         if val >= 0
           then TermUInt $ fromInteger val

--- a/src/Codec/CBOR/Cuddle/CBOR/Gen.hs
+++ b/src/Codec/CBOR/Cuddle/CBOR/Gen.hs
@@ -467,9 +467,9 @@ genRange from to bounds
   , lo <= hi = do
       val <-
         case bounds of
-          ClOpen -> genBetween (lo, hi)
+          ClOpen -> genBetween (lo, pred hi)
           Closed
-            | lo < hi -> genBetween (lo, pred hi)
+            | lo < hi -> genBetween (lo, hi)
             | otherwise -> error "Empty range encountered"
       pure . SingleTerm $
         if val >= 0

--- a/src/Codec/CBOR/Cuddle/CBOR/Gen.hs
+++ b/src/Codec/CBOR/Cuddle/CBOR/Gen.hs
@@ -24,8 +24,13 @@ module Codec.CBOR.Cuddle.CBOR.Gen (
 #endif
 import Codec.CBOR.Cuddle.CBOR.Canonical (toCanonical)
 import Codec.CBOR.Cuddle.CBOR.Term (
+  ArgWidth,
   CBORTerm (..),
+  NInt,
   encodeCBORTerm,
+  genValidWidth,
+  nintArg,
+  optimalWidth,
   toNInt,
   unsignedToBytes,
  )
@@ -58,7 +63,7 @@ import Codec.CBOR.Cuddle.CDDL.Custom.Generator (
  )
 import Codec.CBOR.Cuddle.CDDL.Resolve (XXCTree (..), showSimple)
 import Codec.CBOR.Write qualified as CBOR
-import Control.Monad (zipWithM, (<=<))
+import Control.Monad (forM, zipWithM, (<=<))
 import Control.Monad.Reader (asks)
 import Data.ByteString (ByteString)
 import Data.ByteString qualified as BS
@@ -71,6 +76,7 @@ import Data.Maybe (fromJust, fromMaybe)
 import Data.Ord (Down (..))
 import Data.Text (Text)
 import Data.Text qualified as T
+import Data.Text.Encoding (encodeUtf8)
 import Data.Text.Internal.Encoding.Utf8 (utf8Length)
 import Data.Text.Lazy qualified as LT
 import Data.Text.Lazy.Builder (toLazyText)
@@ -92,11 +98,10 @@ import Test.AntiGen (
  )
 import Test.QuickCheck (
   Arbitrary,
-  NonNegative (..),
  )
 import Test.QuickCheck qualified as QC
 import Test.QuickCheck.Gen (Gen (..), getSize)
-import Test.QuickCheck.GenT (MonadGen (..), elements, frequency, listOf, oneof, suchThat, vectorOf)
+import Test.QuickCheck.GenT (MonadGen (..), elements, frequency, oneof, suchThat, vectorOf)
 
 -- TODO remove this once QuickCheck gets QC
 data QC = QC
@@ -139,57 +144,94 @@ genSublists xs = do
   let (chunk, rest) = splitAt n xs
   (chunk :) <$> genSublists rest
 
+genWidth :: Word64 -> CBORGen ArgWidth
+genWidth v = do
+  twiddle <- asks $ gcTwiddle . geConfig
+  if twiddle
+    then genValidWidth v
+    else pure $ optimalWidth v
+
+twiddleUInt :: Word64 -> CBORGen CBORTerm
+twiddleUInt v = do
+  width <- genWidth v
+  pure $ TermUInt' width v
+
+twiddleNInt :: NInt -> CBORGen CBORTerm
+twiddleNInt v = do
+  width <- genWidth $ nintArg v
+  pure $ TermNInt' width v
+
+genTermString :: T.Text -> CBORGen CBORTerm
+genTermString t = do
+  width <- genWidth . fromIntegral . BS.length $ encodeUtf8 t
+  pure $ TermString' width t
+
+genTermStringI :: LT.Text -> CBORGen CBORTerm
+genTermStringI t = do
+  ts <- fmap (fmap LT.pack) . genSublists $ LT.unpack t
+  tw <- forM ts $ \v -> do
+    width <- genWidth . fromIntegral . BS.length . encodeUtf8 $ LT.toStrict v
+    pure (width, v)
+  pure $ TermStringI' tw
+
+genTermBytes :: BS.ByteString -> CBORGen CBORTerm
+genTermBytes bs = do
+  width <- genWidth . fromIntegral $ BS.length bs
+  pure $ TermBytes' width bs
+
+genTermBytesI :: LBS.ByteString -> CBORGen CBORTerm
+genTermBytesI bs = do
+  bss <- fmap (fmap LBS.pack) . genSublists $ LBS.unpack bs
+  bsw <- forM bss $ \v -> do
+    width <- genWidth . fromIntegral $ LBS.length v
+    pure (width, v)
+  pure $ TermBytesI' bsw
+
+genTermList :: [CBORTerm] -> CBORGen CBORTerm
+genTermList es = do
+  width <- genWidth . fromIntegral $ length es
+  pure $ TermArray' width es
+
+genTermMap :: [(CBORTerm, CBORTerm)] -> CBORGen CBORTerm
+genTermMap kvs = do
+  width <- genWidth . fromIntegral $ length kvs
+  pure $ TermMap' width kvs
+
+twiddleTag :: Word64 -> CBORTerm -> CBORGen CBORTerm
+twiddleTag t v = do
+  width <- genWidth t
+  pure $ TermTag' width t v
+
 twiddleString :: Text -> CBORGen CBORTerm
 twiddleString t = do
-  twiddle <- asks (gcTwiddle . geConfig)
-  let splitText = fmap (fmap LT.pack) . genSublists . T.unpack
+  twiddle <- asks $ gcTwiddle . geConfig
   if twiddle
-    then oneof [pure $ TermString t, TermStringI <$> splitText t]
-    else pure $ TermString t
-
-twiddleList :: [CBORTerm] -> CBORGen CBORTerm
-twiddleList t = do
-  twiddle <- asks (gcTwiddle . geConfig)
-  if twiddle
-    then elements [TermArray t, TermArrayI t]
-    else pure $ TermArray t
+    then oneof [genTermString t, genTermStringI $ LT.fromStrict t]
+    else genTermString t
 
 twiddleBytes :: ByteString -> CBORGen CBORTerm
 twiddleBytes t = do
-  twiddle <- asks (gcTwiddle . geConfig)
-  let splitBytes = fmap (fmap LBS.pack) . genSublists . BS.unpack
+  twiddle <- asks $ gcTwiddle . geConfig
   if twiddle
-    then oneof [pure $ TermBytes t, TermBytesI <$> splitBytes t]
-    else pure $ TermBytes t
+    then oneof [genTermBytes t, genTermBytesI $ LBS.fromStrict t]
+    else genTermBytes t
+
+twiddleList :: [CBORTerm] -> CBORGen CBORTerm
+twiddleList t = do
+  twiddle <- asks $ gcTwiddle . geConfig
+  if twiddle
+    then oneof [genTermList t, pure $ TermArrayI t]
+    else genTermList t
 
 twiddleMap :: [(CBORTerm, CBORTerm)] -> CBORGen CBORTerm
 twiddleMap t = do
-  twiddle <- asks (gcTwiddle . geConfig)
+  twiddle <- asks $ gcTwiddle . geConfig
   if twiddle
-    then elements [TermMap t, TermMapI t]
-    else pure $ TermMap t
-
-genTerm :: CBORGen CBORTerm
-genTerm =
-  oneof
-    [ TermUInt <$> arbitrary
-    , TermNInt <$> arbitrary
-    , twiddleBytes =<< genNBytes . getNonNegative =<< arbitrary
-    , twiddleString . T.pack =<< arbitrary
-    , twiddleList =<< listOf smallerTerm
-    , twiddleMap =<< listOf ((,) <$> smallerTerm <*> smallerTerm)
-    , TermTag <$> choose (6, maxBound :: Word64) <*> smallerTerm
-    , TermSimple <$> elements [20 .. 23]
-    , TermHalf <$> arbitrary
-    , TermFloat <$> arbitrary
-    , TermDouble <$> arbitrary
-    ]
-  where
-    smallerTerm :: CBORGen CBORTerm
-    smallerTerm = scale (`div` 5) genTerm
+    then oneof [genTermMap t, pure $ TermMapI t]
+    else genTermMap t
 
 genNBytes :: MonadGen m => Int -> m ByteString
-genNBytes n = liftGen (uniformByteStringM n QC)
+genNBytes n = liftGen $ uniformByteStringM n QC
 
 genBytes :: MonadGen m => m ByteString
 genBytes = sized $ \sz -> do
@@ -239,15 +281,15 @@ genPostlude pt = genPTerm =<< liftAntiGen (faultyPTerm pt)
       PTBool -> TermSimple <$> elements [20 .. 21]
       -- For integers, introduce decision points that sometimes generate
       -- out-of-bounds values
-      PTUInt -> TermUInt <$> arbitrary
-      PTNInt -> TermNInt <$> arbitrary
-      PTInt -> oneof [TermNInt <$> arbitrary, TermUInt <$> arbitrary]
+      PTUInt -> twiddleUInt =<< arbitrary
+      PTNInt -> twiddleNInt =<< arbitrary
+      PTInt -> oneof [twiddleUInt =<< arbitrary, twiddleNInt =<< arbitrary]
       PTHalf -> TermHalf <$> arbitrary
       PTFloat -> TermFloat <$> arbitrary
       PTDouble -> TermDouble <$> arbitrary
       PTBytes -> twiddleBytes =<< genBytes
       PTText -> twiddleString =<< genText
-      PTAny -> genTerm
+      PTAny -> arbitrary
       PTNil -> pure $ TermSimple 22
       PTUndefined -> pure $ TermSimple 23
 
@@ -283,7 +325,7 @@ genSized :: HasCallStack => Word64 -> CTree GenPhase -> CBORGen RuleTerm
 genSized s target = annotateTerm target $ case target of
   CTree.Postlude PTText -> fmap SingleTerm . twiddleString =<< genNBytesText (fromIntegral s)
   CTree.Postlude PTBytes -> fmap SingleTerm . twiddleBytes =<< genNBytes (fromIntegral s)
-  CTree.Postlude PTUInt -> SingleTerm . TermUInt <$> choose (0, 256 ^ s - 1)
+  CTree.Postlude PTUInt -> fmap SingleTerm . twiddleUInt =<< choose (0, 256 ^ s - 1)
   _ -> error "Cannot apply size operator to target "
 
 genBetween :: (Integral a, Random a) => (a, a) -> CBORGen a
@@ -469,10 +511,10 @@ genRange from to bounds
         case bounds of
           ClOpen -> genBetween (lo, pred hi)
           Closed -> genBetween (lo, hi)
-      pure . SingleTerm $
-        if val >= 0
-          then TermUInt $ fromInteger val
-          else TermNInt . fromJust $ toNInt val
+      SingleTerm
+        <$> if val >= 0
+          then twiddleUInt $ fromInteger val
+          else twiddleNInt . fromJust $ toNInt val
   | Just lo <- unFloatLiteral from
   , Just hi <- unFloatLiteral to
   , lo <= hi = do
@@ -498,11 +540,11 @@ genControl op target controller = annotateTerm target $ do
     x -> pure x
   case (op, resolvedController) of
     (CtlOp.Le, CTree.Literal (Value (VUInt n) _)) -> case target of
-      CTree.Postlude PTUInt -> SingleTerm . TermUInt <$> choose (0, fromIntegral n)
+      CTree.Postlude PTUInt -> fmap SingleTerm . twiddleUInt =<< choose (0, fromIntegral n)
       _ -> error "Cannot apply le operator to target"
     (CtlOp.Le, _) -> error $ "Invalid controller for .le operator: " <> showSimple controller
     (CtlOp.Lt, CTree.Literal (Value (VUInt n) _)) -> case target of
-      CTree.Postlude PTUInt -> SingleTerm . TermUInt <$> choose (0, fromIntegral n - 1)
+      CTree.Postlude PTUInt -> fmap SingleTerm . twiddleUInt =<< choose (0, fromIntegral n - 1)
       _ -> error "Cannot apply lt operator to target"
     (CtlOp.Lt, _) -> error $ "Invalid controller for .lt operator: " <> showSimple controller
     (CtlOp.Size, CTree.Literal (Value (VUInt s) _)) -> do
@@ -554,7 +596,7 @@ genTag t node = do
               disableTwiddle $ genForCTree node
         _ -> genForCTree node
       case enc of
-        SingleTerm x -> pure $ SingleTerm $ TermTag tag x
+        SingleTerm x -> SingleTerm <$> twiddleTag tag x
         _ -> error "Tag controller does not correspond to a single term"
 
 genForNode :: HasCallStack => Name -> CBORGen RuleTerm
@@ -641,12 +683,12 @@ valueToTerm :: Value -> CBORGen CBORTerm
 valueToTerm (Value x _) = valueVariantToTerm x
 
 valueVariantToTerm :: ValueVariant -> CBORGen CBORTerm
-valueVariantToTerm (VUInt i) = pure $ TermUInt i
-valueVariantToTerm (VNInt i) = pure $ TermNInt i
+valueVariantToTerm (VUInt i) = twiddleUInt i
+valueVariantToTerm (VNInt i) = twiddleNInt i
 valueVariantToTerm (VBignum i)
-  | i >= 0 = TermTag 2 <$> twiddleBytes (unsignedToBytes i)
+  | i >= 0 = twiddleTag 2 =<< twiddleBytes (unsignedToBytes i)
   -- RFC 8949 §3.4.3: tag 3 content n denotes -1 - n
-  | otherwise = TermTag 3 <$> twiddleBytes (unsignedToBytes (-1 - i))
+  | otherwise = twiddleTag 3 =<< twiddleBytes (unsignedToBytes (-1 - i))
 valueVariantToTerm (VFloat16 i) = pure $ TermHalf i
 valueVariantToTerm (VFloat32 i) = pure $ TermFloat i
 valueVariantToTerm (VFloat64 i) = pure $ TermDouble i

--- a/src/Codec/CBOR/Cuddle/CBOR/Gen.hs
+++ b/src/Codec/CBOR/Cuddle/CBOR/Gen.hs
@@ -31,6 +31,7 @@ import Codec.CBOR.Cuddle.CBOR.Term (
   genValidWidth,
   nintArg,
   optimalWidth,
+  textArg,
   toNInt,
   unsignedToBytes,
  )
@@ -76,7 +77,6 @@ import Data.Maybe (fromJust, fromMaybe)
 import Data.Ord (Down (..))
 import Data.Text (Text)
 import Data.Text qualified as T
-import Data.Text.Encoding (encodeUtf8)
 import Data.Text.Internal.Encoding.Utf8 (utf8Length)
 import Data.Text.Lazy qualified as LT
 import Data.Text.Lazy.Builder (toLazyText)
@@ -163,14 +163,14 @@ twiddleNInt v = do
 
 genTermString :: T.Text -> CBORGen CBORTerm
 genTermString t = do
-  width <- genWidth . fromIntegral . BS.length $ encodeUtf8 t
+  width <- genWidth $ textArg t
   pure $ TermString' width t
 
 genTermStringI :: LT.Text -> CBORGen CBORTerm
 genTermStringI t = do
   ts <- fmap (fmap LT.pack) . genSublists $ LT.unpack t
   tw <- forM ts $ \v -> do
-    width <- genWidth . fromIntegral . BS.length . encodeUtf8 $ LT.toStrict v
+    width <- genWidth . textArg $ LT.toStrict v
     pure (width, v)
   pure $ TermStringI' tw
 

--- a/src/Codec/CBOR/Cuddle/CBOR/Gen.hs
+++ b/src/Codec/CBOR/Cuddle/CBOR/Gen.hs
@@ -9,7 +9,6 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeData #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE ViewPatterns #-}
 
@@ -23,7 +22,13 @@ module Codec.CBOR.Cuddle.CBOR.Gen (
 
 #if MIN_VERSION_random(1,3,0)
 #endif
-import Codec.CBOR.Cuddle.CBOR.Canonical (nintMin, toCanonical, uintMax)
+import Codec.CBOR.Cuddle.CBOR.Canonical (toCanonical)
+import Codec.CBOR.Cuddle.CBOR.Term (
+  CBORTerm (..),
+  encodeCBORTerm,
+  toNInt,
+  unsignedToBytes,
+ )
 import Codec.CBOR.Cuddle.CDDL (
   GRef (..),
   Name (..),
@@ -35,6 +40,9 @@ import Codec.CBOR.Cuddle.CDDL (
 import Codec.CBOR.Cuddle.CDDL.CTree (
   CTree (..),
   PTerm (..),
+  Range (..),
+  unFloatLiteral,
+  unIntLiteral,
  )
 import Codec.CBOR.Cuddle.CDDL.CTree qualified as CTree
 import Codec.CBOR.Cuddle.CDDL.CtlOp qualified as CtlOp
@@ -49,30 +57,26 @@ import Codec.CBOR.Cuddle.CDDL.Custom.Generator (
   withAntiGen,
  )
 import Codec.CBOR.Cuddle.CDDL.Resolve (XXCTree (..), showSimple)
-import Codec.CBOR.Term (Term (..))
-import Codec.CBOR.Term qualified as CBOR
 import Codec.CBOR.Write qualified as CBOR
 import Control.Monad (zipWithM, (<=<))
 import Control.Monad.Reader (asks)
 import Data.ByteString (ByteString)
+import Data.ByteString qualified as BS
 import Data.ByteString.Lazy qualified as LBS
 import Data.Char (chr)
-import Data.Functor ((<&>))
 import Data.List (sortOn)
 import Data.List.NonEmpty qualified as NE
 import Data.Map.Strict qualified as Map
-import Data.Maybe (fromMaybe)
+import Data.Maybe (fromJust, fromMaybe)
 import Data.Ord (Down (..))
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Text.Internal.Encoding.Utf8 (utf8Length)
 import Data.Text.Lazy qualified as LT
-import Data.Text.Lazy qualified as TL
 import Data.Text.Lazy.Builder (toLazyText)
 import Data.Text.Lazy.Builder qualified as LB
-import Data.Word (Word64, Word8)
+import Data.Word (Word64)
 import GHC.Stack (HasCallStack)
-import Numeric.Half (Half (..), fromHalf)
 import Prettyprinter (Pretty (..), layoutCompact)
 import Prettyprinter.Render.Text (renderStrict)
 import System.Random.Stateful (Random, StatefulGen (..), runStateGen_, uniformByteStringM)
@@ -126,71 +130,62 @@ scale f m = sized $ \n -> resize (f n) m
 -- Postlude
 --------------------------------------------------------------------------------
 
--- | Simple values that are either unassigned or don't have a specialized type already
-simple :: [Word8]
-simple =
-  -- TODO add the other values once they are supported
-  -- [0 .. 19] ++ [23] ++ [32 ..]
-  [23]
+-- | Split a list into a random number of non-empty contiguous sublists, such
+-- that @concat \<$\> genSublists xs@ always yields @xs@ again.
+genSublists :: [a] -> CBORGen [[a]]
+genSublists [] = pure []
+genSublists xs = do
+  n <- choose (1, length xs)
+  let (chunk, rest) = splitAt n xs
+  (chunk :) <$> genSublists rest
 
-genHalf :: MonadGen m => m Float
-genHalf = do
-  half <- Half <$> arbitrary
-  if isDenormalized half
-    then genHalf
-    else pure $ fromHalf half
-
-twiddleString :: Text -> CBORGen Term
+twiddleString :: Text -> CBORGen CBORTerm
 twiddleString t = do
   twiddle <- asks (gcTwiddle . geConfig)
+  let splitText = fmap (fmap LT.pack) . genSublists . T.unpack
   if twiddle
-    then ($ t) <$> elements [TString, TStringI . TL.fromStrict]
-    else pure $ TString t
+    then oneof [pure $ TermString t, TermStringI <$> splitText t]
+    else pure $ TermString t
 
-twiddleList :: [Term] -> CBORGen Term
+twiddleList :: [CBORTerm] -> CBORGen CBORTerm
 twiddleList t = do
   twiddle <- asks (gcTwiddle . geConfig)
   if twiddle
-    then ($ t) <$> elements [TList, TListI]
-    else pure $ TList t
+    then elements [TermArray t, TermArrayI t]
+    else pure $ TermArray t
 
-twiddleBytes :: ByteString -> CBORGen Term
+twiddleBytes :: ByteString -> CBORGen CBORTerm
 twiddleBytes t = do
   twiddle <- asks (gcTwiddle . geConfig)
+  let splitBytes = fmap (fmap LBS.pack) . genSublists . BS.unpack
   if twiddle
-    then ($ t) <$> elements [TBytes, TBytesI . LBS.fromStrict]
-    else pure $ TBytes t
+    then oneof [pure $ TermBytes t, TermBytesI <$> splitBytes t]
+    else pure $ TermBytes t
 
-twiddleMap :: [(Term, Term)] -> CBORGen Term
+twiddleMap :: [(CBORTerm, CBORTerm)] -> CBORGen CBORTerm
 twiddleMap t = do
   twiddle <- asks (gcTwiddle . geConfig)
   if twiddle
-    then ($ t) <$> elements [TMap, TMapI]
-    else pure $ TMap t
+    then elements [TermMap t, TermMapI t]
+    else pure $ TermMap t
 
-genTerm :: CBORGen Term
+genTerm :: CBORGen CBORTerm
 genTerm =
   oneof
-    [ TInt <$> choose (minBound, maxBound)
-    , TInteger
-        <$> oneof
-          [ choose (toInteger (maxBound :: Int) + 1, toInteger (maxBound :: Word64))
-          , choose (negate (toInteger (maxBound :: Word64)), toInteger (minBound :: Int) - 1)
-          ]
+    [ TermUInt <$> arbitrary
+    , TermNInt <$> arbitrary
     , twiddleBytes =<< genNBytes . getNonNegative =<< arbitrary
     , twiddleString . T.pack =<< arbitrary
     , twiddleList =<< listOf smallerTerm
     , twiddleMap =<< listOf ((,) <$> smallerTerm <*> smallerTerm)
-    , TTagged <$> choose (6, maxBound :: Word64) <*> smallerTerm
-    , TBool <$> arbitrary
-    , pure TNull
-    , TSimple <$> elements simple
-    , THalf <$> genHalf
-    , TFloat <$> arbitrary
-    , TDouble <$> arbitrary
+    , TermTag <$> choose (6, maxBound :: Word64) <*> smallerTerm
+    , TermSimple <$> elements [20 .. 23]
+    , TermHalf <$> arbitrary
+    , TermFloat <$> arbitrary
+    , TermDouble <$> arbitrary
     ]
   where
-    smallerTerm :: CBORGen Term
+    smallerTerm :: CBORGen CBORTerm
     smallerTerm = scale (`div` 5) genTerm
 
 genNBytes :: MonadGen m => Int -> m ByteString
@@ -224,7 +219,7 @@ genText :: MonadGen m => m Text
 genText = sized $ \sz -> genNBytesText =<< choose (0, sz)
 
 -- | Primitive types defined by the CDDL specification, with their generators
-genPostlude :: PTerm -> CBORGen Term
+genPostlude :: PTerm -> CBORGen CBORTerm
 genPostlude pt = genPTerm =<< liftAntiGen (faultyPTerm pt)
   where
     genExcluding ls =
@@ -239,26 +234,22 @@ genPostlude pt = genPTerm =<< liftAntiGen (faultyPTerm pt)
         p@PTNInt -> nonPInteger p
         p@PTInt -> nonPInteger p
         p -> pure p |! genExcluding [PTAny, p]
-    genUInt = choose (0, uintMax)
-    genNInt = choose (nintMin, -1)
-    genAboveUInt = choose (uintMax + 1, 2 * uintMax)
-    genBelowNInt = choose (2 * nintMin, nintMin - 1)
     -- \| Given a CDDL postlude type, generates a value of that type
     genPTerm = \case
-      PTBool -> TBool <$> arbitrary
+      PTBool -> TermSimple <$> elements [20 .. 21]
       -- For integers, introduce decision points that sometimes generate
       -- out-of-bounds values
-      PTUInt -> TInteger <$> liftAntiGen (genUInt |! oneof [genNInt, genBelowNInt, genAboveUInt])
-      PTNInt -> TInteger <$> liftAntiGen (genNInt |! oneof [genUInt, genBelowNInt, genAboveUInt])
-      PTInt -> TInteger <$> choose (nintMin, uintMax)
-      PTHalf -> THalf <$> genHalf
-      PTFloat -> TFloat <$> arbitrary
-      PTDouble -> TDouble <$> arbitrary
+      PTUInt -> TermUInt <$> arbitrary
+      PTNInt -> TermNInt <$> arbitrary
+      PTInt -> oneof [TermNInt <$> arbitrary, TermUInt <$> arbitrary]
+      PTHalf -> TermHalf <$> arbitrary
+      PTFloat -> TermFloat <$> arbitrary
+      PTDouble -> TermDouble <$> arbitrary
       PTBytes -> twiddleBytes =<< genBytes
       PTText -> twiddleString =<< genText
       PTAny -> genTerm
-      PTNil -> pure TNull
-      PTUndefined -> pure $ TSimple 23
+      PTNil -> pure $ TermSimple 22
+      PTUndefined -> pure $ TermSimple 23
 
 --------------------------------------------------------------------------------
 -- Kinds of terms
@@ -274,7 +265,7 @@ flattenWrappedList (y : xs) = y : flattenWrappedList xs
 
 -- | Convert a list of wrapped terms to a list of terms. If any 'PairTerm's are
 -- present, we just take their "value" part.
-singleTermList :: [RuleTerm] -> Maybe [Term]
+singleTermList :: [RuleTerm] -> Maybe [CBORTerm]
 singleTermList [] = Just []
 singleTermList (SingleTerm x : xs) = (x :) <$> singleTermList xs
 singleTermList (PairTerm _ y : xs) = (y :) <$> singleTermList xs
@@ -292,12 +283,8 @@ genSized :: HasCallStack => Word64 -> CTree GenPhase -> CBORGen RuleTerm
 genSized s target = annotateTerm target $ case target of
   CTree.Postlude PTText -> fmap SingleTerm . twiddleString =<< genNBytesText (fromIntegral s)
   CTree.Postlude PTBytes -> fmap SingleTerm . twiddleBytes =<< genNBytes (fromIntegral s)
-  CTree.Postlude PTUInt -> SingleTerm . TInteger <$> choose (0, 256 ^ s - 1)
+  CTree.Postlude PTUInt -> SingleTerm . TermUInt <$> choose (0, 256 ^ s - 1)
   _ -> error "Cannot apply size operator to target "
-
-range :: Enum a => RangeBound -> a -> a -> (a, a)
-range ClOpen x y = (x, pred y)
-range Closed x y = (x, y)
 
 genBetween :: (Integral a, Random a) => (a, a) -> CBORGen a
 genBetween rng = liftAntiGen $ do
@@ -322,7 +309,7 @@ annotateTerm = \case
   CTree.Group _ -> annotate "group"
   CTree.KV {} -> annotate "kv"
   CTree.Occur {} -> id
-  CTree.Range {} -> annotate "range"
+  CTree.CRange {} -> annotate "range"
   CTree.Control {} -> id
   CTree.Enum _ -> annotate "enum"
   CTree.Unwrap _ -> annotate "unwrap"
@@ -343,7 +330,7 @@ genForCTree node = annotateTerm node $ case node of
   CTree.KV key value _cut -> genKV key value
   CTree.Occur item occurs ->
     applyOccurenceIndicator occurs (genForCTree item)
-  CTree.Range from to bounds -> genRange from to bounds
+  CTree.CRange (Range from to bounds) -> genRange from to bounds
   CTree.Control op target controller -> genControl op target controller
   CTree.Enum tree -> genEnum tree
   CTree.Unwrap n -> genForCTree n
@@ -362,7 +349,11 @@ genMap nodes = do
     elemsNeeded _ = 0
 
     tryGenKV ::
-      Int -> Map.Map Term a -> CTree GenPhase -> CTree GenPhase -> CBORGen (Maybe (Term, Term))
+      Int ->
+      Map.Map CBORTerm a ->
+      CTree GenPhase ->
+      CTree GenPhase ->
+      CBORGen (Maybe (CBORTerm, CBORTerm))
     tryGenKV nTries m kNode vNode = go nTries
       where
         canonicalKeys = toCanonical <$> Map.keys m
@@ -378,7 +369,8 @@ genMap nodes = do
                 else go (n - 1)
           | otherwise = pure Nothing
 
-    genNodes :: Int -> Map.Map Term Term -> [CTree GenPhase] -> CBORGen (Maybe (Map.Map Term Term))
+    genNodes ::
+      Int -> Map.Map CBORTerm CBORTerm -> [CTree GenPhase] -> CBORGen (Maybe (Map.Map CBORTerm CBORTerm))
     genNodes _ m [] = pure $ Just m
     genNodes !i !m (n : ns) =
       let
@@ -463,24 +455,31 @@ genRange ::
   CTree GenPhase ->
   RangeBound ->
   CBORGen RuleTerm
-genRange from to bounds = do
-  term1 <- withAntiGen dropNegativeGen $ genForCTree from
-  term2 <- withAntiGen dropNegativeGen $ genForCTree to
-  case (term1, term2) of
-    (SingleTerm (TInt a), SingleTerm (TInt b))
-      | a <= b -> genBetween (range bounds a b) <&> SingleTerm . TInt
-    (SingleTerm (TInt a), SingleTerm (TInteger b))
-      | fromIntegral a <= b ->
-          genBetween (range bounds (fromIntegral a) b) <&> SingleTerm . TInteger
-    (SingleTerm (TInteger a), SingleTerm (TInteger b))
-      | a <= b -> genBetween (range bounds a b) <&> SingleTerm . TInteger
-    (SingleTerm (THalf a), SingleTerm (THalf b))
-      | a <= b -> choose (range bounds a b) <&> SingleTerm . THalf
-    (SingleTerm (TFloat a), SingleTerm (TFloat b))
-      | a <= b -> choose (range bounds a b) <&> SingleTerm . TFloat
-    (SingleTerm (TDouble a), SingleTerm (TDouble b))
-      | a <= b -> choose (range bounds a b) <&> SingleTerm . TDouble
-    (a, b) -> error $ "invalid range (a = " <> show a <> ", b = " <> show b <> ")"
+genRange from to bounds
+  | Just lo <- unIntLiteral from
+  , Just hi <- unIntLiteral to
+  , lo <= hi = do
+      val <-
+        case bounds of
+          ClOpen -> genBetween (lo, hi)
+          Closed
+            | lo < hi -> genBetween (lo, pred hi)
+            | otherwise -> error "Empty range encountered"
+      pure . SingleTerm $
+        if val >= 0
+          then TermUInt $ fromInteger val
+          else TermNInt . fromJust $ toNInt val
+  | Just lo <- unFloatLiteral from
+  , Just hi <- unFloatLiteral to
+  , lo <= hi = do
+      val <- choose (lo, hi)
+      SingleTerm
+        <$> elements
+          [ TermHalf $ realToFrac val
+          , TermFloat $ realToFrac val
+          , TermDouble $ realToFrac val
+          ]
+  | otherwise = error "Encountered range with invalid boundary values"
 
 -- | Generate a value with a control operator applied
 genControl ::
@@ -495,18 +494,18 @@ genControl op target controller = annotateTerm target $ do
     x -> pure x
   case (op, resolvedController) of
     (CtlOp.Le, CTree.Literal (Value (VUInt n) _)) -> case target of
-      CTree.Postlude PTUInt -> SingleTerm . TInteger <$> choose (0, fromIntegral n)
+      CTree.Postlude PTUInt -> SingleTerm . TermUInt <$> choose (0, fromIntegral n)
       _ -> error "Cannot apply le operator to target"
     (CtlOp.Le, _) -> error $ "Invalid controller for .le operator: " <> showSimple controller
     (CtlOp.Lt, CTree.Literal (Value (VUInt n) _)) -> case target of
-      CTree.Postlude PTUInt -> SingleTerm . TInteger <$> choose (0, fromIntegral n - 1)
+      CTree.Postlude PTUInt -> SingleTerm . TermUInt <$> choose (0, fromIntegral n - 1)
       _ -> error "Cannot apply lt operator to target"
     (CtlOp.Lt, _) -> error $ "Invalid controller for .lt operator: " <> showSimple controller
     (CtlOp.Size, CTree.Literal (Value (VUInt s) _)) -> do
       s' <- liftAntiGen $ pure s |! sized (\sz -> choose (0, fromIntegral sz) `suchThat` (/= s))
       genSized s' target
-    (CtlOp.Size, CTree.Range {CTree.from, CTree.to}) ->
-      case (from, to) of
+    (CtlOp.Size, CTree.CRange Range {rangeFrom, rangeTo}) ->
+      case (rangeFrom, rangeTo) of
         (CTree.Literal (Value (VUInt f) _), CTree.Literal (Value (VUInt t) _)) -> do
           s <- liftAntiGen $ sized $ \sz ->
             antiChoose
@@ -524,7 +523,7 @@ genControl op target controller = annotateTerm target $ do
     (CtlOp.Cbor, _) -> do
       enc <- genForCTree controller
       case enc of
-        SingleTerm x -> fmap SingleTerm . twiddleBytes $ CBOR.toStrictByteString (CBOR.encodeTerm x)
+        SingleTerm x -> fmap SingleTerm . twiddleBytes $ CBOR.toStrictByteString (encodeCBORTerm x)
         _ -> error "Controller does not correspond to a single term"
     (c, _) -> error $ "Controller not yet implemented: " <> show c
 
@@ -551,7 +550,7 @@ genTag t node = do
               disableTwiddle $ genForCTree node
         _ -> genForCTree node
       case enc of
-        SingleTerm x -> pure $ SingleTerm $ TTagged tag x
+        SingleTerm x -> pure $ SingleTerm $ TermTag tag x
         _ -> error "Tag controller does not correspond to a single term"
 
 genForNode :: HasCallStack => Name -> CBORGen RuleTerm
@@ -576,7 +575,7 @@ resolveRef n = do
 -- This will throw an error if the generated item does not correspond to a
 -- single CBOR term (e.g. if the name resolves to a group, which cannot be
 -- generated outside a context).
-generateFromName :: HasCallStack => Name -> CBORGen Term
+generateFromName :: HasCallStack => Name -> CBORGen CBORTerm
 generateFromName n = do
   mRule <- lookupCddl n
   case mRule of
@@ -634,20 +633,19 @@ applyOccurenceIndicator (OIBounded mlb mub) oldGen =
     i <- fromIntegral <$> genBetween (lb, ub)
     GroupTerm <$> vectorOf i (scale (`div` (i + 1)) oldGen)
 
-valueToTerm :: Value -> CBORGen Term
+valueToTerm :: Value -> CBORGen CBORTerm
 valueToTerm (Value x _) = valueVariantToTerm x
 
-valueVariantToTerm :: ValueVariant -> CBORGen Term
-valueVariantToTerm (VUInt i)
-  | toInteger i <= toInteger (maxBound :: Int) = pure $ TInt (fromIntegral i)
-  | otherwise = pure $ TInteger (fromIntegral i)
-valueVariantToTerm (VNInt i)
-  | -toInteger i >= toInteger (minBound :: Int) = pure $ TInt (-fromIntegral i)
-  | otherwise = pure $ TInteger (-fromIntegral i)
-valueVariantToTerm (VBignum i) = pure $ TInteger i
-valueVariantToTerm (VFloat16 i) = pure $ THalf i
-valueVariantToTerm (VFloat32 i) = pure $ TFloat i
-valueVariantToTerm (VFloat64 i) = pure $ TDouble i
+valueVariantToTerm :: ValueVariant -> CBORGen CBORTerm
+valueVariantToTerm (VUInt i) = pure $ TermUInt i
+valueVariantToTerm (VNInt i) = pure $ TermNInt i
+valueVariantToTerm (VBignum i)
+  | i >= 0 = TermTag 2 <$> twiddleBytes (unsignedToBytes i)
+  | otherwise = TermTag 3 <$> twiddleBytes (unsignedToBytes (-i))
+valueVariantToTerm (VFloat16 i) = pure $ TermHalf i
+valueVariantToTerm (VFloat32 i) = pure $ TermFloat i
+valueVariantToTerm (VFloat64 i) = pure $ TermDouble i
 valueVariantToTerm (VText t) = twiddleString t
 valueVariantToTerm (VBytes b) = twiddleBytes b
-valueVariantToTerm (VBool b) = pure $ TBool b
+valueVariantToTerm (VBool False) = pure $ TermSimple 20
+valueVariantToTerm (VBool True) = pure $ TermSimple 21

--- a/src/Codec/CBOR/Cuddle/CBOR/Gen.hs
+++ b/src/Codec/CBOR/Cuddle/CBOR/Gen.hs
@@ -23,16 +23,15 @@ module Codec.CBOR.Cuddle.CBOR.Gen (
 #if MIN_VERSION_random(1,3,0)
 #endif
 import Codec.CBOR.Cuddle.CBOR.Canonical (toCanonical)
+import Codec.CBOR.Cuddle.CBOR.NInt (NInt, toNInt)
 import Codec.CBOR.Cuddle.CBOR.Term (
   ArgWidth,
   CBORTerm (..),
-  NInt,
   encodeCBORTerm,
   genValidWidth,
   nintArg,
   optimalWidth,
   textArg,
-  toNInt,
   unsignedToBytes,
  )
 import Codec.CBOR.Cuddle.CDDL (

--- a/src/Codec/CBOR/Cuddle/CBOR/NInt.hs
+++ b/src/Codec/CBOR/Cuddle/CBOR/NInt.hs
@@ -1,0 +1,68 @@
+module Codec.CBOR.Cuddle.CBOR.NInt (
+  NInt,
+  fromNInt,
+  toNInt,
+  uintMax,
+  nintMin,
+
+  -- * Internal
+
+  -- | These expose the raw representation and are intended for the
+  -- encoder and decoder in "Codec.CBOR.Cuddle.CBOR.Term" only; use
+  -- 'toNInt' and 'fromNInt' everywhere else.
+  toWord64Raw,
+  fromWord64Raw,
+) where
+
+import Codec.CBOR.Cuddle.Comments (CollectComments)
+import Data.Hashable (Hashable)
+import Data.Maybe (mapMaybe)
+import Data.Word (Word64)
+import Test.QuickCheck (Arbitrary (..))
+
+-- | A negative integer in the range @[-2^64, -1]@: exactly the values
+-- representable by CBOR major type 1 (RFC 8949 §3.1). The range is wider
+-- than 'Int64' on the negative side, so it can't be stored as a plain
+-- signed integer.
+--
+-- Internally, the value is stored as its wire argument @n@, denoting @-1 - n@
+-- (RFC 8949 §3.1).
+newtype NInt = NInt Word64
+  deriving (Eq, Hashable, CollectComments)
+
+instance Ord NInt where
+  compare (NInt a) (NInt b) = compare b a
+
+instance Bounded NInt where
+  minBound = NInt maxBound
+  maxBound = NInt minBound
+
+instance Show NInt where
+  showsPrec p x =
+    showParen (p > 10) $ showString "toNInt " . showsPrec 11 (fromNInt x)
+
+instance Arbitrary NInt where
+  arbitrary = NInt <$> arbitrary
+  shrink = mapMaybe toNInt . shrink . fromNInt
+
+toNInt :: Integer -> Maybe NInt
+toNInt x
+  | x >= nintMin && x < 0 = Just . NInt . fromInteger $ -1 - x
+  | otherwise = Nothing
+
+fromNInt :: NInt -> Integer
+fromNInt (NInt n) = -1 - toInteger n
+
+toWord64Raw :: NInt -> Word64
+toWord64Raw (NInt n) = n
+
+fromWord64Raw :: Word64 -> NInt
+fromWord64Raw = NInt
+
+-- Bounds
+
+uintMax :: Integer
+uintMax = 2 ^ (64 :: Int) - 1
+
+nintMin :: Integer
+nintMin = -(2 ^ (64 :: Int))

--- a/src/Codec/CBOR/Cuddle/CBOR/Term.hs
+++ b/src/Codec/CBOR/Cuddle/CBOR/Term.hs
@@ -1,22 +1,58 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE ViewPatterns #-}
+
 module Codec.CBOR.Cuddle.CBOR.Term (
-  CBORTerm (..),
-  decodeCBORTerm,
-  encodeCBORTerm,
-  NInt,
-  toNInt,
-  fromNInt,
-  bytesToUnsigned,
-  unsignedToBytes,
-  uintMax,
-  nintMin,
+  CBORTerm (
+    ..,
+    TermUInt,
+    TermNInt,
+    TermBytes,
+    TermBytesI,
+    TermString,
+    TermStringI,
+    TermArray,
+    TermMap,
+    TermTag
+  ),
+  mkTermUInt,
+  mkTermNInt,
+  mkTermBytes,
+  mkTermBytesI,
+  mkTermString,
+  mkTermStringI,
+  mkTermArray,
+  mkTermMap,
+  mkTermTag,
   unwrapBytes,
   unwrapString,
   unwrapArray,
   unwrapMap,
+  decodeCBORTerm,
+  encodeCBORTerm,
+
+  -- * Argument width
+  ArgWidth (..),
+  isValidWidth,
+  optimalWidth,
+  genValidWidth,
+
+  -- * NInt
+  NInt,
+  toNInt,
+  fromNInt,
+  nintArg,
+
+  -- * Utils
+  bytesToUnsigned,
+  unsignedToBytes,
+  uintMax,
+  nintMin,
 ) where
 
 import Codec.CBOR.Cuddle.Comments (CollectComments)
 import Codec.CBOR.Decoding (
+  ByteOffset,
   Decoder,
   TokenType (..),
   decodeBreakOr,
@@ -34,49 +70,51 @@ import Codec.CBOR.Decoding (
   decodeStringIndef,
   decodeTag64,
   decodeWord64,
+  peekByteOffset,
   peekTokenType,
  )
 import Codec.CBOR.Encoding (
   Encoding,
   encodeBreak,
-  encodeBytes,
   encodeBytesIndef,
   encodeDouble,
   encodeFloat,
   encodeFloat16,
-  encodeInteger,
-  encodeListLen,
   encodeListLenIndef,
-  encodeMapLen,
   encodeMapLenIndef,
+  encodePreEncoded,
   encodeSimple,
-  encodeString,
   encodeStringIndef,
-  encodeTag64,
-  encodeWord64,
  )
-import Control.Monad (replicateM)
-import Data.Bits (complement)
+import Control.Monad (forM, replicateM)
+import Data.Bits (Bits (..), complement)
 import Data.ByteString (ByteString)
 import Data.ByteString qualified as BS
+import Data.ByteString.Builder qualified as B
 import Data.ByteString.Lazy qualified as LBS
 import Data.Hashable (Hashable)
 import Data.Maybe (mapMaybe)
 import Data.Text (Text)
 import Data.Text qualified as T
+import Data.Text.Encoding qualified as TE
 import Data.Text.Lazy qualified as LT
+import Data.Text.Lazy.Encoding qualified as LTE
 import Data.Word (Word64, Word8)
 import GHC.Generics (Generic)
 import Numeric.Half (Half, fromHalf, toHalf)
 import Test.QuickCheck (
   Arbitrary (..),
   Gen,
-  chooseInt,
+  choose,
+  elements,
+  listOf,
   oneof,
+  scale,
+  shrinkList,
   sized,
   suchThat,
-  vectorOf,
  )
+import Test.QuickCheck.GenT (MonadGen (liftGen))
 import Prelude hiding (decodeFloat, encodeFloat)
 
 -- | A negative integer in the range @[-2^64, -1]@: exactly the values
@@ -102,29 +140,71 @@ toNInt x
 fromNInt :: NInt -> Integer
 fromNInt (NInt n) = nintMin + toInteger n
 
+data ArgWidth
+  = InlineArg
+  | OneByteArg
+  | TwoByteArg
+  | FourByteArg
+  | EightByteArg
+  deriving (Eq, Ord, Enum, Show)
+
+isValidWidth :: Word64 -> ArgWidth -> Bool
+isValidWidth i = \case
+  InlineArg -> i < 24
+  OneByteArg -> i <= 0xff
+  TwoByteArg -> i <= 0xff_ff
+  FourByteArg -> i <= 0xff_ff_ff_ff
+  EightByteArg -> i <= 0xff_ff_ff_ff_ff_ff_ff_ff
+
+optimalWidth :: Word64 -> ArgWidth
+optimalWidth i
+  | i < 24 = InlineArg
+  | i <= 0xff = OneByteArg
+  | i <= 0xff_ff = TwoByteArg
+  | i <= 0xff_ff_ff_ff = FourByteArg
+  | otherwise = EightByteArg
+
+-- | All well-formed widths strictly smaller than the given one.
+shrinkWidth :: Word64 -> ArgWidth -> [ArgWidth]
+shrinkWidth v w = [w' | w' <- [InlineArg ..], w' < w, isValidWidth v w']
+
+-- | The wire argument of a major type 1 head encoding the value @v@ is
+-- @-1 - v@ (RFC 8949 §3.1), which is the complement of the offset stored
+-- in 'NInt'.
+nintArg :: NInt -> Word64
+nintArg (NInt n) = complement n
+
+-- | The length argument of a text string head counts UTF-8 bytes, not
+-- characters.
+textArg :: T.Text -> Word64
+textArg = fromIntegral . BS.length . TE.encodeUtf8
+
+lazyTextArg :: LT.Text -> Word64
+lazyTextArg = fromIntegral . LBS.length . LTE.encodeUtf8
+
 data CBORTerm
   = -- | Major type 0
-    TermUInt Word64
+    TermUInt' ArgWidth Word64
   | -- | Major type 1
-    TermNInt NInt
+    TermNInt' ArgWidth NInt
   | -- | Major type 2 (definite)
-    TermBytes BS.ByteString
+    TermBytes' ArgWidth BS.ByteString
   | -- | Major type 2 (indefinite)
-    TermBytesI [LBS.ByteString]
+    TermBytesI' [(ArgWidth, LBS.ByteString)]
   | -- | Major type 3 (definite)
-    TermString T.Text
+    TermString' ArgWidth T.Text
   | -- | Major type 3 (indefinite)
-    TermStringI [LT.Text]
+    TermStringI' [(ArgWidth, LT.Text)]
   | -- | Major type 4 (definite)
-    TermArray [CBORTerm]
+    TermArray' ArgWidth [CBORTerm]
   | -- | Major type 4 (indefinite)
     TermArrayI [CBORTerm]
   | -- | Major type 5 (definite)
-    TermMap [(CBORTerm, CBORTerm)]
+    TermMap' ArgWidth [(CBORTerm, CBORTerm)]
   | -- | Major type 5 (indefinite)
     TermMapI [(CBORTerm, CBORTerm)]
   | -- | Major type 6
-    TermTag Word64 CBORTerm
+    TermTag' ArgWidth Word64 CBORTerm
   | -- | Major type 7 (0..24)
     TermSimple Word8
   | -- | Major type 7 (25)
@@ -135,77 +215,230 @@ data CBORTerm
     TermDouble Double
   deriving (Generic, Eq, Ord, Show)
 
+pattern TermUInt :: Word64 -> CBORTerm
+pattern TermUInt v <- TermUInt' _ v
+
+pattern TermNInt :: NInt -> CBORTerm
+pattern TermNInt v <- TermNInt' _ v
+
+pattern TermBytes :: BS.ByteString -> CBORTerm
+pattern TermBytes bs <- TermBytes' _ bs
+
+pattern TermBytesI :: [LBS.ByteString] -> CBORTerm
+pattern TermBytesI bss <- TermBytesI' (fmap snd -> bss)
+
+pattern TermString :: T.Text -> CBORTerm
+pattern TermString t <- TermString' _ t
+
+pattern TermStringI :: [LT.Text] -> CBORTerm
+pattern TermStringI ts <- TermStringI' (fmap snd -> ts)
+
+pattern TermArray :: [CBORTerm] -> CBORTerm
+pattern TermArray es <- TermArray' _ es
+
+pattern TermMap :: [(CBORTerm, CBORTerm)] -> CBORTerm
+pattern TermMap kvs <- TermMap' _ kvs
+
+pattern TermTag :: Word64 -> CBORTerm -> CBORTerm
+pattern TermTag t v <- TermTag' _ t v
+
+{-# COMPLETE
+  TermUInt
+  , TermNInt
+  , TermBytes
+  , TermBytesI
+  , TermString
+  , TermStringI
+  , TermArray
+  , TermArrayI
+  , TermMap
+  , TermMapI
+  , TermTag
+  , TermSimple
+  , TermHalf
+  , TermFloat
+  , TermDouble
+  #-}
+
+mkTermUInt :: Word64 -> CBORTerm
+mkTermUInt v = TermUInt' (optimalWidth v) v
+
+mkTermNInt :: NInt -> CBORTerm
+mkTermNInt v = TermNInt' (optimalWidth $ nintArg v) v
+
+mkTermBytes :: BS.ByteString -> CBORTerm
+mkTermBytes bs = TermBytes' (optimalWidth . fromIntegral $ BS.length bs) bs
+
+mkTermBytesI :: [LBS.ByteString] -> CBORTerm
+mkTermBytesI bss = TermBytesI' $ (\bs -> (optimalWidth . fromIntegral $ LBS.length bs, bs)) <$> bss
+
+mkTermString :: T.Text -> CBORTerm
+mkTermString t = TermString' (optimalWidth $ textArg t) t
+
+mkTermStringI :: [LT.Text] -> CBORTerm
+mkTermStringI ts = TermStringI' $ (\t -> (optimalWidth $ lazyTextArg t, t)) <$> ts
+
+mkTermArray :: [CBORTerm] -> CBORTerm
+mkTermArray es = TermArray' (optimalWidth . fromIntegral $ length es) es
+
+mkTermMap :: [(CBORTerm, CBORTerm)] -> CBORTerm
+mkTermMap kvs = TermMap' (optimalWidth . fromIntegral $ length kvs) kvs
+
+mkTermTag :: Word64 -> CBORTerm -> CBORTerm
+mkTermTag t = TermTag' (optimalWidth t) t
+
+genValidWidth :: MonadGen m => Word64 -> m ArgWidth
+genValidWidth v = liftGen $ elements [x | x <- [InlineArg .. EightByteArg], isValidWidth v x]
+
 -- | Floats never include NaN: the many NaN bit patterns don't survive
 -- round-trips through 'Float' (see 'decodeCBORTerm') and compare unequal
 -- to themselves anyway.
 instance Arbitrary CBORTerm where
-  arbitrary = sized genTerm
+  arbitrary = sized $ \sz ->
+    if sz <= 0
+      then leaf
+      else oneof [leaf, branch]
     where
-      genTerm :: Int -> Gen CBORTerm
-      genTerm n
-        | n <= 0 = leaf
-        | otherwise = oneof [leaf, branch]
-        where
-          leaf =
-            oneof
-              [ TermUInt <$> arbitrary
-              , TermNInt <$> arbitrary
-              , TermBytes . BS.pack <$> arbitrary
-              , TermBytesI . fmap LBS.pack <$> arbitrary
-              , TermString . T.pack <$> arbitrary
-              , TermStringI . fmap LT.pack <$> arbitrary
-              , TermSimple <$> arbitrary
-              , TermHalf . toHalf <$> nonNaN
-              , TermFloat <$> nonNaN
-              , TermDouble <$> nonNaN
-              ]
-          nonNaN :: (RealFloat a, Arbitrary a) => Gen a
-          nonNaN = arbitrary `suchThat` (not . isNaN)
-          branch =
-            oneof
-              [ TermArray <$> subterms
-              , TermArrayI <$> subterms
-              , TermMap <$> subpairs
-              , TermMapI <$> subpairs
-              , TermTag <$> arbitrary <*> genTerm (n - 1)
-              ]
-          subterms = do
-            k <- chooseInt (0, 5)
-            vectorOf k . genTerm $ n `div` (k + 1)
-          subpairs = do
-            k <- chooseInt (0, 5)
-            let sub = genTerm $ n `div` (2 * k + 1)
-            vectorOf k $ (,) <$> sub <*> sub
+      leaf =
+        oneof
+          [ do
+              v <- arbitrary
+              w <- genValidWidth v
+              pure $ TermUInt' w v
+          , do
+              v <- arbitrary
+              w <- genValidWidth $ nintArg v
+              pure $ TermNInt' w v
+          , do
+              bs <- BS.pack <$> arbitrary
+              w <- genValidWidth . fromIntegral $ BS.length bs
+              pure $ TermBytes' w bs
+          , do
+              bss <- listOf $ LBS.pack <$> arbitrary
+              bsw <- forM bss $ \bs -> do
+                w <- genValidWidth . fromIntegral $ LBS.length bs
+                pure (w, bs)
+              pure $ TermBytesI' bsw
+          , do
+              t <- T.pack <$> arbitrary
+              w <- genValidWidth $ textArg t
+              pure $ TermString' w t
+          , do
+              tss <- listOf $ LT.pack <$> arbitrary
+              tsw <- forM tss $ \t -> do
+                w <- genValidWidth $ lazyTextArg t
+                pure (w, t)
+              pure $ TermStringI' tsw
+          , TermSimple <$> arbitrary
+          , TermHalf . toHalf <$> nonNaN
+          , TermFloat <$> nonNaN
+          , TermDouble <$> nonNaN
+          ]
+      nonNaN :: (RealFloat a, Arbitrary a) => Gen a
+      nonNaN = arbitrary `suchThat` (not . isNaN)
+      branch =
+        sized $ \sz ->
+          oneof
+            [ do
+                n <- choose (0, max 0 sz)
+                es <- replicateM n $ scale (`div` n) arbitrary
+                w <- genValidWidth . fromIntegral $ length es
+                pure $ TermArray' w es
+            , do
+                n <- choose (0, max 0 sz)
+                es <- replicateM n $ scale (`div` n) arbitrary
+                pure $ TermArrayI es
+            , do
+                n <- choose (0, max 0 sz)
+                es <- replicateM n $ scale (`div` n) arbitrary
+                w <- genValidWidth . fromIntegral $ length es
+                pure $ TermMap' w es
+            , do
+                n <- choose (0, max 0 sz)
+                es <- replicateM n $ scale (`div` n) arbitrary
+                pure $ TermMapI es
+            , do
+                t <- arbitrary
+                v <- scale (\x -> if x > 0 then x - 1 else x) arbitrary
+                w <- genValidWidth t
+                pure $ TermTag' w t v
+            ]
 
   shrink term = case term of
-    TermUInt w -> TermUInt <$> shrink w
-    TermNInt n -> TermNInt <$> shrink n
-    TermBytes bs -> TermBytes . BS.pack <$> shrink (BS.unpack bs)
-    TermBytesI chunks -> TermBytesI . fmap LBS.pack <$> shrink (LBS.unpack <$> chunks)
-    TermString s -> TermString . T.pack <$> shrink (T.unpack s)
-    TermStringI chunks -> TermStringI . fmap LT.pack <$> shrink (LT.unpack <$> chunks)
-    TermArray ts -> ts <> (TermArray <$> shrink ts)
+    TermUInt' w v ->
+      [TermUInt' w' v | w' <- shrinkWidth v w]
+        <> [TermUInt' w v' | v' <- shrink v]
+    TermNInt' w n ->
+      [TermNInt' w' n | w' <- shrinkWidth (nintArg n) w]
+        <> [TermNInt' w n' | n' <- shrink n]
+    TermBytes' w bs ->
+      [TermBytes' w' bs | w' <- shrinkWidth (fromIntegral $ BS.length bs) w]
+        <> [TermBytes' w (BS.pack bs') | bs' <- shrink (BS.unpack bs)]
+    TermBytesI' chunks -> TermBytesI' <$> shrinkList shrinkBytesChunk chunks
+    TermString' w s ->
+      [TermString' w' s | w' <- shrinkWidth (textArg s) w]
+        <> [TermString' w (T.pack s') | s' <- shrink (T.unpack s)]
+    TermStringI' chunks -> TermStringI' <$> shrinkList shrinkStringChunk chunks
+    TermArray' w ts ->
+      ts
+        <> [TermArray' w' ts | w' <- shrinkWidth (fromIntegral $ length ts) w]
+        <> (TermArray' w <$> shrink ts)
     TermArrayI ts -> ts <> (TermArrayI <$> shrink ts)
-    TermMap kvs -> subterms kvs <> (TermMap <$> shrink kvs)
+    TermMap' w kvs ->
+      subterms kvs
+        <> [TermMap' w' kvs | w' <- shrinkWidth (fromIntegral $ length kvs) w]
+        <> (TermMap' w <$> shrink kvs)
     TermMapI kvs -> subterms kvs <> (TermMapI <$> shrink kvs)
-    TermTag tag t -> t : (TermTag <$> shrink tag <*> pure t) <> (TermTag tag <$> shrink t)
-    TermSimple w -> TermSimple <$> shrink w
+    TermTag' w tag t ->
+      t
+        : [TermTag' w' tag t | w' <- shrinkWidth tag w]
+          <> (TermTag' w <$> shrink tag <*> pure t)
+          <> (TermTag' w tag <$> shrink t)
+    TermSimple v -> TermSimple <$> shrink v
     TermHalf _ -> []
     TermFloat f -> TermFloat <$> shrink f
     TermDouble d -> TermDouble <$> shrink d
     where
       subterms = concatMap $ \(k, v) -> [k, v]
+      shrinkBytesChunk (w, c) =
+        [(w', c) | w' <- shrinkWidth (fromIntegral $ LBS.length c) w]
+          <> [(w, LBS.pack c') | c' <- shrink (LBS.unpack c)]
+      shrinkStringChunk (w, c) =
+        [(w', c) | w' <- shrinkWidth (lazyTextArg c) w]
+          <> [(w, LT.pack c') | c' <- shrink (LT.unpack c)]
+
+widthFromOffset :: ByteOffset -> ArgWidth
+widthFromOffset = \case
+  0 -> InlineArg
+  1 -> OneByteArg
+  2 -> TwoByteArg
+  4 -> FourByteArg
+  8 -> EightByteArg
+  n -> error $ "Impossible head size: " <> show n
+
+decodeWithWidth :: Decoder s a -> Decoder s (ArgWidth, a)
+decodeWithWidth = decodeWithLengthWidth $ const 0
+
+-- | Like 'decodeWithWidth', but for decoders that consume both the head and
+-- its content: the content's byte count is discounted from the measured
+-- head size.
+decodeWithLengthWidth :: (a -> Word64) -> Decoder s a -> Decoder s (ArgWidth, a)
+decodeWithLengthWidth contentBytes decoder = do
+  o1 <- peekByteOffset
+  x <- decoder
+  o2 <- peekByteOffset
+  pure (widthFromOffset (o2 - o1 - 1 - fromIntegral (contentBytes x)), x)
 
 decodeCBORTerm :: Decoder s CBORTerm
 decodeCBORTerm = do
   tokType <- peekTokenType
   case tokType of
-    TypeUInt -> TermUInt <$> decodeWord64
-    TypeUInt64 -> TermUInt <$> decodeWord64
+    TypeUInt -> decodeUInt
+    TypeUInt64 -> decodeUInt
     -- 'decodeNegWord64' yields the argument @n@ of the wire encoding, which
     -- denotes the value @-1 - n@, i.e. @nintMin + complement n@.
-    TypeNInt -> TermNInt . NInt . complement <$> decodeNegWord64
-    TypeNInt64 -> TermNInt . NInt . complement <$> decodeNegWord64
+    TypeNInt -> decodeNInt
+    TypeNInt64 -> decodeNInt
     -- 'peekTokenType' classifies tags 2 and 3 (bignums) as 'TypeInteger'
     -- so that 'Integer' decoders know to take the bignum path. We want the
     -- uninterpreted term, and 'decodeTag64' accepts these headers like any
@@ -216,14 +449,20 @@ decodeCBORTerm = do
     TypeFloat16 -> TermHalf . toHalf <$> decodeFloat
     TypeFloat32 -> TermFloat <$> decodeFloat
     TypeFloat64 -> TermDouble <$> decodeDouble
-    TypeBytes -> TermBytes <$> decodeBytes
-    TypeBytesIndef ->
+    TypeBytes -> uncurry TermBytes' <$> decodeBytesWithWidth
+    TypeBytesIndef -> do
       decodeBytesIndef
-        >> TermBytesI <$> decodeChunks (LBS.fromStrict <$> decodeBytes)
-    TypeString -> TermString <$> decodeString
-    TypeStringIndef ->
+      bsw <- decodeChunks $ do
+        (w, bs) <- decodeBytesWithWidth
+        pure (w, LBS.fromStrict bs)
+      pure $ TermBytesI' bsw
+    TypeString -> uncurry TermString' <$> decodeStringWithWidth
+    TypeStringIndef -> do
       decodeStringIndef
-        >> TermStringI <$> decodeChunks (LT.fromStrict <$> decodeString)
+      tsw <- decodeChunks $ do
+        (w, t) <- decodeStringWithWidth
+        pure (w, LT.fromStrict t)
+      pure $ TermStringI' tsw
     TypeListLen -> decodeArray
     TypeListLen64 -> decodeArray
     TypeListLenIndef ->
@@ -242,15 +481,23 @@ decodeCBORTerm = do
     TypeBreak -> fail "decodeCBORTerm: unexpected break"
     TypeInvalid -> fail "decodeCBORTerm: invalid token"
   where
+    decodeBytesWithWidth = decodeWithLengthWidth (fromIntegral . BS.length) decodeBytes
+    decodeStringWithWidth = decodeWithLengthWidth textArg decodeString
+    decodeUInt = do
+      (w, v) <- decodeWithWidth decodeWord64
+      pure $ TermUInt' w v
+    decodeNInt = do
+      (w, v) <- decodeWithWidth decodeNegWord64
+      pure . TermNInt' w . NInt $ complement v
     decodeTagged = do
-      tag <- decodeTag64
-      TermTag tag <$> decodeCBORTerm
+      (w, tag) <- decodeWithWidth decodeTag64
+      TermTag' w tag <$> decodeCBORTerm
     decodeArray = do
-      n <- decodeListLen
-      TermArray <$> replicateM n decodeCBORTerm
+      (w, n) <- decodeWithWidth decodeListLen
+      TermArray' w <$> replicateM n decodeCBORTerm
     decodeMap = do
-      n <- decodeMapLen
-      TermMap <$> replicateM n decodeKeyValue
+      (w, n) <- decodeWithWidth decodeMapLen
+      TermMap' w <$> replicateM n decodeKeyValue
     decodeKeyValue = (,) <$> decodeCBORTerm <*> decodeCBORTerm
 
 -- | Decode items with @dec@ until hitting (and consuming) a break stop code.
@@ -261,41 +508,70 @@ decodeChunks dec = go
       done <- decodeBreakOr
       if done then pure [] else (:) <$> dec <*> go
 
+data MajorType = M0 | M1 | M2 | M3 | M4 | M5 | M6 | M7
+  deriving (Enum, Eq, Ord, Show)
+
+majorTypeMask :: MajorType -> Word8
+majorTypeMask = (`shiftL` 5) . fromIntegral . fromEnum
+
+argWidthMask :: ArgWidth -> Word8
+argWidthMask = \case
+  InlineArg -> 0x00
+  OneByteArg -> 0x18
+  TwoByteArg -> 0x19
+  FourByteArg -> 0x1a
+  EightByteArg -> 0x1b
+
+encodeRawDataItem :: MajorType -> ArgWidth -> Word64 -> Encoding
+encodeRawDataItem major width arg
+  | isValidWidth arg width =
+      encodePreEncoded . LBS.toStrict . B.toLazyByteString $
+        B.word8 headerByte <> payload
+  | otherwise = error $ "Argument is too large to be encoded as " <> show width <> ": " <> show arg
+  where
+    headerByte = majorTypeMask major .|. argWidthMask width .|. inlineArgMask
+    payload = case width of
+      InlineArg -> mempty
+      OneByteArg -> B.word8 $ fromIntegral arg
+      TwoByteArg -> B.word16BE $ fromIntegral arg
+      FourByteArg -> B.word32BE $ fromIntegral arg
+      EightByteArg -> B.word64BE arg
+    inlineArgMask
+      | InlineArg <- width = fromIntegral arg
+      | otherwise = 0x00
+
 -- | Encode a term back to CBOR. Integer, length and tag arguments are
 -- emitted with minimal width, so @encodeCBORTerm@ after 'decodeCBORTerm'
 -- reproduces the input bytes only if the input used minimal-width
 -- arguments; the definite\/indefinite structure is always preserved.
 encodeCBORTerm :: CBORTerm -> Encoding
 encodeCBORTerm term = case term of
-  TermUInt w -> encodeWord64 w
+  TermUInt' w v -> encodeRawDataItem M0 w v
   -- For values in @[-2^64, -1]@ 'encodeInteger' always emits major type 1
   -- with argument @-1 - n@, never a bignum.
-  TermNInt n -> encodeInteger $ fromNInt n
-  TermBytes bs -> encodeBytes bs
-  TermBytesI chunks ->
-    encodeBytesIndef
-      <> foldMap (encodeBytes . LBS.toStrict) chunks
-      <> encodeBreak
-  TermString s -> encodeString s
-  TermStringI chunks ->
-    encodeStringIndef
-      <> foldMap (encodeString . LT.toStrict) chunks
-      <> encodeBreak
-  TermArray ts ->
-    encodeListLen (fromIntegral $ length ts) <> foldMap encodeCBORTerm ts
-  TermArrayI ts ->
-    encodeListLenIndef <> foldMap encodeCBORTerm ts <> encodeBreak
-  TermMap kvs ->
-    encodeMapLen (fromIntegral $ length kvs) <> foldMap encodeKeyValue kvs
-  TermMapI kvs ->
-    encodeMapLenIndef <> foldMap encodeKeyValue kvs <> encodeBreak
-  TermTag tag t -> encodeTag64 tag <> encodeCBORTerm t
-  TermSimple w -> encodeSimple w
+  TermNInt' w v -> encodeRawDataItem M1 w (nintArg v)
+  TermBytes' w bs -> encodeBytesW w bs
+  TermBytesI' chunks ->
+    encodeBytesIndef <> foldMap (\(w, bs) -> encodeBytesW w $ LBS.toStrict bs) chunks <> encodeBreak
+  TermString' w s -> encodeStringW w s
+  TermStringI' chunks ->
+    encodeStringIndef <> foldMap (\(w, t) -> encodeStringW w $ LT.toStrict t) chunks <> encodeBreak
+  TermArray' w ts -> encodeRawDataItem M4 w (fromIntegral $ length ts) <> foldMap encodeCBORTerm ts
+  TermArrayI ts -> encodeListLenIndef <> foldMap encodeCBORTerm ts <> encodeBreak
+  TermMap' w kvs -> encodeRawDataItem M5 w (fromIntegral $ length kvs) <> encodeKVs kvs
+  TermMapI kvs -> encodeMapLenIndef <> encodeKVs kvs <> encodeBreak
+  TermTag' w tag t -> encodeRawDataItem M6 w tag <> encodeCBORTerm t
+  TermSimple v -> encodeSimple v
   TermHalf h -> encodeFloat16 $ fromHalf h
   TermFloat f -> encodeFloat f
   TermDouble d -> encodeDouble d
   where
-    encodeKeyValue (k, v) = encodeCBORTerm k <> encodeCBORTerm v
+    encodeBytesW w bs =
+      encodeRawDataItem M2 w (fromIntegral $ BS.length bs) <> encodePreEncoded bs
+    encodeStringW w t =
+      let bs = TE.encodeUtf8 t
+       in encodeRawDataItem M3 w (fromIntegral $ BS.length bs) <> encodePreEncoded bs
+    encodeKVs = foldMap (\(k, v) -> encodeCBORTerm k <> encodeCBORTerm v)
 
 bytesToUnsigned :: ByteString -> Integer
 bytesToUnsigned = BS.foldl' (\acc b -> acc * 256 + toInteger b) 0
@@ -307,22 +583,22 @@ unsignedToBytes = BS.pack . reverse . go
     go n = let (d, r) = divMod n 256 in fromInteger r : go d
 
 unwrapBytes :: CBORTerm -> Maybe ByteString
-unwrapBytes (TermBytes bs) = Just bs
-unwrapBytes (TermBytesI bss) = Just . LBS.toStrict $ mconcat bss
+unwrapBytes (TermBytes' _ bs) = Just bs
+unwrapBytes (TermBytesI' bss) = Just . LBS.toStrict . mconcat $ snd <$> bss
 unwrapBytes _ = Nothing
 
 unwrapString :: CBORTerm -> Maybe Text
-unwrapString (TermString t) = Just t
-unwrapString (TermStringI ts) = Just . LT.toStrict $ mconcat ts
+unwrapString (TermString' _ t) = Just t
+unwrapString (TermStringI' ts) = Just . LT.toStrict . mconcat $ snd <$> ts
 unwrapString _ = Nothing
 
 unwrapArray :: CBORTerm -> Maybe [CBORTerm]
-unwrapArray (TermArray xs) = Just xs
+unwrapArray (TermArray' _ xs) = Just xs
 unwrapArray (TermArrayI xs) = Just xs
 unwrapArray _ = Nothing
 
 unwrapMap :: CBORTerm -> Maybe [(CBORTerm, CBORTerm)]
-unwrapMap (TermMap kvs) = Just kvs
+unwrapMap (TermMap' _ kvs) = Just kvs
 unwrapMap (TermMapI kvs) = Just kvs
 unwrapMap _ = Nothing
 

--- a/src/Codec/CBOR/Cuddle/CBOR/Term.hs
+++ b/src/Codec/CBOR/Cuddle/CBOR/Term.hs
@@ -9,6 +9,10 @@ module Codec.CBOR.Cuddle.CBOR.Term (
   unsignedToBytes,
   uintMax,
   nintMin,
+  unwrapBytes,
+  unwrapString,
+  unwrapArray,
+  unwrapMap,
 ) where
 
 import Codec.CBOR.Cuddle.Comments (CollectComments)
@@ -58,6 +62,7 @@ import Data.ByteString qualified as BS
 import Data.ByteString.Lazy qualified as LBS
 import Data.Hashable (Hashable)
 import Data.Maybe (mapMaybe)
+import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Text.Lazy qualified as LT
 import Data.Word (Word64, Word8)
@@ -300,6 +305,26 @@ unsignedToBytes = BS.pack . reverse . go
   where
     go 0 = []
     go n = let (d, r) = divMod n 256 in fromInteger r : go d
+
+unwrapBytes :: CBORTerm -> Maybe ByteString
+unwrapBytes (TermBytes bs) = Just bs
+unwrapBytes (TermBytesI bss) = Just . LBS.toStrict $ mconcat bss
+unwrapBytes _ = Nothing
+
+unwrapString :: CBORTerm -> Maybe Text
+unwrapString (TermString t) = Just t
+unwrapString (TermStringI ts) = Just . LT.toStrict $ mconcat ts
+unwrapString _ = Nothing
+
+unwrapArray :: CBORTerm -> Maybe [CBORTerm]
+unwrapArray (TermArray xs) = Just xs
+unwrapArray (TermArrayI xs) = Just xs
+unwrapArray _ = Nothing
+
+unwrapMap :: CBORTerm -> Maybe [(CBORTerm, CBORTerm)]
+unwrapMap (TermMap kvs) = Just kvs
+unwrapMap (TermMapI kvs) = Just kvs
+unwrapMap _ = Nothing
 
 -- Bounds
 

--- a/src/Codec/CBOR/Cuddle/CBOR/Term.hs
+++ b/src/Codec/CBOR/Cuddle/CBOR/Term.hs
@@ -37,21 +37,15 @@ module Codec.CBOR.Cuddle.CBOR.Term (
   optimalWidth,
   genValidWidth,
   textArg,
-
-  -- * NInt
-  NInt,
-  toNInt,
-  fromNInt,
   nintArg,
 
   -- * Utils
   bytesToUnsigned,
   unsignedToBytes,
-  uintMax,
-  nintMin,
 ) where
 
-import Codec.CBOR.Cuddle.Comments (CollectComments)
+import Codec.CBOR.Cuddle.CBOR.NInt (NInt, toWord64Raw)
+import Codec.CBOR.Cuddle.CBOR.NInt qualified as NInt
 import Codec.CBOR.Decoding (
   ByteOffset,
   Decoder,
@@ -88,12 +82,10 @@ import Codec.CBOR.Encoding (
   encodeStringIndef,
  )
 import Control.Monad (forM, replicateM)
-import Data.Bits (Bits (..), complement)
+import Data.Bits (Bits (..))
 import Data.ByteString (ByteString)
 import Data.ByteString qualified as BS
 import Data.ByteString.Lazy qualified as LBS
-import Data.Hashable (Hashable)
-import Data.Maybe (mapMaybe)
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Text.Encoding qualified as TE
@@ -116,29 +108,6 @@ import Test.QuickCheck (
  )
 import Test.QuickCheck.GenT (MonadGen (liftGen))
 import Prelude hiding (decodeFloat, encodeFloat)
-
--- | A negative integer in the range @[-2^64, -1]@: exactly the values
--- representable by CBOR major type 1 (RFC 8949 §3.1). The range is wider
--- than 'Int64' on the negative side, so it can't be stored as a plain
--- signed integer.
-newtype NInt = NInt Word64
-  deriving (Eq, Ord, Bounded, Hashable, CollectComments)
-
-instance Show NInt where
-  showsPrec p x =
-    showParen (p > 10) $ showString "toNInt " . showsPrec 11 (fromNInt x)
-
-instance Arbitrary NInt where
-  arbitrary = NInt <$> arbitrary
-  shrink = mapMaybe toNInt . shrink . fromNInt
-
-toNInt :: Integer -> Maybe NInt
-toNInt x
-  | x >= nintMin && x < 0 = Just . NInt . fromInteger $ x - nintMin
-  | otherwise = Nothing
-
-fromNInt :: NInt -> Integer
-fromNInt (NInt n) = nintMin + toInteger n
 
 data ArgWidth
   = InlineArg
@@ -168,16 +137,13 @@ optimalWidth i
 shrinkWidth :: Word64 -> ArgWidth -> [ArgWidth]
 shrinkWidth v w = [w' | w' <- [InlineArg ..], w' < w, isValidWidth v w']
 
--- | The wire argument of a major type 1 head encoding the value @v@ is
--- @-1 - v@ (RFC 8949 §3.1), which is the complement of the offset stored
--- in 'NInt'.
-nintArg :: NInt -> Word64
-nintArg (NInt n) = complement n
-
 -- | The length argument of a text string head counts UTF-8 bytes, not
 -- characters.
 textArg :: T.Text -> Word64
 textArg = fromIntegral . lengthWord8
+
+nintArg :: NInt -> Word64
+nintArg = toWord64Raw
 
 data CBORTerm
   = -- | Major type 0
@@ -485,7 +451,7 @@ decodeCBORTerm = do
       pure $ TermUInt' w v
     decodeNInt = do
       (w, v) <- decodeWithWidth decodeNegWord64
-      pure . TermNInt' w . NInt $ complement v
+      pure . TermNInt' w . NInt.fromWord64Raw $ v
     decodeTagged = do
       (w, tag) <- decodeWithWidth decodeTag64
       TermTag' w tag <$> decodeCBORTerm
@@ -597,11 +563,3 @@ unwrapMap :: CBORTerm -> Maybe [(CBORTerm, CBORTerm)]
 unwrapMap (TermMap' _ kvs) = Just kvs
 unwrapMap (TermMapI kvs) = Just kvs
 unwrapMap _ = Nothing
-
--- Bounds
-
-uintMax :: Integer
-uintMax = 2 ^ (64 :: Int) - 1
-
-nintMin :: Integer
-nintMin = -(2 ^ (64 :: Int))

--- a/src/Codec/CBOR/Cuddle/CBOR/Term.hs
+++ b/src/Codec/CBOR/Cuddle/CBOR/Term.hs
@@ -1,6 +1,7 @@
 module Codec.CBOR.Cuddle.CBOR.Term (
   CBORTerm (..),
   decodeCBORTerm,
+  encodeCBORTerm,
   NInt,
   toNInt,
   fromNInt,
@@ -28,6 +29,25 @@ import Codec.CBOR.Decoding (
   decodeWord64,
   peekTokenType,
  )
+import Codec.CBOR.Encoding (
+  Encoding,
+  encodeBreak,
+  encodeBytes,
+  encodeBytesIndef,
+  encodeDouble,
+  encodeFloat,
+  encodeFloat16,
+  encodeInteger,
+  encodeListLen,
+  encodeListLenIndef,
+  encodeMapLen,
+  encodeMapLenIndef,
+  encodeSimple,
+  encodeString,
+  encodeStringIndef,
+  encodeTag64,
+  encodeWord64,
+ )
 import Control.Monad (replicateM)
 import Data.Bits (complement)
 import Data.ByteString qualified as BS
@@ -35,9 +55,9 @@ import Data.ByteString.Lazy qualified as LBS
 import Data.Text qualified as T
 import Data.Text.Lazy qualified as LT
 import Data.Word (Word64, Word8)
-import Numeric.Half (Half, toHalf)
+import Numeric.Half (Half, fromHalf, toHalf)
 import Test.QuickCheck (Arbitrary (..))
-import Prelude hiding (decodeFloat)
+import Prelude hiding (decodeFloat, encodeFloat)
 
 -- | A negative integer in the range @[-2^64, -1]@: exactly the values
 -- representable by CBOR major type 1 (RFC 8949 §3.1). The range is wider
@@ -158,6 +178,42 @@ decodeChunks dec = go
     go = do
       done <- decodeBreakOr
       if done then pure [] else (:) <$> dec <*> go
+
+-- | Encode a term back to CBOR. Integer, length and tag arguments are
+-- emitted with minimal width, so @encodeCBORTerm@ after 'decodeCBORTerm'
+-- reproduces the input bytes only if the input used minimal-width
+-- arguments; the definite\/indefinite structure is always preserved.
+encodeCBORTerm :: CBORTerm -> Encoding
+encodeCBORTerm term = case term of
+  TermUInt w -> encodeWord64 w
+  -- For values in @[-2^64, -1]@ 'encodeInteger' always emits major type 1
+  -- with argument @-1 - n@, never a bignum.
+  TermNInt n -> encodeInteger $ fromNInt n
+  TermBytes bs -> encodeBytes bs
+  TermBytesI chunks ->
+    encodeBytesIndef
+      <> foldMap (encodeBytes . LBS.toStrict) chunks
+      <> encodeBreak
+  TermString s -> encodeString s
+  TermStringI chunks ->
+    encodeStringIndef
+      <> foldMap (encodeString . LT.toStrict) chunks
+      <> encodeBreak
+  TermArray ts ->
+    encodeListLen (fromIntegral $ length ts) <> foldMap encodeCBORTerm ts
+  TermArrayI ts ->
+    encodeListLenIndef <> foldMap encodeCBORTerm ts <> encodeBreak
+  TermMap kvs ->
+    encodeMapLen (fromIntegral $ length kvs) <> foldMap encodeKeyValue kvs
+  TermMapI kvs ->
+    encodeMapLenIndef <> foldMap encodeKeyValue kvs <> encodeBreak
+  TermTag tag t -> encodeTag64 tag <> encodeCBORTerm t
+  TermSimple w -> encodeSimple w
+  TermHalf h -> encodeFloat16 $ fromHalf h
+  TermFloat f -> encodeFloat f
+  TermDouble d -> encodeDouble d
+  where
+    encodeKeyValue (k, v) = encodeCBORTerm k <> encodeCBORTerm v
 
 -- Bounds
 

--- a/src/Codec/CBOR/Cuddle/CBOR/Term.hs
+++ b/src/Codec/CBOR/Cuddle/CBOR/Term.hs
@@ -1,0 +1,168 @@
+module Codec.CBOR.Cuddle.CBOR.Term (
+  CBORTerm (..),
+  decodeCBORTerm,
+  NInt,
+  toNInt,
+  fromNInt,
+  uintMax,
+  nintMin,
+) where
+
+import Codec.CBOR.Decoding (
+  Decoder,
+  TokenType (..),
+  decodeBreakOr,
+  decodeBytes,
+  decodeBytesIndef,
+  decodeDouble,
+  decodeFloat,
+  decodeListLen,
+  decodeListLenIndef,
+  decodeMapLen,
+  decodeMapLenIndef,
+  decodeNegWord64,
+  decodeSimple,
+  decodeString,
+  decodeStringIndef,
+  decodeTag64,
+  decodeWord64,
+  peekTokenType,
+ )
+import Control.Monad (replicateM)
+import Data.Bits (complement)
+import Data.ByteString qualified as BS
+import Data.ByteString.Lazy qualified as LBS
+import Data.Text qualified as T
+import Data.Text.Lazy qualified as LT
+import Data.Word (Word64, Word8)
+import Numeric.Half (Half, toHalf)
+import Test.QuickCheck (Arbitrary (..))
+import Prelude hiding (decodeFloat)
+
+-- | A negative integer in the range @[-2^64, -1]@: exactly the values
+-- representable by CBOR major type 1 (RFC 8949 §3.1). The range is wider
+-- than 'Int64' on the negative side, so it can't be stored as a plain
+-- signed integer.
+newtype NInt = NInt Word64
+  deriving (Eq, Ord, Bounded)
+
+instance Show NInt where
+  showsPrec p x =
+    showParen (p > 10) $ showString "toNInt " . showsPrec 11 (fromNInt x)
+
+instance Arbitrary NInt where
+  arbitrary = NInt <$> arbitrary
+
+toNInt :: Integer -> Maybe NInt
+toNInt x
+  | x >= nintMin && x < 0 = Just . NInt . fromInteger $ x - nintMin
+  | otherwise = Nothing
+
+fromNInt :: NInt -> Integer
+fromNInt (NInt n) = nintMin + toInteger n
+
+data CBORTerm
+  = -- | Major type 0
+    TermUInt Word64
+  | -- | Major type 1
+    TermNInt NInt
+  | -- | Major type 2 (definite)
+    TermBytes BS.ByteString
+  | -- | Major type 2 (indefinite)
+    TermBytesI [LBS.ByteString]
+  | -- | Major type 3 (definite)
+    TermString T.Text
+  | -- | Major type 3 (indefinite)
+    TermStringI [LT.Text]
+  | -- | Major type 4 (definite)
+    TermArray [CBORTerm]
+  | -- | Major type 4 (indefinite)
+    TermArrayI [CBORTerm]
+  | -- | Major type 5 (definite)
+    TermMap [(CBORTerm, CBORTerm)]
+  | -- | Major type 5 (indefinite)
+    TermMapI [(CBORTerm, CBORTerm)]
+  | -- | Major type 6
+    TermTag Word64 CBORTerm
+  | -- | Major type 7 (0..24)
+    TermSimple Word8
+  | -- | Major type 7 (25)
+    TermHalf Half
+  | -- | Major type 7 (26)
+    TermFloat Float
+  | -- | Major type 7 (27)
+    TermDouble Double
+  deriving (Eq, Show)
+
+decodeCBORTerm :: Decoder s CBORTerm
+decodeCBORTerm = do
+  tokType <- peekTokenType
+  case tokType of
+    TypeUInt -> TermUInt <$> decodeWord64
+    TypeUInt64 -> TermUInt <$> decodeWord64
+    -- 'decodeNegWord64' yields the argument @n@ of the wire encoding, which
+    -- denotes the value @-1 - n@, i.e. @nintMin + complement n@.
+    TypeNInt -> TermNInt . NInt . complement <$> decodeNegWord64
+    TypeNInt64 -> TermNInt . NInt . complement <$> decodeNegWord64
+    -- 'peekTokenType' classifies tags 2 and 3 (bignums) as 'TypeInteger'
+    -- so that 'Integer' decoders know to take the bignum path. We want the
+    -- uninterpreted term, and 'decodeTag64' accepts these headers like any
+    -- other tag.
+    TypeInteger -> decodeTagged
+    -- Half NaNs with non-canonical payloads may not survive the round-trip
+    -- through 'Float': cborg only exposes the half as a widened 'Float'.
+    TypeFloat16 -> TermHalf . toHalf <$> decodeFloat
+    TypeFloat32 -> TermFloat <$> decodeFloat
+    TypeFloat64 -> TermDouble <$> decodeDouble
+    TypeBytes -> TermBytes <$> decodeBytes
+    TypeBytesIndef ->
+      decodeBytesIndef
+        >> TermBytesI <$> decodeChunks (LBS.fromStrict <$> decodeBytes)
+    TypeString -> TermString <$> decodeString
+    TypeStringIndef ->
+      decodeStringIndef
+        >> TermStringI <$> decodeChunks (LT.fromStrict <$> decodeString)
+    TypeListLen -> decodeArray
+    TypeListLen64 -> decodeArray
+    TypeListLenIndef ->
+      decodeListLenIndef >> TermArrayI <$> decodeChunks decodeCBORTerm
+    TypeMapLen -> decodeMap
+    TypeMapLen64 -> decodeMap
+    TypeMapLenIndef ->
+      decodeMapLenIndef >> TermMapI <$> decodeChunks decodeKeyValue
+    TypeTag -> decodeTagged
+    TypeTag64 -> decodeTagged
+    -- Bools, null and undefined are simple values like any other;
+    -- 'decodeSimple' accepts the whole simple range.
+    TypeBool -> TermSimple <$> decodeSimple
+    TypeNull -> TermSimple <$> decodeSimple
+    TypeSimple -> TermSimple <$> decodeSimple
+    TypeBreak -> fail "decodeCBORTerm: unexpected break"
+    TypeInvalid -> fail "decodeCBORTerm: invalid token"
+  where
+    decodeTagged = do
+      tag <- decodeTag64
+      TermTag tag <$> decodeCBORTerm
+    decodeArray = do
+      n <- decodeListLen
+      TermArray <$> replicateM n decodeCBORTerm
+    decodeMap = do
+      n <- decodeMapLen
+      TermMap <$> replicateM n decodeKeyValue
+    decodeKeyValue = (,) <$> decodeCBORTerm <*> decodeCBORTerm
+
+-- | Decode items with @dec@ until hitting (and consuming) a break stop code.
+decodeChunks :: Decoder s a -> Decoder s [a]
+decodeChunks dec = go
+  where
+    go = do
+      done <- decodeBreakOr
+      if done then pure [] else (:) <$> dec <*> go
+
+-- Bounds
+
+uintMax :: Integer
+uintMax = 2 ^ (64 :: Int) - 1
+
+nintMin :: Integer
+nintMin = -(2 ^ (64 :: Int))

--- a/src/Codec/CBOR/Cuddle/CBOR/Term.hs
+++ b/src/Codec/CBOR/Cuddle/CBOR/Term.hs
@@ -36,6 +36,7 @@ module Codec.CBOR.Cuddle.CBOR.Term (
   isValidWidth,
   optimalWidth,
   genValidWidth,
+  textArg,
 
   -- * NInt
   NInt,
@@ -98,7 +99,7 @@ import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Text.Encoding qualified as TE
 import Data.Text.Lazy qualified as LT
-import Data.Text.Lazy.Encoding qualified as LTE
+import Data.Text.Unsafe (lengthWord8)
 import Data.Word (Word64, Word8)
 import GHC.Generics (Generic)
 import Numeric.Half (Half, fromHalf, toHalf)
@@ -177,10 +178,7 @@ nintArg (NInt n) = complement n
 -- | The length argument of a text string head counts UTF-8 bytes, not
 -- characters.
 textArg :: T.Text -> Word64
-textArg = fromIntegral . BS.length . TE.encodeUtf8
-
-lazyTextArg :: LT.Text -> Word64
-lazyTextArg = fromIntegral . LBS.length . LTE.encodeUtf8
+textArg = fromIntegral . lengthWord8
 
 data CBORTerm
   = -- | Major type 0
@@ -276,7 +274,7 @@ mkTermString :: T.Text -> CBORTerm
 mkTermString t = TermString' (optimalWidth $ textArg t) t
 
 mkTermStringI :: [LT.Text] -> CBORTerm
-mkTermStringI ts = TermStringI' $ (\t -> (optimalWidth $ lazyTextArg t, t)) <$> ts
+mkTermStringI ts = TermStringI' $ (\t -> (optimalWidth . textArg $ LT.toStrict t, t)) <$> ts
 
 mkTermArray :: [CBORTerm] -> CBORTerm
 mkTermArray es = TermArray' (optimalWidth . fromIntegral $ length es) es
@@ -326,7 +324,7 @@ instance Arbitrary CBORTerm where
           , do
               tss <- listOf $ LT.pack <$> arbitrary
               tsw <- forM tss $ \t -> do
-                w <- genValidWidth $ lazyTextArg t
+                w <- genValidWidth . textArg $ LT.toStrict t
                 pure (w, t)
               pure $ TermStringI' tsw
           , TermSimple <$> arbitrary
@@ -404,7 +402,7 @@ instance Arbitrary CBORTerm where
         [(w', c) | w' <- shrinkWidth (fromIntegral $ LBS.length c) w]
           <> [(w, LBS.pack c') | c' <- shrink (LBS.unpack c)]
       shrinkStringChunk (w, c) =
-        [(w', c) | w' <- shrinkWidth (lazyTextArg c) w]
+        [(w', c) | w' <- shrinkWidth (textArg $ LT.toStrict c) w]
           <> [(w, LT.pack c') | c' <- shrink (LT.unpack c)]
 
 widthFromOffset :: ByteOffset -> ArgWidth

--- a/src/Codec/CBOR/Cuddle/CBOR/Term.hs
+++ b/src/Codec/CBOR/Cuddle/CBOR/Term.hs
@@ -91,7 +91,6 @@ import Control.Monad (forM, replicateM)
 import Data.Bits (Bits (..), complement)
 import Data.ByteString (ByteString)
 import Data.ByteString qualified as BS
-import Data.ByteString.Builder qualified as B
 import Data.ByteString.Lazy qualified as LBS
 import Data.Hashable (Hashable)
 import Data.Maybe (mapMaybe)
@@ -522,18 +521,17 @@ argWidthMask = \case
 
 encodeRawDataItem :: MajorType -> ArgWidth -> Word64 -> Encoding
 encodeRawDataItem major width arg
-  | isValidWidth arg width =
-      encodePreEncoded . LBS.toStrict . B.toLazyByteString $
-        B.word8 headerByte <> payload
+  | isValidWidth arg width = encodePreEncoded . BS.pack $ headerByte : argBytes
   | otherwise = error $ "Argument is too large to be encoded as " <> show width <> ": " <> show arg
   where
     headerByte = majorTypeMask major .|. argWidthMask width .|. inlineArgMask
-    payload = case width of
+    argBytes = case width of
       InlineArg -> mempty
-      OneByteArg -> B.word8 $ fromIntegral arg
-      TwoByteArg -> B.word16BE $ fromIntegral arg
-      FourByteArg -> B.word32BE $ fromIntegral arg
-      EightByteArg -> B.word64BE arg
+      OneByteArg -> beBytes 1
+      TwoByteArg -> beBytes 2
+      FourByteArg -> beBytes 4
+      EightByteArg -> beBytes 8
+    beBytes n = [fromIntegral (arg `shiftR` (8 * i)) | i <- [n - 1, n - 2 .. 0]]
     inlineArgMask
       | InlineArg <- width = fromIntegral arg
       | otherwise = 0x00

--- a/src/Codec/CBOR/Cuddle/CBOR/Term.hs
+++ b/src/Codec/CBOR/Cuddle/CBOR/Term.hs
@@ -98,7 +98,7 @@ isValidWidth i = \case
   OneByteArg -> i <= 0xff
   TwoByteArg -> i <= 0xff_ff
   FourByteArg -> i <= 0xff_ff_ff_ff
-  EightByteArg -> i <= 0xff_ff_ff_ff_ff_ff_ff_ff
+  EightByteArg -> True
 
 optimalWidth :: Word64 -> ArgWidth
 optimalWidth i

--- a/src/Codec/CBOR/Cuddle/CBOR/Term.hs
+++ b/src/Codec/CBOR/Cuddle/CBOR/Term.hs
@@ -5,10 +5,13 @@ module Codec.CBOR.Cuddle.CBOR.Term (
   NInt,
   toNInt,
   fromNInt,
+  bytesToUnsigned,
+  unsignedToBytes,
   uintMax,
   nintMin,
 ) where
 
+import Codec.CBOR.Cuddle.Comments (CollectComments)
 import Codec.CBOR.Decoding (
   Decoder,
   TokenType (..),
@@ -50,12 +53,15 @@ import Codec.CBOR.Encoding (
  )
 import Control.Monad (replicateM)
 import Data.Bits (complement)
+import Data.ByteString (ByteString)
 import Data.ByteString qualified as BS
 import Data.ByteString.Lazy qualified as LBS
+import Data.Hashable (Hashable)
 import Data.Maybe (mapMaybe)
 import Data.Text qualified as T
 import Data.Text.Lazy qualified as LT
 import Data.Word (Word64, Word8)
+import GHC.Generics (Generic)
 import Numeric.Half (Half, fromHalf, toHalf)
 import Test.QuickCheck (
   Arbitrary (..),
@@ -73,7 +79,7 @@ import Prelude hiding (decodeFloat, encodeFloat)
 -- than 'Int64' on the negative side, so it can't be stored as a plain
 -- signed integer.
 newtype NInt = NInt Word64
-  deriving (Eq, Ord, Bounded)
+  deriving (Eq, Ord, Bounded, Hashable, CollectComments)
 
 instance Show NInt where
   showsPrec p x =
@@ -122,7 +128,7 @@ data CBORTerm
     TermFloat Float
   | -- | Major type 7 (27)
     TermDouble Double
-  deriving (Eq, Show)
+  deriving (Generic, Eq, Ord, Show)
 
 -- | Floats never include NaN: the many NaN bit patterns don't survive
 -- round-trips through 'Float' (see 'decodeCBORTerm') and compare unequal
@@ -285,6 +291,15 @@ encodeCBORTerm term = case term of
   TermDouble d -> encodeDouble d
   where
     encodeKeyValue (k, v) = encodeCBORTerm k <> encodeCBORTerm v
+
+bytesToUnsigned :: ByteString -> Integer
+bytesToUnsigned = BS.foldl' (\acc b -> acc * 256 + toInteger b) 0
+
+unsignedToBytes :: Integer -> ByteString
+unsignedToBytes = BS.pack . reverse . go
+  where
+    go 0 = []
+    go n = let (d, r) = divMod n 256 in fromInteger r : go d
 
 -- Bounds
 

--- a/src/Codec/CBOR/Cuddle/CBOR/Term.hs
+++ b/src/Codec/CBOR/Cuddle/CBOR/Term.hs
@@ -46,41 +46,8 @@ module Codec.CBOR.Cuddle.CBOR.Term (
 
 import Codec.CBOR.Cuddle.CBOR.NInt (NInt, toWord64Raw)
 import Codec.CBOR.Cuddle.CBOR.NInt qualified as NInt
-import Codec.CBOR.Decoding (
-  ByteOffset,
-  Decoder,
-  TokenType (..),
-  decodeBreakOr,
-  decodeBytes,
-  decodeBytesIndef,
-  decodeDouble,
-  decodeFloat,
-  decodeListLen,
-  decodeListLenIndef,
-  decodeMapLen,
-  decodeMapLenIndef,
-  decodeNegWord64,
-  decodeSimple,
-  decodeString,
-  decodeStringIndef,
-  decodeTag64,
-  decodeWord64,
-  peekByteOffset,
-  peekTokenType,
- )
-import Codec.CBOR.Encoding (
-  Encoding,
-  encodeBreak,
-  encodeBytesIndef,
-  encodeDouble,
-  encodeFloat,
-  encodeFloat16,
-  encodeListLenIndef,
-  encodeMapLenIndef,
-  encodePreEncoded,
-  encodeSimple,
-  encodeStringIndef,
- )
+import Codec.CBOR.Decoding
+import Codec.CBOR.Encoding
 import Control.Monad (forM, replicateM)
 import Data.Bits (Bits (..))
 import Data.ByteString (ByteString)

--- a/src/Codec/CBOR/Cuddle/CBOR/Term.hs
+++ b/src/Codec/CBOR/Cuddle/CBOR/Term.hs
@@ -117,6 +117,8 @@ shrinkWidth v w = [w' | w' <- [InlineArg ..], w' < w, isValidWidth v w']
 textArg :: T.Text -> Word64
 textArg = fromIntegral . lengthWord8
 
+-- | The wire argument of the major type 1 head encoding this value:
+-- @-1 - v@ (RFC 8949 §3.1).
 nintArg :: NInt -> Word64
 nintArg = toWord64Raw
 
@@ -374,7 +376,7 @@ decodeCBORTerm = do
     TypeUInt -> decodeUInt
     TypeUInt64 -> decodeUInt
     -- 'decodeNegWord64' yields the argument @n@ of the wire encoding, which
-    -- denotes the value @-1 - n@, i.e. @nintMin + complement n@.
+    -- denotes the value @-1 - n@: exactly the raw word 'NInt' stores.
     TypeNInt -> decodeNInt
     TypeNInt64 -> decodeNInt
     -- 'peekTokenType' classifies tags 2 and 3 (bignums) as 'TypeInteger'
@@ -475,10 +477,12 @@ encodeRawDataItem major width arg
       | InlineArg <- width = fromIntegral arg
       | otherwise = 0x00
 
--- | Encode a term back to CBOR. Integer, length and tag arguments are
--- emitted with minimal width, so @encodeCBORTerm@ after 'decodeCBORTerm'
--- reproduces the input bytes only if the input used minimal-width
--- arguments; the definite\/indefinite structure is always preserved.
+-- | Encode a term back to CBOR. Every argument is emitted at the width
+-- recorded in the term (an 'error' if the argument does not fit it), so
+-- @encodeCBORTerm@ after 'decodeCBORTerm' reproduces the input bytes
+-- exactly, with one exception: a float16 NaN with a non-canonical payload
+-- may re-encode differently, since cborg only exposes halves as a widened
+-- 'Float' (see 'decodeCBORTerm').
 encodeCBORTerm :: CBORTerm -> Encoding
 encodeCBORTerm term = case term of
   TermUInt' w v -> encodeRawDataItem M0 w v

--- a/src/Codec/CBOR/Cuddle/CBOR/Term.hs
+++ b/src/Codec/CBOR/Cuddle/CBOR/Term.hs
@@ -440,11 +440,9 @@ decodeCBORTerm = do
 
 -- | Decode items with @dec@ until hitting (and consuming) a break stop code.
 decodeChunks :: Decoder s a -> Decoder s [a]
-decodeChunks dec = go
-  where
-    go = do
-      done <- decodeBreakOr
-      if done then pure [] else (:) <$> dec <*> go
+decodeChunks dec = do
+  done <- decodeBreakOr
+  if done then pure [] else (:) <$> dec <*> decodeChunks dec
 
 data MajorType = M0 | M1 | M2 | M3 | M4 | M5 | M6 | M7
   deriving (Enum, Eq, Ord, Show)

--- a/src/Codec/CBOR/Cuddle/CBOR/Term.hs
+++ b/src/Codec/CBOR/Cuddle/CBOR/Term.hs
@@ -15,6 +15,16 @@ module Codec.CBOR.Cuddle.CBOR.Term (
     TermMap,
     TermTag
   ),
+
+  -- * Argument width
+  ArgWidth (..),
+  isValidWidth,
+  optimalWidth,
+  genValidWidth,
+  textArg,
+  nintArg,
+
+  -- * Construction
   mkTermUInt,
   mkTermNInt,
   mkTermBytes,
@@ -24,20 +34,18 @@ module Codec.CBOR.Cuddle.CBOR.Term (
   mkTermArray,
   mkTermMap,
   mkTermTag,
+
+  -- * Encoding-agnostic unwrapping
   unwrapBytes,
   unwrapString,
   unwrapArray,
   unwrapMap,
-  decodeCBORTerm,
+
+  -- * Encoding
   encodeCBORTerm,
 
-  -- * Argument width
-  ArgWidth (..),
-  isValidWidth,
-  optimalWidth,
-  genValidWidth,
-  textArg,
-  nintArg,
+  -- * Decoding
+  decodeCBORTerm,
 
   -- * Utils
   bytesToUnsigned,

--- a/src/Codec/CBOR/Cuddle/CBOR/Term.hs
+++ b/src/Codec/CBOR/Cuddle/CBOR/Term.hs
@@ -52,11 +52,20 @@ import Control.Monad (replicateM)
 import Data.Bits (complement)
 import Data.ByteString qualified as BS
 import Data.ByteString.Lazy qualified as LBS
+import Data.Maybe (mapMaybe)
 import Data.Text qualified as T
 import Data.Text.Lazy qualified as LT
 import Data.Word (Word64, Word8)
 import Numeric.Half (Half, fromHalf, toHalf)
-import Test.QuickCheck (Arbitrary (..))
+import Test.QuickCheck (
+  Arbitrary (..),
+  Gen,
+  chooseInt,
+  oneof,
+  sized,
+  suchThat,
+  vectorOf,
+ )
 import Prelude hiding (decodeFloat, encodeFloat)
 
 -- | A negative integer in the range @[-2^64, -1]@: exactly the values
@@ -72,6 +81,7 @@ instance Show NInt where
 
 instance Arbitrary NInt where
   arbitrary = NInt <$> arbitrary
+  shrink = mapMaybe toNInt . shrink . fromNInt
 
 toNInt :: Integer -> Maybe NInt
 toNInt x
@@ -113,6 +123,67 @@ data CBORTerm
   | -- | Major type 7 (27)
     TermDouble Double
   deriving (Eq, Show)
+
+-- | Floats never include NaN: the many NaN bit patterns don't survive
+-- round-trips through 'Float' (see 'decodeCBORTerm') and compare unequal
+-- to themselves anyway.
+instance Arbitrary CBORTerm where
+  arbitrary = sized genTerm
+    where
+      genTerm :: Int -> Gen CBORTerm
+      genTerm n
+        | n <= 0 = leaf
+        | otherwise = oneof [leaf, branch]
+        where
+          leaf =
+            oneof
+              [ TermUInt <$> arbitrary
+              , TermNInt <$> arbitrary
+              , TermBytes . BS.pack <$> arbitrary
+              , TermBytesI . fmap LBS.pack <$> arbitrary
+              , TermString . T.pack <$> arbitrary
+              , TermStringI . fmap LT.pack <$> arbitrary
+              , TermSimple <$> arbitrary
+              , TermHalf . toHalf <$> nonNaN
+              , TermFloat <$> nonNaN
+              , TermDouble <$> nonNaN
+              ]
+          nonNaN :: (RealFloat a, Arbitrary a) => Gen a
+          nonNaN = arbitrary `suchThat` (not . isNaN)
+          branch =
+            oneof
+              [ TermArray <$> subterms
+              , TermArrayI <$> subterms
+              , TermMap <$> subpairs
+              , TermMapI <$> subpairs
+              , TermTag <$> arbitrary <*> genTerm (n - 1)
+              ]
+          subterms = do
+            k <- chooseInt (0, 5)
+            vectorOf k . genTerm $ n `div` (k + 1)
+          subpairs = do
+            k <- chooseInt (0, 5)
+            let sub = genTerm $ n `div` (2 * k + 1)
+            vectorOf k $ (,) <$> sub <*> sub
+
+  shrink term = case term of
+    TermUInt w -> TermUInt <$> shrink w
+    TermNInt n -> TermNInt <$> shrink n
+    TermBytes bs -> TermBytes . BS.pack <$> shrink (BS.unpack bs)
+    TermBytesI chunks -> TermBytesI . fmap LBS.pack <$> shrink (LBS.unpack <$> chunks)
+    TermString s -> TermString . T.pack <$> shrink (T.unpack s)
+    TermStringI chunks -> TermStringI . fmap LT.pack <$> shrink (LT.unpack <$> chunks)
+    TermArray ts -> ts <> (TermArray <$> shrink ts)
+    TermArrayI ts -> ts <> (TermArrayI <$> shrink ts)
+    TermMap kvs -> subterms kvs <> (TermMap <$> shrink kvs)
+    TermMapI kvs -> subterms kvs <> (TermMapI <$> shrink kvs)
+    TermTag tag t -> t : (TermTag <$> shrink tag <*> pure t) <> (TermTag tag <$> shrink t)
+    TermSimple w -> TermSimple <$> shrink w
+    TermHalf _ -> []
+    TermFloat f -> TermFloat <$> shrink f
+    TermDouble d -> TermDouble <$> shrink d
+    where
+      subterms = concatMap $ \(k, v) -> [k, v]
 
 decodeCBORTerm :: Decoder s CBORTerm
 decodeCBORTerm = do

--- a/src/Codec/CBOR/Cuddle/CBOR/Validator.hs
+++ b/src/Codec/CBOR/Cuddle/CBOR/Validator.hs
@@ -18,6 +18,13 @@ import Codec.CBOR.Cuddle.CBOR.Term (
   bytesToUnsigned,
   decodeCBORTerm,
   fromNInt,
+  mkTermArray,
+  mkTermBytes,
+  mkTermMap,
+  mkTermNInt,
+  mkTermString,
+  mkTermTag,
+  mkTermUInt,
   unwrapBytes,
  )
 import Codec.CBOR.Cuddle.CBOR.Validator.Trace (
@@ -197,7 +204,7 @@ validateUInt ::
 validateUInt cddl i rule =
   case rule of
     CTreeE (VRuleRef n) -> dereferenceAndValidate cddl n $ validateUInt cddl i
-    CTreeE (VValidator v _) -> runCustomValidator cddl (SingleTerm $ TermUInt i) v
+    CTreeE (VValidator v _) -> runCustomValidator cddl (SingleTerm $ mkTermUInt i) v
     Postlude PTAny -> terminal rule
     Postlude PTInt -> terminal rule
     Postlude PTUInt -> terminal rule
@@ -248,7 +255,7 @@ validateNInt ::
 validateNInt cddl i rule =
   case rule of
     CTreeE (VRuleRef n) -> dereferenceAndValidate cddl n $ validateNInt cddl i
-    CTreeE (VValidator v _) -> runCustomValidator cddl (SingleTerm $ TermNInt i) v
+    CTreeE (VValidator v _) -> runCustomValidator cddl (SingleTerm $ mkTermNInt i) v
     Postlude PTAny -> terminal rule
     Postlude PTInt -> terminal rule
     Postlude PTNInt -> terminal rule
@@ -558,7 +565,7 @@ validateBytes ::
   CTreeRoot ValidatorPhase -> BS.ByteString -> CTree ValidatorPhase -> Evidenced ValidationTrace
 validateBytes cddl bs (CTreeE (VRuleRef n)) =
   dereferenceAndValidate cddl n $ validateBytes cddl bs
-validateBytes cddl bs (CTreeE (VValidator v _)) = runCustomValidator cddl (SingleTerm $ TermBytes bs) v
+validateBytes cddl bs (CTreeE (VValidator v _)) = runCustomValidator cddl (SingleTerm $ mkTermBytes bs) v
 validateBytes cddl bs rule =
   case rule of
     -- a = any
@@ -622,7 +629,7 @@ controlBytes cddl bs Cbor ctrl =
     _ -> False
 controlBytes cddl bs Cborseq ctrl =
   case deserialiseFromBytes decodeCBORTerm (BSL.fromStrict (BS.snoc (BS.cons 0x9f bs) 0xff)) of
-    Right (BSL.null -> True, TermArrayI terms) -> isValid $ validateTerm cddl (TermArray terms) (Array [Occur ctrl OIZeroOrMore])
+    Right (BSL.null -> True, TermArrayI terms) -> isValid $ validateTerm cddl (mkTermArray terms) (Array [Occur ctrl OIZeroOrMore])
     _ -> False
 controlBytes _ _ op _ = error $ "Not yet implmented for bytes: " <> show op
 
@@ -637,7 +644,7 @@ validateText ::
   Evidenced ValidationTrace
 validateText cddl txt (CTreeE (VRuleRef n)) =
   dereferenceAndValidate cddl n $ validateText cddl txt
-validateText cddl txt (CTreeE (VValidator v _)) = runCustomValidator cddl (SingleTerm $ TermString txt) v
+validateText cddl txt (CTreeE (VValidator v _)) = runCustomValidator cddl (SingleTerm $ mkTermString txt) v
 validateText cddl txt rule =
   case rule of
     -- a = any
@@ -689,7 +696,7 @@ validateTagged ::
   CTreeRoot ValidatorPhase -> Word64 -> CBORTerm -> CTree ValidatorPhase -> Evidenced ValidationTrace
 validateTagged cddl tag term (CTreeE (VRuleRef n)) =
   dereferenceAndValidate cddl n $ validateTagged cddl tag term
-validateTagged cddl tag term (CTreeE (VValidator v _)) = runCustomValidator cddl (SingleTerm $ TermTag tag term) v
+validateTagged cddl tag term (CTreeE (VValidator v _)) = runCustomValidator cddl (SingleTerm $ mkTermTag tag term) v
 validateTagged cddl tag term rule =
   case rule of
     Postlude PTAny -> terminal rule
@@ -758,7 +765,7 @@ validateList ::
   Evidenced ValidationTrace
 validateList cddl terms (CTreeE (VRuleRef n)) =
   dereferenceAndValidate cddl n $ validateList cddl terms
-validateList cddl terms (CTreeE (VValidator v _)) = runCustomValidator cddl (SingleTerm $ TermArray terms) v
+validateList cddl terms (CTreeE (VValidator v _)) = runCustomValidator cddl (SingleTerm $ mkTermArray terms) v
 validateList cddl terms rule =
   case rule of
     Postlude PTAny -> terminal rule
@@ -850,7 +857,7 @@ validateMap ::
   Evidenced ValidationTrace
 validateMap cddl terms (CTreeE (VRuleRef n)) =
   dereferenceAndValidate cddl n $ validateMap cddl terms
-validateMap cddl terms (CTreeE (VValidator v _)) = runCustomValidator cddl (SingleTerm $ TermMap terms) v
+validateMap cddl terms (CTreeE (VValidator v _)) = runCustomValidator cddl (SingleTerm $ mkTermMap terms) v
 validateMap cddl terms rule =
   case rule of
     Postlude PTAny -> terminal rule

--- a/src/Codec/CBOR/Cuddle/CBOR/Validator.hs
+++ b/src/Codec/CBOR/Cuddle/CBOR/Validator.hs
@@ -67,7 +67,6 @@ import Data.Text qualified as T
 import Data.Text.Encoding (encodeUtf8)
 import Data.Text.Lazy qualified as TL
 import Data.Word
-import GHC.Float
 import GHC.Stack (HasCallStack)
 import Numeric.Half (Half)
 import Text.Regex.TDFA
@@ -320,42 +319,24 @@ controlInteger cddl i Bits ctrl = do
       let bitSet = testBit n 0
           allowed = not bitSet || IS.member idx indices
        in allowed && go indices (shiftR n 1) (idx + 1)
-controlInteger _ i Lt ctrl =
-  case ctrl of
-    Literal (Value (VUInt i') _) -> i < toInteger i'
-    Literal (Value (VNInt i') _) -> i < fromNInt i'
-    Literal (Value (VBignum i') _) -> i < i'
-    _ -> False
-controlInteger _ i Gt ctrl =
-  case ctrl of
-    Literal (Value (VUInt i') _) -> i > fromIntegral i'
-    Literal (Value (VNInt i') _) -> i > fromNInt i'
-    Literal (Value (VBignum i') _) -> i > i'
-    _ -> False
-controlInteger _ i Le ctrl =
-  case ctrl of
-    Literal (Value (VUInt i') _) -> i <= fromIntegral i'
-    Literal (Value (VNInt i') _) -> i <= fromNInt i'
-    Literal (Value (VBignum i') _) -> i <= i'
-    _ -> False
-controlInteger _ i Ge ctrl =
-  case ctrl of
-    Literal (Value (VUInt i') _) -> i >= fromIntegral i'
-    Literal (Value (VNInt i') _) -> i >= fromNInt i'
-    Literal (Value (VBignum i') _) -> i >= i'
-    _ -> False
-controlInteger _ i Eq ctrl =
-  case ctrl of
-    Literal (Value (VUInt i') _) -> i == fromIntegral i'
-    Literal (Value (VNInt i') _) -> i == fromNInt i'
-    Literal (Value (VBignum i') _) -> i == i'
-    _ -> False
-controlInteger _ i Ne ctrl =
-  case ctrl of
-    Literal (Value (VUInt i') _) -> i /= fromIntegral i'
-    Literal (Value (VNInt i') _) -> i /= fromNInt i'
-    Literal (Value (VBignum i') _) -> i /= i'
-    _ -> False
+controlInteger _ i Lt ctrl
+  | Just i' <- unIntLiteral ctrl = i < i'
+  | otherwise = False
+controlInteger _ i Gt ctrl
+  | Just i' <- unIntLiteral ctrl = i > i'
+  | otherwise = False
+controlInteger _ i Le ctrl
+  | Just i' <- unIntLiteral ctrl = i <= i'
+  | otherwise = False
+controlInteger _ i Ge ctrl
+  | Just i' <- unIntLiteral ctrl = i >= i'
+  | otherwise = False
+controlInteger _ i Eq ctrl
+  | Just i' <- unIntLiteral ctrl = i == i'
+  | otherwise = False
+controlInteger _ i Ne ctrl
+  | Just i' <- unIntLiteral ctrl = i /= i'
+  | otherwise = False
 controlInteger _ _ _ ctrl = error $ "unexpected control: " <> showSimple ctrl
 
 --------------------------------------------------------------------------------
@@ -457,18 +438,12 @@ controlFloat ::
   Bool
 controlFloat cddl f op (CTreeE (VRuleRef n)) =
   controlFloat cddl f op $ dereference cddl n
-controlFloat _ f Eq ctrl =
-  case ctrl of
-    Literal (Value (VFloat16 f') _) -> f == realToFrac f'
-    Literal (Value (VFloat32 f') _) -> f == f'
-    Literal (Value (VFloat64 f') _) -> f == realToFrac f'
-    _ -> False
-controlFloat _ f Ne ctrl =
-  case ctrl of
-    Literal (Value (VFloat16 f') _) -> f /= realToFrac f'
-    Literal (Value (VFloat32 f') _) -> f /= f'
-    Literal (Value (VFloat64 f') _) -> f /= realToFrac f'
-    _ -> False
+controlFloat _ f Eq ctrl
+  | Just f' <- unFloatLiteral ctrl = realToFrac f == f'
+  | otherwise = False
+controlFloat _ f Ne ctrl
+  | Just f' <- unFloatLiteral ctrl = realToFrac f /= f'
+  | otherwise = False
 controlFloat _ _ op _ = error $ "Not yet implemented for float: " <> show op
 
 -- | Validating a `Float64`
@@ -500,11 +475,8 @@ validateDouble cddl f rule =
       dereferenceAndValidate cddl n $ \lo -> validateDouble cddl f . CRange $ Range lo high bound
     CRange (Range low (CTreeE (VRuleRef n)) bound) ->
       dereferenceAndValidate cddl n $ \hi -> validateDouble cddl f . CRange $ Range low hi bound
-    CRange (Range nv mv bound)
-      | Just n <- unFloatLiteral nv
-      , Just m <- unFloatLiteral mv
-      , f `isInRange` Range (realToFrac n) (realToFrac m) bound ->
-          terminal rule
+    CRange (Range (unFloatLiteral -> Just n) (unFloatLiteral -> Just m) bound)
+      | f `isInRange` Range (realToFrac n) (realToFrac m) bound -> terminal rule
     _ -> unapplicable rule
 
 -- | Controls for `Float64`
@@ -517,18 +489,12 @@ controlDouble ::
   Bool
 controlDouble cddl f op (CTreeE (VRuleRef n)) =
   controlDouble cddl f op $ dereference cddl n
-controlDouble _ f Eq ctrl =
-  case ctrl of
-    Literal (Value (VFloat16 f') _) -> f == realToFrac f'
-    Literal (Value (VFloat32 f') _) -> f == float2Double f'
-    Literal (Value (VFloat64 f') _) -> f == f'
-    _ -> False
-controlDouble _ f Ne ctrl =
-  case ctrl of
-    Literal (Value (VFloat16 f') _) -> f /= realToFrac f'
-    Literal (Value (VFloat32 f') _) -> f /= float2Double f'
-    Literal (Value (VFloat64 f') _) -> f /= f'
-    _ -> False
+controlDouble _ f Eq ctrl
+  | Just f' <- unFloatLiteral ctrl = f == f'
+  | otherwise = False
+controlDouble _ f Ne ctrl
+  | Just f' <- unFloatLiteral ctrl = f /= f'
+  | otherwise = False
 controlDouble _ _ op _ = error $ "Not yet implmented for double: " <> show op
 
 --------------------------------------------------------------------------------
@@ -624,16 +590,9 @@ controlBytes cddl bs op@Size ctrl =
       dereference cddl n & \lo -> controlBytes cddl bs op . CRange $ Range lo high bound
     CRange (Range low (CTreeE (VRuleRef n)) bound) ->
       dereference cddl n & \hi -> controlBytes cddl bs op . CRange $ Range low hi bound
-    CRange (Range low high bound) ->
+    CRange (Range (unIntLiteral -> Just n) (unIntLiteral -> Just m) bound) ->
       let i = toInteger $ BS.length bs
-       in case (low, high) of
-            (Literal (Value (VUInt (toInteger -> n)) _), Literal (Value (VUInt (toInteger -> m)) _)) ->
-              boundPlacement i (Just n, Just m) bound == WithinBounds
-            (Literal (Value (VNInt (fromNInt -> n)) _), Literal (Value (VUInt (toInteger -> m)) _)) ->
-              boundPlacement i (Just $ -n, Just m) bound == WithinBounds
-            (Literal (Value (VNInt (fromNInt -> n)) _), Literal (Value (VNInt (fromNInt -> m)) _)) ->
-              boundPlacement i (Just $ -n, Just $ -m) bound == WithinBounds
-            _ -> False
+       in boundPlacement i (Just n, Just m) bound == WithinBounds
     _ -> False
 controlBytes cddl bs Bits ctrl = do
   let
@@ -711,15 +670,8 @@ controlText cddl bs op@Size ctrl =
           dereference cddl n & \lo -> controlText cddl bs op . CRange $ Range lo high bound
         CRange (Range low (CTreeE (VRuleRef n)) bound) ->
           dereference cddl n & \hi -> controlText cddl bs op . CRange $ Range low hi bound
-        CRange (Range ff tt bound) ->
-          case (ff, tt) of
-            (Literal (Value (VUInt (toInteger -> n)) _), Literal (Value (VUInt (toInteger -> m)) _)) ->
-              bsSize `isInRange` Range n m bound
-            (Literal (Value (VNInt (fromNInt -> n)) _), Literal (Value (VUInt (toInteger -> m)) _)) ->
-              bsSize `isInRange` Range n m bound
-            (Literal (Value (VNInt (fromNInt -> n)) _), Literal (Value (VNInt (fromNInt -> m)) _)) ->
-              bsSize `isInRange` Range n m bound
-            _ -> False
+        CRange (Range (unIntLiteral -> Just n) (unIntLiteral -> Just m) bound) ->
+          bsSize `isInRange` Range n m bound
         _ -> error "Invalid control value in .size"
 controlText _ s Regexp ctrl =
   case ctrl of

--- a/src/Codec/CBOR/Cuddle/CBOR/Validator.hs
+++ b/src/Codec/CBOR/Cuddle/CBOR/Validator.hs
@@ -534,29 +534,6 @@ controlDouble _ _ op _ = error $ "Not yet implmented for double: " <> show op
 --------------------------------------------------------------------------------
 -- Bool
 
--- | Validating a boolean
-validateBool ::
-  CTreeRoot ValidatorPhase ->
-  Bool ->
-  CTree ValidatorPhase ->
-  Evidenced ValidationTrace
-validateBool cddl b (CTreeE (VRuleRef n)) =
-  dereferenceAndValidate cddl n $ validateBool cddl b
-validateBool cddl b (CTreeE (VValidator v _)) = runCustomValidator cddl (SingleTerm $ TermSimple (if b then 21 else 20)) v
-validateBool cddl b rule =
-  case rule of
-    -- a = any
-    Postlude PTAny -> terminal rule
-    -- a = bool
-    Postlude PTBool -> terminal rule
-    -- a = true
-    Literal (Value (VBool b') _) | b == b' -> terminal rule
-    -- a = foo .ctrl bar
-    Control op tgt ctrl -> ctrlDispatch (validateBool cddl b) op tgt ctrl (controlBool cddl b)
-    -- a = foo / bar
-    Choice opts -> validateChoice (validateBool cddl b) opts
-    _ -> unapplicable rule
-
 -- | Controls for `Bool`
 controlBool ::
   HasCallStack =>
@@ -580,7 +557,6 @@ controlBool _ _ op _ = error $ "Not yet implemented for bool: " <> show op
 --------------------------------------------------------------------------------
 -- Simple
 
--- | Validating a `TSimple`. It is unclear if this is used for anything else than `undefined`.
 validateSimple ::
   CTreeRoot ValidatorPhase ->
   Word8 ->
@@ -590,37 +566,23 @@ validateSimple cddl i (CTreeE (VRuleRef n)) =
   dereferenceAndValidate cddl n $ validateSimple cddl i
 validateSimple cddl i (CTreeE (VValidator v _)) = runCustomValidator cddl (SingleTerm $ TermSimple i) v
 validateSimple cddl i rule =
-  case i of
-    20 -> validateBool cddl False rule
-    21 -> validateBool cddl True rule
-    22 -> validateNull cddl rule
-    23 ->
-      case rule of
-        -- a = any
-        Postlude PTAny -> terminal rule
-        -- a = undefined
-        Postlude PTUndefined -> terminal rule
-        -- a = foo / bar
-        Choice opts -> validateChoice (validateSimple cddl 23) opts
-        _ -> unapplicable rule
-    _ -> error $ "Invalid simple value: " <> show i
-
---------------------------------------------------------------------------------
--- Null/nil
-
--- | Validating nil
-validateNull :: CTreeRoot ValidatorPhase -> CTree ValidatorPhase -> Evidenced ValidationTrace
-validateNull cddl (CTreeE (VRuleRef n)) =
-  dereferenceAndValidate cddl n $ validateNull cddl
-validateNull cddl (CTreeE (VValidator v _)) = runCustomValidator cddl (SingleTerm $ TermSimple 22) v
-validateNull cddl rule =
   case rule of
     -- a = any
     Postlude PTAny -> terminal rule
-    -- a = nil
-    Postlude PTNil -> terminal rule
-    Choice opts -> validateChoice (validateNull cddl) opts
+    Postlude PTBool | isJust boolVal -> terminal rule
+    Literal (Value (VBool b) _) | boolVal == Just b -> terminal rule
+    Control op tgt ctrl | Just b <- boolVal -> ctrlDispatch (validateSimple cddl i) op tgt ctrl (controlBool cddl b)
+    Postlude PTNil | i == 22 -> terminal rule
+    -- a = undefined
+    Postlude PTUndefined | i == 23 -> terminal rule
+    -- a = foo / bar
+    Choice opts -> validateChoice (validateSimple cddl i) opts
     _ -> unapplicable rule
+  where
+    boolVal
+      | i == 20 = Just False
+      | i == 21 = Just True
+      | otherwise = Nothing
 
 --------------------------------------------------------------------------------
 -- Bytes

--- a/src/Codec/CBOR/Cuddle/CBOR/Validator.hs
+++ b/src/Codec/CBOR/Cuddle/CBOR/Validator.hs
@@ -201,22 +201,22 @@ validateUInt cddl i rule =
     CRange (Range low high bound) ->
       case (low, high) of
         (Literal (Value (VUInt (toInteger -> n)) _), Literal (Value (VUInt (toInteger -> m)) _))
-          | n <= i' && range bound i' m -> terminal rule
+          | i' `isInRange` Range n m bound -> terminal rule
           | otherwise -> unapplicable rule
         (Literal (Value (VNInt (fromNInt -> n)) _), Literal (Value (VUInt (toInteger -> m)) _))
-          | -n <= i' && range bound i' m -> terminal rule
+          | i' `isInRange` Range n m bound -> terminal rule
           | otherwise -> unapplicable rule
         (Literal (Value (VNInt _) _), Literal (Value (VNInt _) _)) -> unapplicable rule
         (Literal (Value VUInt {} _), Literal (Value VNInt {} _)) -> error "range types mismatch"
         (Literal (Value (VBignum n) _), Literal (Value (VUInt (toInteger -> m)) _))
-          | n <= i' && range bound i' m -> terminal rule
+          | i' `isInRange` Range n m bound -> terminal rule
           | otherwise -> unapplicable rule
         (Literal (Value (VBignum _) _), Literal (Value (VNInt _) _)) -> unapplicable rule
         (Literal (Value (VUInt (toInteger -> n)) _), Literal (Value (VBignum m) _))
-          | n <= i' && range bound i' m -> terminal rule
+          | i' `isInRange` Range n m bound -> terminal rule
           | otherwise -> unapplicable rule
         (Literal (Value (VNInt (fromNInt -> n)) _), Literal (Value (VBignum m) _))
-          | (-n) <= i' && range bound i' m -> terminal rule
+          | i' `isInRange` Range n m bound -> terminal rule
           | otherwise -> unapplicable rule
         (CTreeE (VRuleRef n), _) ->
           dereferenceAndValidate cddl n $ \lo -> validateUInt cddl i (CRange (Range lo high bound))
@@ -253,19 +253,19 @@ validateNInt cddl i rule =
       case (low, high) of
         (Literal (Value (VUInt _) _), Literal (Value (VUInt _) _)) -> unapplicable rule
         (Literal (Value (VNInt (fromNInt -> n)) _), Literal (Value (VUInt (toInteger -> m)) _))
-          | -n <= i' && range bound i' m -> terminal rule
+          | i' `isInRange` Range n m bound -> terminal rule
           | otherwise -> unapplicable rule
         (Literal (Value (VNInt _) _), Literal (Value (VNInt _) _)) -> unapplicable rule
         (Literal (Value VUInt {} _), Literal (Value VNInt {} _)) -> error "range types mismatch"
         (Literal (Value (VBignum n) _), Literal (Value (VUInt (toInteger -> m)) _))
-          | n <= i' && range bound i' m -> terminal rule
+          | i' `isInRange` Range n m bound -> terminal rule
           | otherwise -> unapplicable rule
-        (Literal (Value (VBignum _) _), Literal (Value (VNInt _) _)) -> unapplicable rule
-        (Literal (Value (VUInt (toInteger -> n)) _), Literal (Value (VBignum m) _))
-          | n <= i' && range bound i' m -> terminal rule
+        (Literal (Value (VBignum n) _), Literal (Value (VNInt (fromNInt -> m)) _))
+          | i' `isInRange` Range n m bound -> terminal rule
           | otherwise -> unapplicable rule
+        (Literal (Value (VUInt _) _), Literal (Value (VBignum _) _)) -> unapplicable rule
         (Literal (Value (VNInt (fromNInt -> n)) _), Literal (Value (VBignum m) _))
-          | (-n) <= i' && range bound i' m -> terminal rule
+          | i' `isInRange` Range n m bound -> terminal rule
           | otherwise -> unapplicable rule
         (CTreeE (VRuleRef n), _) ->
           dereferenceAndValidate cddl n $ \lo -> validateNInt cddl i (CRange (Range lo high bound))
@@ -412,37 +412,37 @@ controlInteger cddl i Bits ctrl = do
 controlInteger _ i Lt ctrl =
   case ctrl of
     Literal (Value (VUInt i') _) -> i < toInteger i'
-    Literal (Value (VNInt i') _) -> i < -fromNInt i'
+    Literal (Value (VNInt i') _) -> i < fromNInt i'
     Literal (Value (VBignum i') _) -> i < i'
     _ -> False
 controlInteger _ i Gt ctrl =
   case ctrl of
     Literal (Value (VUInt i') _) -> i > fromIntegral i'
-    Literal (Value (VNInt i') _) -> i > -fromNInt i'
+    Literal (Value (VNInt i') _) -> i > fromNInt i'
     Literal (Value (VBignum i') _) -> i > i'
     _ -> False
 controlInteger _ i Le ctrl =
   case ctrl of
     Literal (Value (VUInt i') _) -> i <= fromIntegral i'
-    Literal (Value (VNInt i') _) -> i <= -fromNInt i'
+    Literal (Value (VNInt i') _) -> i <= fromNInt i'
     Literal (Value (VBignum i') _) -> i <= i'
     _ -> False
 controlInteger _ i Ge ctrl =
   case ctrl of
     Literal (Value (VUInt i') _) -> i >= fromIntegral i'
-    Literal (Value (VNInt i') _) -> i >= -fromNInt i'
+    Literal (Value (VNInt i') _) -> i >= fromNInt i'
     Literal (Value (VBignum i') _) -> i >= i'
     _ -> False
 controlInteger _ i Eq ctrl =
   case ctrl of
     Literal (Value (VUInt i') _) -> i == fromIntegral i'
-    Literal (Value (VNInt i') _) -> i == -fromNInt i'
+    Literal (Value (VNInt i') _) -> i == fromNInt i'
     Literal (Value (VBignum i') _) -> i == i'
     _ -> False
 controlInteger _ i Ne ctrl =
   case ctrl of
     Literal (Value (VUInt i') _) -> i /= fromIntegral i'
-    Literal (Value (VNInt i') _) -> i /= -fromNInt i'
+    Literal (Value (VNInt i') _) -> i /= fromNInt i'
     Literal (Value (VBignum i') _) -> i /= i'
     _ -> False
 controlInteger _ _ _ ctrl = error $ "unexpected control: " <> showSimple ctrl
@@ -851,9 +851,9 @@ controlText cddl bs op@Size ctrl =
             (Literal (Value (VUInt (toInteger -> n)) _), Literal (Value (VUInt (toInteger -> m)) _)) ->
               n <= toInteger (T.length bs) && range bound bsSize m
             (Literal (Value (VNInt (fromNInt -> n)) _), Literal (Value (VUInt (toInteger -> m)) _)) ->
-              -n <= toInteger (T.length bs) && range bound bsSize m
+              n <= toInteger (T.length bs) && range bound bsSize m
             (Literal (Value (VNInt (fromNInt -> n)) _), Literal (Value (VNInt (fromNInt -> m)) _)) ->
-              -n <= toInteger (T.length bs) && range bound bsSize (-m)
+              n <= toInteger (T.length bs) && range bound bsSize m
             _ -> False
         _ -> error "Invalid control value in .size"
 controlText _ s Regexp ctrl =

--- a/src/Codec/CBOR/Cuddle/CBOR/Validator.hs
+++ b/src/Codec/CBOR/Cuddle/CBOR/Validator.hs
@@ -211,31 +211,7 @@ validateUInt cddl i rule =
     Literal (Value (VUInt j) _) | i' == toInteger j -> terminal rule
     Control op tgt ctrl -> ctrlDispatch (validateUInt cddl i) op tgt ctrl (controlInteger cddl i')
     Choice opts -> validateChoice (validateUInt cddl i) opts
-    CRange (Range low high bound) ->
-      case (low, high) of
-        (Literal (Value (VUInt (toInteger -> n)) _), Literal (Value (VUInt (toInteger -> m)) _))
-          | i' `isInRange` Range n m bound -> terminal rule
-          | otherwise -> unapplicable rule
-        (Literal (Value (VNInt (fromNInt -> n)) _), Literal (Value (VUInt (toInteger -> m)) _))
-          | i' `isInRange` Range n m bound -> terminal rule
-          | otherwise -> unapplicable rule
-        (Literal (Value (VNInt _) _), Literal (Value (VNInt _) _)) -> unapplicable rule
-        (Literal (Value VUInt {} _), Literal (Value VNInt {} _)) -> error "range types mismatch"
-        (Literal (Value (VBignum n) _), Literal (Value (VUInt (toInteger -> m)) _))
-          | i' `isInRange` Range n m bound -> terminal rule
-          | otherwise -> unapplicable rule
-        (Literal (Value (VBignum _) _), Literal (Value (VNInt _) _)) -> unapplicable rule
-        (Literal (Value (VUInt (toInteger -> n)) _), Literal (Value (VBignum m) _))
-          | i' `isInRange` Range n m bound -> terminal rule
-          | otherwise -> unapplicable rule
-        (Literal (Value (VNInt (fromNInt -> n)) _), Literal (Value (VBignum m) _))
-          | i' `isInRange` Range n m bound -> terminal rule
-          | otherwise -> unapplicable rule
-        (CTreeE (VRuleRef n), _) ->
-          dereferenceAndValidate cddl n $ \lo -> validateUInt cddl i (CRange (Range lo high bound))
-        (_, CTreeE (VRuleRef n)) ->
-          dereferenceAndValidate cddl n $ \hi -> validateUInt cddl i (CRange (Range low hi bound))
-        (lo, hi) -> error $ "Unable to validate range: (" <> showSimple lo <> ", " <> showSimple hi <> ")"
+    CRange rng -> validateIntRange cddl (validateUInt cddl i) i' rng
     Enum g ->
       case g of
         CTreeE (VRuleRef n) -> dereferenceAndValidate cddl n $ validateUInt cddl i
@@ -262,31 +238,7 @@ validateNInt cddl i rule =
     Literal (Value (VNInt j) _) | i' == fromNInt j -> terminal rule
     Control op tgt ctrl -> ctrlDispatch (validateNInt cddl i) op tgt ctrl (controlInteger cddl i')
     Choice opts -> validateChoice (validateNInt cddl i) opts
-    CRange (Range low high bound) ->
-      case (low, high) of
-        (Literal (Value (VUInt _) _), Literal (Value (VUInt _) _)) -> unapplicable rule
-        (Literal (Value (VNInt (fromNInt -> n)) _), Literal (Value (VUInt (toInteger -> m)) _))
-          | i' `isInRange` Range n m bound -> terminal rule
-          | otherwise -> unapplicable rule
-        (Literal (Value (VNInt (fromNInt -> n)) _), Literal (Value (VNInt (fromNInt -> m)) _))
-          | i' `isInRange` Range n m bound -> terminal rule
-          | otherwise -> unapplicable rule
-        (Literal (Value VUInt {} _), Literal (Value VNInt {} _)) -> error "range types mismatch"
-        (Literal (Value (VBignum n) _), Literal (Value (VUInt (toInteger -> m)) _))
-          | i' `isInRange` Range n m bound -> terminal rule
-          | otherwise -> unapplicable rule
-        (Literal (Value (VBignum n) _), Literal (Value (VNInt (fromNInt -> m)) _))
-          | i' `isInRange` Range n m bound -> terminal rule
-          | otherwise -> unapplicable rule
-        (Literal (Value (VUInt _) _), Literal (Value (VBignum _) _)) -> unapplicable rule
-        (Literal (Value (VNInt (fromNInt -> n)) _), Literal (Value (VBignum m) _))
-          | i' `isInRange` Range n m bound -> terminal rule
-          | otherwise -> unapplicable rule
-        (CTreeE (VRuleRef n), _) ->
-          dereferenceAndValidate cddl n $ \lo -> validateNInt cddl i (CRange (Range lo high bound))
-        (_, CTreeE (VRuleRef n)) ->
-          dereferenceAndValidate cddl n $ \hi -> validateNInt cddl i (CRange (Range low hi bound))
-        (lo, hi) -> error $ "Unable to validate range: (" <> showSimple lo <> ", " <> showSimple hi <> ")"
+    CRange rng -> validateIntRange cddl (validateNInt cddl i) i' rng
     Enum g ->
       case g of
         CTreeE (VRuleRef n) -> dereferenceAndValidate cddl n $ validateNInt cddl i
@@ -296,6 +248,67 @@ validateNInt cddl i rule =
     _ -> unapplicable rule
   where
     i' = fromNInt i
+
+-- | The integer value of a literal range bound. Unlike 'unIntLiteral' this
+-- also interprets bignum literals, which is safe here because the value is
+-- only compared against, never narrowed to a machine word.
+intBound :: CTree ValidatorPhase -> Maybe Integer
+intBound (Literal (Value v _)) = case v of
+  VUInt n -> Just $ toInteger n
+  VNInt n -> Just $ fromNInt n
+  VBignum n -> Just n
+  _ -> Nothing
+intBound _ = Nothing
+
+-- | Validate an integer against a range with integer-literal or referenced
+-- bounds, re-entering the given validator once a referenced bound has been
+-- dereferenced. A range whose lower bound exceeds its upper bound is the
+-- empty type (RFC 8610 §2.2.2.1) and simply never matches.
+validateIntRange ::
+  HasCallStack =>
+  CTreeRoot ValidatorPhase ->
+  (CTree ValidatorPhase -> Evidenced ValidationTrace) ->
+  Integer ->
+  Range (CTree ValidatorPhase) ->
+  Evidenced ValidationTrace
+validateIntRange cddl self i rng@(Range low high bound) =
+  case (low, high) of
+    (intBound -> Just n, intBound -> Just m)
+      | i `isInRange` Range n m bound -> terminal rule
+      | otherwise -> unapplicable rule
+    (CTreeE (VRuleRef n), _) ->
+      dereferenceAndValidate cddl n $ \lo -> self (CRange (Range lo high bound))
+    (_, CTreeE (VRuleRef n)) ->
+      dereferenceAndValidate cddl n $ \hi -> self (CRange (Range low hi bound))
+    (lo, hi) -> error $ "Unable to validate range: (" <> showSimple lo <> ", " <> showSimple hi <> ")"
+  where
+    rule = CRange rng
+
+-- | Validate a float against a range with float-literal or referenced
+-- bounds, re-entering the given validator once a referenced bound has been
+-- dereferenced. Ranges are typed by kind, not width (RFC 8610 §2.2.2.1),
+-- so bounds of any float width apply and are compared at 'Double'
+-- precision, which is lossless for the narrower widths. A range with
+-- bounds of any other shape is unapplicable.
+validateFloatRange ::
+  HasCallStack =>
+  CTreeRoot ValidatorPhase ->
+  (CTree ValidatorPhase -> Evidenced ValidationTrace) ->
+  Double ->
+  Range (CTree ValidatorPhase) ->
+  Evidenced ValidationTrace
+validateFloatRange cddl self f rng@(Range low high bound) =
+  case (low, high) of
+    (unFloatLiteral -> Just n, unFloatLiteral -> Just m)
+      | f `isInRange` Range n m bound -> terminal rule
+      | otherwise -> unapplicable rule
+    (CTreeE (VRuleRef n), _) ->
+      dereferenceAndValidate cddl n $ \lo -> self (CRange (Range lo high bound))
+    (_, CTreeE (VRuleRef n)) ->
+      dereferenceAndValidate cddl n $ \hi -> self (CRange (Range low hi bound))
+    _ -> unapplicable rule
+  where
+    rule = CRange rng
 
 -- | Controls for an Integer
 controlInteger ::
@@ -374,12 +387,7 @@ validateHalf cddl f rule =
     -- a = foo .ctrl bar
     Control op tgt ctrl -> ctrlDispatch (validateHalf cddl f) op tgt ctrl (controlHalf cddl f)
     -- a = x..y
-    CRange (Range (CTreeE (VRuleRef n)) high bound) ->
-      dereferenceAndValidate cddl n $ \lo -> validateHalf cddl f . CRange $ Range lo high bound
-    CRange (Range low (CTreeE (VRuleRef n)) bound) ->
-      dereferenceAndValidate cddl n $ \hi -> validateHalf cddl f . CRange $ Range low hi bound
-    CRange (Range (unFloatLiteral -> Just n) (unFloatLiteral -> Just m) bound)
-      | realToFrac f `isInRange` Range n m bound -> terminal rule
+    CRange rng -> validateFloatRange cddl (validateHalf cddl f) (realToFrac f) rng
     _ -> unapplicable rule
 
 -- | Controls for `Float16`
@@ -426,13 +434,7 @@ validateFloat cddl f rule =
     -- a = foo .ctrl bar
     Control op tgt ctrl -> ctrlDispatch (validateFloat cddl f) op tgt ctrl (controlFloat cddl f)
     -- a = x..y
-    -- TODO it is unclear if this should mix floating point types too
-    CRange (Range (CTreeE (VRuleRef n)) high bound) ->
-      dereferenceAndValidate cddl n $ \lo -> validateFloat cddl f . CRange $ Range lo high bound
-    CRange (Range low (CTreeE (VRuleRef n)) bound) ->
-      dereferenceAndValidate cddl n $ \hi -> validateFloat cddl f . CRange $ Range low hi bound
-    CRange (Range (unFloatLiteral -> Just low) (unFloatLiteral -> Just high) bound)
-      | realToFrac f `isInRange` Range low high bound -> terminal rule
+    CRange rng -> validateFloatRange cddl (validateFloat cddl f) (realToFrac f) rng
     _ -> unapplicable rule
 
 -- | Controls for `Float32`
@@ -477,13 +479,7 @@ validateDouble cddl f rule =
     -- a = foo .ctrl bar
     Control op tgt ctrl -> ctrlDispatch (validateDouble cddl f) op tgt ctrl (controlDouble cddl f)
     -- a = x..y
-    -- TODO it is unclear if this should mix floating point types too
-    CRange (Range (CTreeE (VRuleRef n)) high bound) ->
-      dereferenceAndValidate cddl n $ \lo -> validateDouble cddl f . CRange $ Range lo high bound
-    CRange (Range low (CTreeE (VRuleRef n)) bound) ->
-      dereferenceAndValidate cddl n $ \hi -> validateDouble cddl f . CRange $ Range low hi bound
-    CRange (Range (unFloatLiteral -> Just n) (unFloatLiteral -> Just m) bound)
-      | f `isInRange` Range (realToFrac n) (realToFrac m) bound -> terminal rule
+    CRange rng -> validateFloatRange cddl (validateDouble cddl f) f rng
     _ -> unapplicable rule
 
 -- | Controls for `Float64`

--- a/src/Codec/CBOR/Cuddle/CBOR/Validator.hs
+++ b/src/Codec/CBOR/Cuddle/CBOR/Validator.hs
@@ -12,6 +12,7 @@ module Codec.CBOR.Cuddle.CBOR.Validator (
 ) where
 
 import Codec.CBOR.Cuddle.CBOR.Canonical (CanonicalTerm, toCanonical)
+import Codec.CBOR.Cuddle.CBOR.Term (CBORTerm (..), NInt, decodeCBORTerm, fromNInt)
 import Codec.CBOR.Cuddle.CBOR.Validator.Trace (
   ControlInfo (..),
   Evidenced (..),
@@ -41,7 +42,6 @@ import Codec.CBOR.Cuddle.CDDL.Custom.Validator (
 import Codec.CBOR.Cuddle.CDDL.Resolve (showSimple)
 import Codec.CBOR.Cuddle.IndexMappable (IndexMappable (..))
 import Codec.CBOR.Read
-import Codec.CBOR.Term
 import Control.Monad.Reader (asks)
 import Data.Bifunctor (Bifunctor (..))
 import Data.Bits hiding (And)
@@ -62,6 +62,7 @@ import Data.Text.Lazy qualified as TL
 import Data.Word
 import GHC.Float
 import GHC.Stack (HasCallStack)
+import Numeric.Half (Half)
 import Text.Regex.TDFA
 
 data ValidateCBORError
@@ -79,7 +80,7 @@ validateCBOR ::
   CTreeRoot ValidatorPhase ->
   Either ValidateCBORError (Evidenced ValidationTrace)
 validateCBOR bs ruleName cddl@(CTreeRoot tree) =
-  case deserialiseFromBytes decodeTerm (BSL.fromStrict bs) of
+  case deserialiseFromBytes decodeCBORTerm (BSL.fromStrict bs) of
     Left e -> Left $ DecodingFailed e
     Right (rest, term)
       | BSL.null rest -> case tree Map.!? ruleName of
@@ -90,7 +91,7 @@ validateCBOR bs ruleName cddl@(CTreeRoot tree) =
 -- | Validate a CBOR 'Term' against a top-level rule from inside a custom
 -- validator.
 validateFromName ::
-  HasCallStack => Name -> Term -> Validator ()
+  HasCallStack => Name -> CBORTerm -> Validator ()
 validateFromName n term = do
   mRule <- lookupCddl n
   case mRule of
@@ -101,14 +102,14 @@ validateFromName n term = do
 -- parameter at the enclosing rule. Use this from inside a custom validator
 -- attached to a generic rule.
 validateFromGRef ::
-  HasCallStack => GRef -> Term -> Validator ()
+  HasCallStack => GRef -> CBORTerm -> Validator ()
 validateFromGRef ref term = do
   mRule <- lookupGRef ref
   case mRule of
     Nothing -> fail $ "Unbound generic reference: " <> show ref
     Just rule -> validateAgainst term rule
 
-validateAgainst :: Term -> CTree ValidatorPhase -> Validator ()
+validateAgainst :: CBORTerm -> CTree ValidatorPhase -> Validator ()
 validateAgainst term rule = do
   cddl <- asks veRoot
   let res = validateTerm cddl term rule
@@ -123,7 +124,7 @@ validateAgainst term rule = do
 -- spec
 validateTerm ::
   CTreeRoot ValidatorPhase ->
-  Term ->
+  CBORTerm ->
   CTree ValidatorPhase ->
   Evidenced ValidationTrace
 validateTerm cddl term rule
@@ -133,23 +134,21 @@ validateTerm cddl term rule
       runCustomValidator cddl (SingleTerm term) v
   | otherwise =
       case term of
-        TInt i -> validateInteger cddl (fromIntegral i) rule
-        TInteger i -> validateInteger cddl i rule
-        TBytes b -> validateBytes cddl b rule
-        TBytesI b -> validateBytes cddl (BSL.toStrict b) rule
-        TString s -> validateText cddl s rule
-        TStringI s -> validateText cddl (TL.toStrict s) rule
-        TList ts -> validateList cddl ts rule
-        TListI ts -> validateList cddl ts rule
-        TMap ts -> validateMap cddl ts rule
-        TMapI ts -> validateMap cddl ts rule
-        TTagged w t -> validateTagged cddl w t rule
-        TBool b -> validateBool cddl b rule
-        TNull -> validateNull cddl rule
-        TSimple s -> validateSimple cddl s rule
-        THalf h -> validateHalf cddl h rule
-        TFloat h -> validateFloat cddl h rule
-        TDouble d -> validateDouble cddl d rule
+        TermUInt i -> validateUInt cddl i rule
+        TermNInt i -> validateNInt cddl i rule
+        TermBytes bs -> validateBytes cddl bs rule
+        TermBytesI bss -> validateBytes cddl (mconcat $ BSL.toStrict <$> bss) rule
+        TermString t -> validateText cddl t rule
+        TermStringI ts -> validateText cddl (mconcat $ TL.toStrict <$> ts) rule
+        TermArray xs -> validateList cddl xs rule
+        TermArrayI xs -> validateList cddl xs rule
+        TermMap xs -> validateMap cddl xs rule
+        TermMapI xs -> validateMap cddl xs rule
+        TermTag i t -> validateTagged cddl i t rule
+        TermSimple i -> validateSimple cddl i rule
+        TermHalf x -> validateHalf cddl x rule
+        TermFloat x -> validateFloat cddl x rule
+        TermDouble x -> validateDouble cddl x rule
 
 terminal :: CTree ValidatorPhase -> Evidenced ValidationTrace
 terminal = evidence . TerminalRule . mapIndex
@@ -183,103 +182,203 @@ unapplicable = evidence . UnapplicableRule . mapIndex
 --
 -- For this reason, we cannot assume that bounds or literals are going to be
 -- Ints, so we convert everything to Integer.
-validateInteger ::
+validateUInt ::
   HasCallStack =>
   CTreeRoot ValidatorPhase ->
-  Integer ->
+  Word64 ->
   CTree ValidatorPhase ->
   Evidenced ValidationTrace
-validateInteger cddl i rule =
+validateUInt cddl i rule =
   case rule of
-    CTreeE (VRuleRef n) -> dereferenceAndValidate cddl n $ validateInteger cddl i
-    CTreeE (VValidator v _) -> runCustomValidator cddl (SingleTerm $ TInteger i) v
-    -- echo "C24101" | xxd -r -p - example.cbor
-    -- echo "foo = int" > a.cddl
-    -- cddl a.cddl validate example.cbor
-    --
-    -- but
-    --
-    -- echo "C249010000000000000000"| xxd -r -p - example.cbor
-    -- echo "foo = int" > a.cddl
-    -- cddl a.cddl validate example.cbor
-    --
-    -- and they are both bigints?
-
-    -- a = any
+    CTreeE (VRuleRef n) -> dereferenceAndValidate cddl n $ validateUInt cddl i
+    CTreeE (VValidator v _) -> runCustomValidator cddl (SingleTerm $ TermUInt i) v
     Postlude PTAny -> terminal rule
-    -- a = int
-    Postlude PTInt
-      | i >= nintMin && i <= uintMax -> terminal rule
-    -- a = uint
-    Postlude PTUInt
-      | i >= 0 && i <= uintMax -> terminal rule
-    -- a = nint
-    Postlude PTNInt
-      | i >= nintMin && i <= -1 -> terminal rule
-    -- a = x
-    Literal (Value (VUInt i') _) | i == fromIntegral i' -> terminal rule
-    -- a = -x
-    Literal (Value (VNInt i') _) | -i == fromIntegral i' -> terminal rule
-    -- a = <big number>
-    Literal (Value (VBignum i') _) | i == i' -> terminal rule
-    -- a = foo .ctrl bar
-    Control op tgt ctrl -> ctrlDispatch (validateInteger cddl i) op tgt ctrl (controlInteger cddl i)
-    -- a = foo / bar
-    Choice opts -> validateChoice (validateInteger cddl i) opts
-    -- a = x..y
-    Range low high bound ->
+    Postlude PTInt -> terminal rule
+    Postlude PTUInt -> terminal rule
+    Literal (Value (VUInt j) _) | i' == toInteger j -> terminal rule
+    Control op tgt ctrl -> ctrlDispatch (validateUInt cddl i) op tgt ctrl (controlInteger cddl i')
+    Choice opts -> validateChoice (validateUInt cddl i) opts
+    CRange (Range low high bound) ->
       case (low, high) of
-        (Literal (Value (VUInt (fromIntegral -> n)) _), Literal (Value (VUInt (fromIntegral -> m)) _))
-          | n <= i && range bound i m -> terminal rule
+        (Literal (Value (VUInt (toInteger -> n)) _), Literal (Value (VUInt (toInteger -> m)) _))
+          | n <= i' && range bound i' m -> terminal rule
           | otherwise -> unapplicable rule
-        (Literal (Value (VNInt (fromIntegral -> n)) _), Literal (Value (VUInt (fromIntegral -> m)) _))
-          | -n <= i && range bound i m -> terminal rule
+        (Literal (Value (VNInt (fromNInt -> n)) _), Literal (Value (VUInt (toInteger -> m)) _))
+          | -n <= i' && range bound i' m -> terminal rule
           | otherwise -> unapplicable rule
-        (Literal (Value (VNInt (fromIntegral -> n)) _), Literal (Value (VNInt (fromIntegral -> m)) _))
-          | -n <= i && range bound i (-m) -> terminal rule
-          | otherwise -> unapplicable rule
+        (Literal (Value (VNInt _) _), Literal (Value (VNInt _) _)) -> unapplicable rule
         (Literal (Value VUInt {} _), Literal (Value VNInt {} _)) -> error "range types mismatch"
-        (Literal (Value (VBignum n) _), Literal (Value (VUInt (fromIntegral -> m)) _))
-          | n <= i && range bound i m -> terminal rule
+        (Literal (Value (VBignum n) _), Literal (Value (VUInt (toInteger -> m)) _))
+          | n <= i' && range bound i' m -> terminal rule
           | otherwise -> unapplicable rule
-        (Literal (Value (VBignum n) _), Literal (Value (VNInt (fromIntegral -> m)) _))
-          | n <= i && range bound i (-m) -> terminal rule
+        (Literal (Value (VBignum _) _), Literal (Value (VNInt _) _)) -> unapplicable rule
+        (Literal (Value (VUInt (toInteger -> n)) _), Literal (Value (VBignum m) _))
+          | n <= i' && range bound i' m -> terminal rule
           | otherwise -> unapplicable rule
-        (Literal (Value (VUInt (fromIntegral -> n)) _), Literal (Value (VBignum m) _))
-          | n <= i && range bound i m -> terminal rule
-          | otherwise -> unapplicable rule
-        (Literal (Value (VNInt (fromIntegral -> n)) _), Literal (Value (VBignum m) _))
-          | (-n) <= i && range bound i m -> terminal rule
+        (Literal (Value (VNInt (fromNInt -> n)) _), Literal (Value (VBignum m) _))
+          | (-n) <= i' && range bound i' m -> terminal rule
           | otherwise -> unapplicable rule
         (CTreeE (VRuleRef n), _) ->
-          dereferenceAndValidate cddl n $ \lo -> validateInteger cddl i (Range lo high bound)
+          dereferenceAndValidate cddl n $ \lo -> validateUInt cddl i (CRange (Range lo high bound))
         (_, CTreeE (VRuleRef n)) ->
-          dereferenceAndValidate cddl n $ \hi -> validateInteger cddl i (Range low hi bound)
+          dereferenceAndValidate cddl n $ \hi -> validateUInt cddl i (CRange (Range low hi bound))
         (lo, hi) -> error $ "Unable to validate range: (" <> showSimple lo <> ", " <> showSimple hi <> ")"
-    -- a = &(x, y, z)
     Enum g ->
       case g of
-        CTreeE (VRuleRef n) -> dereferenceAndValidate cddl n $ validateInteger cddl i
-        Group g' -> validateInteger cddl i (Choice (NE.fromList g'))
+        CTreeE (VRuleRef n) -> dereferenceAndValidate cddl n $ validateUInt cddl i
+        Group g' -> validateUInt cddl i (Choice (NE.fromList g'))
         _ -> error "Not yet implemented"
-    -- a = x: y
-    -- Note KV cannot appear on its own, but we will use this when validating
-    -- lists.
-    KV _ v _ -> validateInteger cddl i v
-    Tag 2 x -> validateBigInt x
-    Tag 3 x -> validateBigInt x
+    KV _ v _ -> validateUInt cddl i v
     _ -> unapplicable rule
   where
-    validateBigInt x = case x of
-      CTreeE (VRuleRef n) -> dereferenceAndValidate cddl n validateBigInt
-      Postlude PTBytes -> terminal rule
-      Control op tgt@(Postlude PTBytes) ctrl ->
-        ctrlDispatch (validateBytes cddl bs) op tgt ctrl (controlBytes cddl bs)
-        where
-          -- TODO figure out a way to turn Integer into bytes or figure out why
-          -- tagged bigints are decoded as integers in the first place
-          bs = mempty
-      _ -> unapplicable rule
+    i' = toInteger i
+
+validateNInt ::
+  HasCallStack =>
+  CTreeRoot ValidatorPhase ->
+  NInt ->
+  CTree ValidatorPhase ->
+  Evidenced ValidationTrace
+validateNInt cddl i rule =
+  case rule of
+    CTreeE (VRuleRef n) -> dereferenceAndValidate cddl n $ validateNInt cddl i
+    CTreeE (VValidator v _) -> runCustomValidator cddl (SingleTerm $ TermNInt i) v
+    Postlude PTAny -> terminal rule
+    Postlude PTInt -> terminal rule
+    Postlude PTUInt -> terminal rule
+    Literal (Value (VNInt j) _) | i' == fromNInt j -> terminal rule
+    Control op tgt ctrl -> ctrlDispatch (validateNInt cddl i) op tgt ctrl (controlInteger cddl i')
+    Choice opts -> validateChoice (validateNInt cddl i) opts
+    CRange (Range low high bound) ->
+      case (low, high) of
+        (Literal (Value (VUInt _) _), Literal (Value (VUInt _) _)) -> unapplicable rule
+        (Literal (Value (VNInt (fromNInt -> n)) _), Literal (Value (VUInt (toInteger -> m)) _))
+          | -n <= i' && range bound i' m -> terminal rule
+          | otherwise -> unapplicable rule
+        (Literal (Value (VNInt _) _), Literal (Value (VNInt _) _)) -> unapplicable rule
+        (Literal (Value VUInt {} _), Literal (Value VNInt {} _)) -> error "range types mismatch"
+        (Literal (Value (VBignum n) _), Literal (Value (VUInt (toInteger -> m)) _))
+          | n <= i' && range bound i' m -> terminal rule
+          | otherwise -> unapplicable rule
+        (Literal (Value (VBignum _) _), Literal (Value (VNInt _) _)) -> unapplicable rule
+        (Literal (Value (VUInt (toInteger -> n)) _), Literal (Value (VBignum m) _))
+          | n <= i' && range bound i' m -> terminal rule
+          | otherwise -> unapplicable rule
+        (Literal (Value (VNInt (fromNInt -> n)) _), Literal (Value (VBignum m) _))
+          | (-n) <= i' && range bound i' m -> terminal rule
+          | otherwise -> unapplicable rule
+        (CTreeE (VRuleRef n), _) ->
+          dereferenceAndValidate cddl n $ \lo -> validateNInt cddl i (CRange (Range lo high bound))
+        (_, CTreeE (VRuleRef n)) ->
+          dereferenceAndValidate cddl n $ \hi -> validateNInt cddl i (CRange (Range low hi bound))
+        (lo, hi) -> error $ "Unable to validate range: (" <> showSimple lo <> ", " <> showSimple hi <> ")"
+    Enum g ->
+      case g of
+        CTreeE (VRuleRef n) -> dereferenceAndValidate cddl n $ validateNInt cddl i
+        Group g' -> validateNInt cddl i (Choice (NE.fromList g'))
+        _ -> error "Not yet implemented"
+    KV _ v _ -> validateNInt cddl i v
+    _ -> unapplicable rule
+  where
+    i' = fromNInt i
+
+-- validateInteger ::
+--  HasCallStack =>
+--  CTreeRoot ValidatorPhase ->
+--  Integer ->
+--  CTree ValidatorPhase ->
+--  Evidenced ValidationTrace
+-- validateInteger cddl i rule =
+--  case rule of
+--    CTreeE (VRuleRef n) -> dereferenceAndValidate cddl n $ validateInteger cddl i
+--    CTreeE (VValidator v _) -> runCustomValidator cddl (SingleTerm $ TInteger i) v
+--    -- echo "C24101" | xxd -r -p - example.cbor
+--    -- echo "foo = int" > a.cddl
+--    -- cddl a.cddl validate example.cbor
+--    --
+--    -- but
+--    --
+--    -- echo "C249010000000000000000"| xxd -r -p - example.cbor
+--    -- echo "foo = int" > a.cddl
+--    -- cddl a.cddl validate example.cbor
+--    --
+--    -- and they are both bigints?
+--
+--    -- a = any
+--    Postlude PTAny -> terminal rule
+--    -- a = int
+--    Postlude PTInt
+--      | i >= nintMin && i <= uintMax -> terminal rule
+--    -- a = uint
+--    Postlude PTUInt
+--      | i >= 0 && i <= uintMax -> terminal rule
+--    -- a = nint
+--    Postlude PTNInt
+--      | i >= nintMin && i <= -1 -> terminal rule
+--    -- a = x
+--    Literal (Value (VUInt i') _) | i == fromIntegral i' -> terminal rule
+--    -- a = -x
+--    Literal (Value (VNInt i') _) | -i == fromIntegral i' -> terminal rule
+--    -- a = <big number>
+--    Literal (Value (VBignum i') _) | i == i' -> terminal rule
+--    -- a = foo .ctrl bar
+--    Control op tgt ctrl -> ctrlDispatch (validateInteger cddl i) op tgt ctrl (controlInteger cddl i)
+--    -- a = foo / bar
+--    Choice opts -> validateChoice (validateInteger cddl i) opts
+--    -- a = x..y
+--    Range low high bound ->
+--      case (low, high) of
+--        (Literal (Value (VUInt (fromIntegral -> n)) _), Literal (Value (VUInt (fromIntegral -> m)) _))
+--          | n <= i && range bound i m -> terminal rule
+--          | otherwise -> unapplicable rule
+--        (Literal (Value (VNInt (fromIntegral -> n)) _), Literal (Value (VUInt (fromIntegral -> m)) _))
+--          | -n <= i && range bound i m -> terminal rule
+--          | otherwise -> unapplicable rule
+--        (Literal (Value (VNInt (fromIntegral -> n)) _), Literal (Value (VNInt (fromIntegral -> m)) _))
+--          | -n <= i && range bound i (-m) -> terminal rule
+--          | otherwise -> unapplicable rule
+--        (Literal (Value VUInt {} _), Literal (Value VNInt {} _)) -> error "range types mismatch"
+--        (Literal (Value (VBignum n) _), Literal (Value (VUInt (fromIntegral -> m)) _))
+--          | n <= i && range bound i m -> terminal rule
+--          | otherwise -> unapplicable rule
+--        (Literal (Value (VBignum n) _), Literal (Value (VNInt (fromIntegral -> m)) _))
+--          | n <= i && range bound i (-m) -> terminal rule
+--          | otherwise -> unapplicable rule
+--        (Literal (Value (VUInt (fromIntegral -> n)) _), Literal (Value (VBignum m) _))
+--          | n <= i && range bound i m -> terminal rule
+--          | otherwise -> unapplicable rule
+--        (Literal (Value (VNInt (fromIntegral -> n)) _), Literal (Value (VBignum m) _))
+--          | (-n) <= i && range bound i m -> terminal rule
+--          | otherwise -> unapplicable rule
+--        (CTreeE (VRuleRef n), _) ->
+--          dereferenceAndValidate cddl n $ \lo -> validateInteger cddl i (Range lo high bound)
+--        (_, CTreeE (VRuleRef n)) ->
+--          dereferenceAndValidate cddl n $ \hi -> validateInteger cddl i (Range low hi bound)
+--        (lo, hi) -> error $ "Unable to validate range: (" <> showSimple lo <> ", " <> showSimple hi <> ")"
+--    -- a = &(x, y, z)
+--    Enum g ->
+--      case g of
+--        CTreeE (VRuleRef n) -> dereferenceAndValidate cddl n $ validateInteger cddl i
+--        Group g' -> validateInteger cddl i (Choice (NE.fromList g'))
+--        _ -> error "Not yet implemented"
+--    -- a = x: y
+--    -- Note KV cannot appear on its own, but we will use this when validating
+--    -- lists.
+--    KV _ v _ -> validateInteger cddl i v
+--    Tag 2 x -> validateBigInt x
+--    Tag 3 x -> validateBigInt x
+--    _ -> unapplicable rule
+--  where
+--    validateBigInt x = case x of
+--      CTreeE (VRuleRef n) -> dereferenceAndValidate cddl n validateBigInt
+--      Postlude PTBytes -> terminal rule
+--      Control op tgt@(Postlude PTBytes) ctrl ->
+--        ctrlDispatch (validateBytes cddl bs) op tgt ctrl (controlBytes cddl bs)
+--        where
+--          -- TODO figure out a way to turn Integer into bytes or figure out why
+--          -- tagged bigints are decoded as integers in the first place
+--          bs = mempty
+--      _ -> unapplicable rule
 
 -- | Controls for an Integer
 controlInteger ::
@@ -300,7 +399,7 @@ controlInteger cddl i Bits ctrl = do
     indices = case ctrl of
       Literal (Value (VUInt i') _) -> [i']
       Choice nodes -> getIndicesOfChoice cddl nodes
-      Range ff tt incl -> getIndicesOfRange cddl ff tt incl
+      CRange (Range ff tt incl) -> getIndicesOfRange cddl ff tt incl
       Enum g -> getIndicesOfEnum cddl g
       _ -> error "Not yet implemented"
   go (IS.fromList (map fromIntegral indices)) i 0
@@ -312,38 +411,38 @@ controlInteger cddl i Bits ctrl = do
        in allowed && go indices (shiftR n 1) (idx + 1)
 controlInteger _ i Lt ctrl =
   case ctrl of
-    Literal (Value (VUInt i') _) -> i < fromIntegral i'
-    Literal (Value (VNInt i') _) -> i < -fromIntegral i'
+    Literal (Value (VUInt i') _) -> i < toInteger i'
+    Literal (Value (VNInt i') _) -> i < -fromNInt i'
     Literal (Value (VBignum i') _) -> i < i'
     _ -> False
 controlInteger _ i Gt ctrl =
   case ctrl of
     Literal (Value (VUInt i') _) -> i > fromIntegral i'
-    Literal (Value (VNInt i') _) -> i > -fromIntegral i'
+    Literal (Value (VNInt i') _) -> i > -fromNInt i'
     Literal (Value (VBignum i') _) -> i > i'
     _ -> False
 controlInteger _ i Le ctrl =
   case ctrl of
     Literal (Value (VUInt i') _) -> i <= fromIntegral i'
-    Literal (Value (VNInt i') _) -> i <= -fromIntegral i'
+    Literal (Value (VNInt i') _) -> i <= -fromNInt i'
     Literal (Value (VBignum i') _) -> i <= i'
     _ -> False
 controlInteger _ i Ge ctrl =
   case ctrl of
     Literal (Value (VUInt i') _) -> i >= fromIntegral i'
-    Literal (Value (VNInt i') _) -> i >= -fromIntegral i'
+    Literal (Value (VNInt i') _) -> i >= -fromNInt i'
     Literal (Value (VBignum i') _) -> i >= i'
     _ -> False
 controlInteger _ i Eq ctrl =
   case ctrl of
     Literal (Value (VUInt i') _) -> i == fromIntegral i'
-    Literal (Value (VNInt i') _) -> i == -fromIntegral i'
+    Literal (Value (VNInt i') _) -> i == -fromNInt i'
     Literal (Value (VBignum i') _) -> i == i'
     _ -> False
 controlInteger _ i Ne ctrl =
   case ctrl of
     Literal (Value (VUInt i') _) -> i /= fromIntegral i'
-    Literal (Value (VNInt i') _) -> i /= -fromIntegral i'
+    Literal (Value (VNInt i') _) -> i /= -fromNInt i'
     Literal (Value (VBignum i') _) -> i /= i'
     _ -> False
 controlInteger _ _ _ ctrl = error $ "unexpected control: " <> showSimple ctrl
@@ -358,11 +457,11 @@ controlInteger _ _ _ ctrl = error $ "unexpected control: " <> showSimple ctrl
 validateHalf ::
   HasCallStack =>
   CTreeRoot ValidatorPhase ->
-  Float ->
+  Half ->
   CTree ValidatorPhase ->
   Evidenced ValidationTrace
 validateHalf cddl f (CTreeE (VRuleRef n)) = dereferenceAndValidate cddl n $ validateHalf cddl f
-validateHalf cddl f (CTreeE (VValidator v _)) = runCustomValidator cddl (SingleTerm $ THalf f) v
+validateHalf cddl f (CTreeE (VValidator v _)) = runCustomValidator cddl (SingleTerm $ TermHalf f) v
 validateHalf cddl f rule =
   case rule of
     -- a = any
@@ -370,25 +469,25 @@ validateHalf cddl f rule =
     -- a = float16
     Postlude PTHalf -> terminal rule
     -- a = 0.5
-    Literal (Value (VFloat16 f') _) | f == f' -> terminal rule
+    Literal (Value (VFloat16 f') _) | f == realToFrac f' -> terminal rule
     -- a = foo / bar
     Choice opts -> validateChoice (validateHalf cddl f) opts
     -- a = foo .ctrl bar
     Control op tgt ctrl -> ctrlDispatch (validateHalf cddl f) op tgt ctrl (controlHalf cddl f)
     -- a = x..y
-    Range (CTreeE (VRuleRef n)) high bound ->
-      dereferenceAndValidate cddl n $ \lo -> validateHalf cddl f $ Range lo high bound
-    Range low (CTreeE (VRuleRef n)) bound ->
-      dereferenceAndValidate cddl n $ \hi -> validateHalf cddl f $ Range low hi bound
-    Range (Literal (Value (VFloat16 n) _)) (Literal (Value (VFloat16 m) _)) bound
-      | n <= f && range bound f m -> terminal rule
+    CRange (Range (CTreeE (VRuleRef n)) high bound) ->
+      dereferenceAndValidate cddl n $ \lo -> validateHalf cddl f . CRange $ Range lo high bound
+    CRange (Range low (CTreeE (VRuleRef n)) bound) ->
+      dereferenceAndValidate cddl n $ \hi -> validateHalf cddl f . CRange $ Range low hi bound
+    CRange (Range (Literal (Value (VFloat16 n) _)) (Literal (Value (VFloat16 m) _)) bound)
+      | n <= realToFrac f && range bound f (realToFrac m) -> terminal rule
     _ -> unapplicable rule
 
 -- | Controls for `Float16`
 controlHalf ::
   HasCallStack =>
   CTreeRoot ValidatorPhase ->
-  Float ->
+  Half ->
   CtlOp ->
   CTree ValidatorPhase ->
   Bool
@@ -396,11 +495,11 @@ controlHalf cddl f op (CTreeE (VRuleRef n)) =
   controlHalf cddl f op $ dereference cddl n
 controlHalf _ f Eq ctrl =
   case ctrl of
-    Literal (Value (VFloat16 f') _) -> f == f'
+    Literal (Value (VFloat16 f') _) -> f == realToFrac f'
     _ -> False
 controlHalf _ f Ne ctrl =
   case ctrl of
-    Literal (Value (VFloat16 f') _) -> f /= f'
+    Literal (Value (VFloat16 f') _) -> f /= realToFrac f'
     _ -> False
 controlHalf _ _ op _ = error $ "Not yet implemented for half: " <> show op
 
@@ -413,7 +512,7 @@ validateFloat ::
   Evidenced ValidationTrace
 validateFloat cddl f (CTreeE (VRuleRef n)) =
   dereferenceAndValidate cddl n $ validateFloat cddl f
-validateFloat cddl f (CTreeE (VValidator v _)) = runCustomValidator cddl (SingleTerm $ TFloat f) v
+validateFloat cddl f (CTreeE (VValidator v _)) = runCustomValidator cddl (SingleTerm $ TermFloat f) v
 validateFloat cddl f rule =
   case rule of
     -- a = any
@@ -429,19 +528,12 @@ validateFloat cddl f rule =
     Control op tgt ctrl -> ctrlDispatch (validateFloat cddl f) op tgt ctrl (controlFloat cddl f)
     -- a = x..y
     -- TODO it is unclear if this should mix floating point types too
-    Range (CTreeE (VRuleRef n)) high bound ->
-      dereferenceAndValidate cddl n $ \lo -> validateFloat cddl f $ Range lo high bound
-    Range low (CTreeE (VRuleRef n)) bound ->
-      dereferenceAndValidate cddl n $ \hi -> validateFloat cddl f $ Range low hi bound
-    Range (Literal (Value nv _)) (Literal (Value mv _)) bound
-      | VFloat16 n <- nv
-      , VFloat16 m <- mv
-      , n <= f && range bound f m ->
-          terminal rule
-      | VFloat32 n <- nv
-      , VFloat32 m <- mv
-      , n <= f && range bound f m ->
-          terminal rule
+    CRange (Range (CTreeE (VRuleRef n)) high bound) ->
+      dereferenceAndValidate cddl n $ \lo -> validateFloat cddl f . CRange $ Range lo high bound
+    CRange (Range low (CTreeE (VRuleRef n)) bound) ->
+      dereferenceAndValidate cddl n $ \hi -> validateFloat cddl f . CRange $ Range low hi bound
+    CRange (Range (unFloatLiteral -> Just low) (unFloatLiteral -> Just high) bound)
+      | range bound low high -> terminal rule
     _ -> unapplicable rule
 
 -- | Controls for `Float32`
@@ -456,13 +548,15 @@ controlFloat cddl f op (CTreeE (VRuleRef n)) =
   controlFloat cddl f op $ dereference cddl n
 controlFloat _ f Eq ctrl =
   case ctrl of
-    Literal (Value (VFloat16 f') _) -> f == f'
+    Literal (Value (VFloat16 f') _) -> f == realToFrac f'
     Literal (Value (VFloat32 f') _) -> f == f'
+    Literal (Value (VFloat64 f') _) -> f == realToFrac f'
     _ -> False
 controlFloat _ f Ne ctrl =
   case ctrl of
-    Literal (Value (VFloat16 f') _) -> f /= f'
+    Literal (Value (VFloat16 f') _) -> f /= realToFrac f'
     Literal (Value (VFloat32 f') _) -> f /= f'
+    Literal (Value (VFloat64 f') _) -> f /= realToFrac f'
     _ -> False
 controlFloat _ _ op _ = error $ "Not yet implemented for float: " <> show op
 
@@ -475,7 +569,7 @@ validateDouble ::
   Evidenced ValidationTrace
 validateDouble cddl f (CTreeE (VRuleRef n)) =
   dereferenceAndValidate cddl n $ validateDouble cddl f
-validateDouble cddl f (CTreeE (VValidator v _)) = runCustomValidator cddl (SingleTerm $ TDouble f) v
+validateDouble cddl f (CTreeE (VValidator v _)) = runCustomValidator cddl (SingleTerm $ TermDouble f) v
 validateDouble cddl f rule =
   case rule of
     -- a = any
@@ -491,14 +585,14 @@ validateDouble cddl f rule =
     Control op tgt ctrl -> ctrlDispatch (validateDouble cddl f) op tgt ctrl (controlDouble cddl f)
     -- a = x..y
     -- TODO it is unclear if this should mix floating point types too
-    Range (CTreeE (VRuleRef n)) high bound ->
-      dereferenceAndValidate cddl n $ \lo -> validateDouble cddl f $ Range lo high bound
-    Range low (CTreeE (VRuleRef n)) bound ->
-      dereferenceAndValidate cddl n $ \hi -> validateDouble cddl f $ Range low hi bound
-    Range (Literal (Value nv _)) (Literal (Value mv _)) bound
+    CRange (Range (CTreeE (VRuleRef n)) high bound) ->
+      dereferenceAndValidate cddl n $ \lo -> validateDouble cddl f . CRange $ Range lo high bound
+    CRange (Range low (CTreeE (VRuleRef n)) bound) ->
+      dereferenceAndValidate cddl n $ \hi -> validateDouble cddl f . CRange $ Range low hi bound
+    CRange (Range (Literal (Value nv _)) (Literal (Value mv _)) bound)
       | VFloat16 n <- nv
       , VFloat16 m <- mv
-      , float2Double n <= f && range bound f (float2Double m) ->
+      , realToFrac n <= f && range bound f (realToFrac m) ->
           terminal rule
       | VFloat32 n <- nv
       , VFloat32 m <- mv
@@ -522,13 +616,13 @@ controlDouble cddl f op (CTreeE (VRuleRef n)) =
   controlDouble cddl f op $ dereference cddl n
 controlDouble _ f Eq ctrl =
   case ctrl of
-    Literal (Value (VFloat16 f') _) -> f == float2Double f'
+    Literal (Value (VFloat16 f') _) -> f == realToFrac f'
     Literal (Value (VFloat32 f') _) -> f == float2Double f'
     Literal (Value (VFloat64 f') _) -> f == f'
     _ -> False
 controlDouble _ f Ne ctrl =
   case ctrl of
-    Literal (Value (VFloat16 f') _) -> f /= float2Double f'
+    Literal (Value (VFloat16 f') _) -> f /= realToFrac f'
     Literal (Value (VFloat32 f') _) -> f /= float2Double f'
     Literal (Value (VFloat64 f') _) -> f /= f'
     _ -> False
@@ -545,7 +639,7 @@ validateBool ::
   Evidenced ValidationTrace
 validateBool cddl b (CTreeE (VRuleRef n)) =
   dereferenceAndValidate cddl n $ validateBool cddl b
-validateBool cddl b (CTreeE (VValidator v _)) = runCustomValidator cddl (SingleTerm $ TBool b) v
+validateBool cddl b (CTreeE (VValidator v _)) = runCustomValidator cddl (SingleTerm $ TermSimple (if b then 21 else 20)) v
 validateBool cddl b rule =
   case rule of
     -- a = any
@@ -591,17 +685,22 @@ validateSimple ::
   Evidenced ValidationTrace
 validateSimple cddl i (CTreeE (VRuleRef n)) =
   dereferenceAndValidate cddl n $ validateSimple cddl i
-validateSimple cddl i (CTreeE (VValidator v _)) = runCustomValidator cddl (SingleTerm $ TSimple i) v
-validateSimple cddl 23 rule =
-  case rule of
-    -- a = any
-    Postlude PTAny -> terminal rule
-    -- a = undefined
-    Postlude PTUndefined -> terminal rule
-    -- a = foo / bar
-    Choice opts -> validateChoice (validateSimple cddl 23) opts
-    _ -> unapplicable rule
-validateSimple _ n _ = error $ "Found simple different to 23! please report this somewhere! Found: " <> show n
+validateSimple cddl i (CTreeE (VValidator v _)) = runCustomValidator cddl (SingleTerm $ TermSimple i) v
+validateSimple cddl i rule =
+  case i of
+    20 -> validateBool cddl False rule
+    21 -> validateBool cddl True rule
+    22 -> validateNull cddl rule
+    23 ->
+      case rule of
+        -- a = any
+        Postlude PTAny -> terminal rule
+        -- a = undefined
+        Postlude PTUndefined -> terminal rule
+        -- a = foo / bar
+        Choice opts -> validateChoice (validateSimple cddl 23) opts
+        _ -> unapplicable rule
+    _ -> error $ "Invalid simple value: " <> show i
 
 --------------------------------------------------------------------------------
 -- Null/nil
@@ -610,7 +709,7 @@ validateSimple _ n _ = error $ "Found simple different to 23! please report this
 validateNull :: CTreeRoot ValidatorPhase -> CTree ValidatorPhase -> Evidenced ValidationTrace
 validateNull cddl (CTreeE (VRuleRef n)) =
   dereferenceAndValidate cddl n $ validateNull cddl
-validateNull cddl (CTreeE (VValidator v _)) = runCustomValidator cddl (SingleTerm TNull) v
+validateNull cddl (CTreeE (VValidator v _)) = runCustomValidator cddl (SingleTerm $ TermSimple 22) v
 validateNull cddl rule =
   case rule of
     -- a = any
@@ -628,7 +727,7 @@ validateBytes ::
   CTreeRoot ValidatorPhase -> BS.ByteString -> CTree ValidatorPhase -> Evidenced ValidationTrace
 validateBytes cddl bs (CTreeE (VRuleRef n)) =
   dereferenceAndValidate cddl n $ validateBytes cddl bs
-validateBytes cddl bs (CTreeE (VValidator v _)) = runCustomValidator cddl (SingleTerm $ TBytes bs) v
+validateBytes cddl bs (CTreeE (VValidator v _)) = runCustomValidator cddl (SingleTerm $ TermBytes bs) v
 validateBytes cddl bs rule =
   case rule of
     -- a = any
@@ -656,18 +755,18 @@ controlBytes cddl bs op (CTreeE (VRuleRef n)) =
 controlBytes cddl bs op@Size ctrl =
   case ctrl of
     Literal (Value (VUInt sz) _) -> fromIntegral (BS.length bs) == sz
-    Range (CTreeE (VRuleRef n)) high bound ->
-      dereference cddl n & \lo -> controlBytes cddl bs op $ Range lo high bound
-    Range low (CTreeE (VRuleRef n)) bound ->
-      dereference cddl n & \hi -> controlBytes cddl bs op $ Range low hi bound
-    Range low high bound ->
-      let i = BS.length bs
+    CRange (Range (CTreeE (VRuleRef n)) high bound) ->
+      dereference cddl n & \lo -> controlBytes cddl bs op . CRange $ Range lo high bound
+    CRange (Range low (CTreeE (VRuleRef n)) bound) ->
+      dereference cddl n & \hi -> controlBytes cddl bs op . CRange $ Range low hi bound
+    CRange (Range low high bound) ->
+      let i = toInteger $ BS.length bs
        in case (low, high) of
-            (Literal (Value (VUInt (fromIntegral -> n)) _), Literal (Value (VUInt (fromIntegral -> m)) _)) ->
+            (Literal (Value (VUInt (toInteger -> n)) _), Literal (Value (VUInt (toInteger -> m)) _)) ->
               boundPlacement i (Just n, Just m) bound == WithinBounds
-            (Literal (Value (VNInt (fromIntegral -> n)) _), Literal (Value (VUInt (fromIntegral -> m)) _)) ->
+            (Literal (Value (VNInt (fromNInt -> n)) _), Literal (Value (VUInt (toInteger -> m)) _)) ->
               boundPlacement i (Just $ -n, Just m) bound == WithinBounds
-            (Literal (Value (VNInt (fromIntegral -> n)) _), Literal (Value (VNInt (fromIntegral -> m)) _)) ->
+            (Literal (Value (VNInt (fromNInt -> n)) _), Literal (Value (VNInt (fromNInt -> m)) _)) ->
               boundPlacement i (Just $ -n, Just $ -m) bound == WithinBounds
             _ -> False
     _ -> False
@@ -677,7 +776,7 @@ controlBytes cddl bs Bits ctrl = do
       case ctrl of
         Literal (Value (VUInt i') _) -> [i']
         Choice nodes -> getIndicesOfChoice cddl nodes
-        Range ff tt incl -> getIndicesOfRange cddl ff tt incl
+        CRange (Range ff tt incl) -> getIndicesOfRange cddl ff tt incl
         Enum g -> getIndicesOfEnum cddl g
         _ -> error "Not yet implemented"
   bitsControlCheck (map fromIntegral indices)
@@ -694,12 +793,12 @@ controlBytes cddl bs Bits ctrl = do
                   Nothing -> True
        in all isAllowedBit [0 .. totalBits - 1]
 controlBytes cddl bs Cbor ctrl =
-  case deserialiseFromBytes decodeTerm (BSL.fromStrict bs) of
+  case deserialiseFromBytes decodeCBORTerm (BSL.fromStrict bs) of
     Right (BSL.null -> True, term) -> isValid $ validateTerm cddl term ctrl
     _ -> False
 controlBytes cddl bs Cborseq ctrl =
-  case deserialiseFromBytes decodeTerm (BSL.fromStrict (BS.snoc (BS.cons 0x9f bs) 0xff)) of
-    Right (BSL.null -> True, TListI terms) -> isValid $ validateTerm cddl (TList terms) (Array [Occur ctrl OIZeroOrMore])
+  case deserialiseFromBytes decodeCBORTerm (BSL.fromStrict (BS.snoc (BS.cons 0x9f bs) 0xff)) of
+    Right (BSL.null -> True, TermArrayI terms) -> isValid $ validateTerm cddl (TermArray terms) (Array [Occur ctrl OIZeroOrMore])
     _ -> False
 controlBytes _ _ op _ = error $ "Not yet implmented for bytes: " <> show op
 
@@ -714,7 +813,7 @@ validateText ::
   Evidenced ValidationTrace
 validateText cddl txt (CTreeE (VRuleRef n)) =
   dereferenceAndValidate cddl n $ validateText cddl txt
-validateText cddl txt (CTreeE (VValidator v _)) = runCustomValidator cddl (SingleTerm $ TString txt) v
+validateText cddl txt (CTreeE (VValidator v _)) = runCustomValidator cddl (SingleTerm $ TermString txt) v
 validateText cddl txt rule =
   case rule of
     -- a = any
@@ -740,21 +839,21 @@ controlText ::
 controlText cddl bs op (CTreeE (VRuleRef n)) =
   controlText cddl bs op $ dereference cddl n
 controlText cddl bs op@Size ctrl =
-  let bsSize = BS.length $ encodeUtf8 bs
+  let bsSize = toInteger . BS.length $ encodeUtf8 bs
    in case ctrl of
         Literal (Value (VUInt (fromIntegral -> sz)) _) -> bsSize == sz
-        Range (CTreeE (VRuleRef n)) high bound ->
-          dereference cddl n & \lo -> controlText cddl bs op $ Range lo high bound
-        Range low (CTreeE (VRuleRef n)) bound ->
-          dereference cddl n & \hi -> controlText cddl bs op $ Range low hi bound
-        Range ff tt bound ->
+        CRange (Range (CTreeE (VRuleRef n)) high bound) ->
+          dereference cddl n & \lo -> controlText cddl bs op . CRange $ Range lo high bound
+        CRange (Range low (CTreeE (VRuleRef n)) bound) ->
+          dereference cddl n & \hi -> controlText cddl bs op . CRange $ Range low hi bound
+        CRange (Range ff tt bound) ->
           case (ff, tt) of
-            (Literal (Value (VUInt (fromIntegral -> n)) _), Literal (Value (VUInt (fromIntegral -> m)) _)) ->
-              n <= T.length bs && range bound bsSize m
-            (Literal (Value (VNInt (fromIntegral -> n)) _), Literal (Value (VUInt (fromIntegral -> m)) _)) ->
-              -n <= T.length bs && range bound bsSize m
-            (Literal (Value (VNInt (fromIntegral -> n)) _), Literal (Value (VNInt (fromIntegral -> m)) _)) ->
-              -n <= T.length bs && range bound bsSize (-m)
+            (Literal (Value (VUInt (toInteger -> n)) _), Literal (Value (VUInt (toInteger -> m)) _)) ->
+              n <= toInteger (T.length bs) && range bound bsSize m
+            (Literal (Value (VNInt (fromNInt -> n)) _), Literal (Value (VUInt (toInteger -> m)) _)) ->
+              -n <= toInteger (T.length bs) && range bound bsSize m
+            (Literal (Value (VNInt (fromNInt -> n)) _), Literal (Value (VNInt (fromNInt -> m)) _)) ->
+              -n <= toInteger (T.length bs) && range bound bsSize (-m)
             _ -> False
         _ -> error "Invalid control value in .size"
 controlText _ s Regexp ctrl =
@@ -770,10 +869,10 @@ controlText _ _ op _ = error $ "Not yet implemented for text: " <> show op
 
 -- | Validating a `TTagged`
 validateTagged ::
-  CTreeRoot ValidatorPhase -> Word64 -> Term -> CTree ValidatorPhase -> Evidenced ValidationTrace
+  CTreeRoot ValidatorPhase -> Word64 -> CBORTerm -> CTree ValidatorPhase -> Evidenced ValidationTrace
 validateTagged cddl tag term (CTreeE (VRuleRef n)) =
   dereferenceAndValidate cddl n $ validateTagged cddl tag term
-validateTagged cddl tag term (CTreeE (VValidator v _)) = runCustomValidator cddl (SingleTerm $ TTagged tag term) v
+validateTagged cddl tag term (CTreeE (VValidator v _)) = runCustomValidator cddl (SingleTerm $ TermTag tag term) v
 validateTagged cddl tag term rule =
   case rule of
     Postlude PTAny -> terminal rule
@@ -822,12 +921,12 @@ decrementBounds (lb, ub) = OIBounded (clampedPred <$> lb) (clampedPred <$> ub)
 
 validateList ::
   CTreeRoot ValidatorPhase ->
-  [Term] ->
+  [CBORTerm] ->
   CTree ValidatorPhase ->
   Evidenced ValidationTrace
 validateList cddl terms (CTreeE (VRuleRef n)) =
   dereferenceAndValidate cddl n $ validateList cddl terms
-validateList cddl terms (CTreeE (VValidator v _)) = runCustomValidator cddl (SingleTerm $ TList terms) v
+validateList cddl terms (CTreeE (VValidator v _)) = runCustomValidator cddl (SingleTerm $ TermArray terms) v
 validateList cddl terms rule =
   case rule of
     Postlude PTAny -> terminal rule
@@ -852,11 +951,11 @@ validateList cddl terms rule =
     _ -> unapplicable rule
   where
     validate ::
-      ([CTree ValidatorPhase] -> [Term] -> Evidenced ListValidationTrace) ->
+      ([CTree ValidatorPhase] -> [CBORTerm] -> Evidenced ListValidationTrace) ->
       [CTree ValidatorPhase] ->
-      [Term] ->
+      [CBORTerm] ->
       [CTree ValidatorPhase] ->
-      (Evidenced ListValidationTrace, [Term])
+      (Evidenced ListValidationTrace, [CBORTerm])
     validate f skipped tss [] = (f skipped tss, tss)
     validate f skipped [] (r : rs)
       | isOptional r = validate f skipped [] rs
@@ -914,12 +1013,12 @@ validateList cddl terms rule =
 validateMap ::
   HasCallStack =>
   CTreeRoot ValidatorPhase ->
-  [(Term, Term)] ->
+  [(CBORTerm, CBORTerm)] ->
   CTree ValidatorPhase ->
   Evidenced ValidationTrace
 validateMap cddl terms (CTreeE (VRuleRef n)) =
   dereferenceAndValidate cddl n $ validateMap cddl terms
-validateMap cddl terms (CTreeE (VValidator v _)) = runCustomValidator cddl (SingleTerm $ TMap terms) v
+validateMap cddl terms (CTreeE (VValidator v _)) = runCustomValidator cddl (SingleTerm $ TermMap terms) v
 validateMap cddl terms rule =
   case rule of
     Postlude PTAny -> terminal rule
@@ -929,7 +1028,7 @@ validateMap cddl terms rule =
   where
     validate ::
       [CTree ValidatorPhase] ->
-      [(Term, Term)] ->
+      [(CBORTerm, CBORTerm)] ->
       [CTree ValidatorPhase] ->
       Set CanonicalTerm ->
       Evidenced MapValidationTrace
@@ -1062,7 +1161,7 @@ getIndicesOfChoice cddl = concatMap go
             error $
               "Malformed value in KV in choice in .bits: "
                 <> showSimple somethingElse
-      Range ff tt incl -> getIndicesOfRange cddl ff tt incl
+      CRange (Range ff tt incl) -> getIndicesOfRange cddl ff tt incl
       Enum g -> getIndicesOfEnum cddl g
       somethingElse ->
         error $

--- a/src/Codec/CBOR/Cuddle/CBOR/Validator.hs
+++ b/src/Codec/CBOR/Cuddle/CBOR/Validator.hs
@@ -12,12 +12,11 @@ module Codec.CBOR.Cuddle.CBOR.Validator (
 ) where
 
 import Codec.CBOR.Cuddle.CBOR.Canonical (CanonicalTerm, toCanonical)
+import Codec.CBOR.Cuddle.CBOR.NInt (NInt, fromNInt)
 import Codec.CBOR.Cuddle.CBOR.Term (
   CBORTerm (..),
-  NInt,
   bytesToUnsigned,
   decodeCBORTerm,
-  fromNInt,
   mkTermArray,
   mkTermBytes,
   mkTermMap,

--- a/src/Codec/CBOR/Cuddle/CBOR/Validator.hs
+++ b/src/Codec/CBOR/Cuddle/CBOR/Validator.hs
@@ -849,11 +849,11 @@ controlText cddl bs op@Size ctrl =
         CRange (Range ff tt bound) ->
           case (ff, tt) of
             (Literal (Value (VUInt (toInteger -> n)) _), Literal (Value (VUInt (toInteger -> m)) _)) ->
-              n <= toInteger (T.length bs) && range bound bsSize m
+              bsSize `isInRange` Range n m bound
             (Literal (Value (VNInt (fromNInt -> n)) _), Literal (Value (VUInt (toInteger -> m)) _)) ->
-              n <= toInteger (T.length bs) && range bound bsSize m
+              bsSize `isInRange` Range n m bound
             (Literal (Value (VNInt (fromNInt -> n)) _), Literal (Value (VNInt (fromNInt -> m)) _)) ->
-              n <= toInteger (T.length bs) && range bound bsSize m
+              bsSize `isInRange` Range n m bound
             _ -> False
         _ -> error "Invalid control value in .size"
 controlText _ s Regexp ctrl =

--- a/src/Codec/CBOR/Cuddle/CBOR/Validator.hs
+++ b/src/Codec/CBOR/Cuddle/CBOR/Validator.hs
@@ -12,7 +12,14 @@ module Codec.CBOR.Cuddle.CBOR.Validator (
 ) where
 
 import Codec.CBOR.Cuddle.CBOR.Canonical (CanonicalTerm, toCanonical)
-import Codec.CBOR.Cuddle.CBOR.Term (CBORTerm (..), NInt, decodeCBORTerm, fromNInt)
+import Codec.CBOR.Cuddle.CBOR.Term (
+  CBORTerm (..),
+  NInt,
+  bytesToUnsigned,
+  decodeCBORTerm,
+  fromNInt,
+  unwrapBytes,
+ )
 import Codec.CBOR.Cuddle.CBOR.Validator.Trace (
   ControlInfo (..),
   Evidenced (..),
@@ -284,104 +291,6 @@ validateNInt cddl i rule =
   where
     i' = fromNInt i
 
--- validateInteger ::
---  HasCallStack =>
---  CTreeRoot ValidatorPhase ->
---  Integer ->
---  CTree ValidatorPhase ->
---  Evidenced ValidationTrace
--- validateInteger cddl i rule =
---  case rule of
---    CTreeE (VRuleRef n) -> dereferenceAndValidate cddl n $ validateInteger cddl i
---    CTreeE (VValidator v _) -> runCustomValidator cddl (SingleTerm $ TInteger i) v
---    -- echo "C24101" | xxd -r -p - example.cbor
---    -- echo "foo = int" > a.cddl
---    -- cddl a.cddl validate example.cbor
---    --
---    -- but
---    --
---    -- echo "C249010000000000000000"| xxd -r -p - example.cbor
---    -- echo "foo = int" > a.cddl
---    -- cddl a.cddl validate example.cbor
---    --
---    -- and they are both bigints?
---
---    -- a = any
---    Postlude PTAny -> terminal rule
---    -- a = int
---    Postlude PTInt
---      | i >= nintMin && i <= uintMax -> terminal rule
---    -- a = uint
---    Postlude PTUInt
---      | i >= 0 && i <= uintMax -> terminal rule
---    -- a = nint
---    Postlude PTNInt
---      | i >= nintMin && i <= -1 -> terminal rule
---    -- a = x
---    Literal (Value (VUInt i') _) | i == fromIntegral i' -> terminal rule
---    -- a = -x
---    Literal (Value (VNInt i') _) | -i == fromIntegral i' -> terminal rule
---    -- a = <big number>
---    Literal (Value (VBignum i') _) | i == i' -> terminal rule
---    -- a = foo .ctrl bar
---    Control op tgt ctrl -> ctrlDispatch (validateInteger cddl i) op tgt ctrl (controlInteger cddl i)
---    -- a = foo / bar
---    Choice opts -> validateChoice (validateInteger cddl i) opts
---    -- a = x..y
---    Range low high bound ->
---      case (low, high) of
---        (Literal (Value (VUInt (fromIntegral -> n)) _), Literal (Value (VUInt (fromIntegral -> m)) _))
---          | n <= i && range bound i m -> terminal rule
---          | otherwise -> unapplicable rule
---        (Literal (Value (VNInt (fromIntegral -> n)) _), Literal (Value (VUInt (fromIntegral -> m)) _))
---          | -n <= i && range bound i m -> terminal rule
---          | otherwise -> unapplicable rule
---        (Literal (Value (VNInt (fromIntegral -> n)) _), Literal (Value (VNInt (fromIntegral -> m)) _))
---          | -n <= i && range bound i (-m) -> terminal rule
---          | otherwise -> unapplicable rule
---        (Literal (Value VUInt {} _), Literal (Value VNInt {} _)) -> error "range types mismatch"
---        (Literal (Value (VBignum n) _), Literal (Value (VUInt (fromIntegral -> m)) _))
---          | n <= i && range bound i m -> terminal rule
---          | otherwise -> unapplicable rule
---        (Literal (Value (VBignum n) _), Literal (Value (VNInt (fromIntegral -> m)) _))
---          | n <= i && range bound i (-m) -> terminal rule
---          | otherwise -> unapplicable rule
---        (Literal (Value (VUInt (fromIntegral -> n)) _), Literal (Value (VBignum m) _))
---          | n <= i && range bound i m -> terminal rule
---          | otherwise -> unapplicable rule
---        (Literal (Value (VNInt (fromIntegral -> n)) _), Literal (Value (VBignum m) _))
---          | (-n) <= i && range bound i m -> terminal rule
---          | otherwise -> unapplicable rule
---        (CTreeE (VRuleRef n), _) ->
---          dereferenceAndValidate cddl n $ \lo -> validateInteger cddl i (Range lo high bound)
---        (_, CTreeE (VRuleRef n)) ->
---          dereferenceAndValidate cddl n $ \hi -> validateInteger cddl i (Range low hi bound)
---        (lo, hi) -> error $ "Unable to validate range: (" <> showSimple lo <> ", " <> showSimple hi <> ")"
---    -- a = &(x, y, z)
---    Enum g ->
---      case g of
---        CTreeE (VRuleRef n) -> dereferenceAndValidate cddl n $ validateInteger cddl i
---        Group g' -> validateInteger cddl i (Choice (NE.fromList g'))
---        _ -> error "Not yet implemented"
---    -- a = x: y
---    -- Note KV cannot appear on its own, but we will use this when validating
---    -- lists.
---    KV _ v _ -> validateInteger cddl i v
---    Tag 2 x -> validateBigInt x
---    Tag 3 x -> validateBigInt x
---    _ -> unapplicable rule
---  where
---    validateBigInt x = case x of
---      CTreeE (VRuleRef n) -> dereferenceAndValidate cddl n validateBigInt
---      Postlude PTBytes -> terminal rule
---      Control op tgt@(Postlude PTBytes) ctrl ->
---        ctrlDispatch (validateBytes cddl bs) op tgt ctrl (controlBytes cddl bs)
---        where
---          -- TODO figure out a way to turn Integer into bytes or figure out why
---          -- tagged bigints are decoded as integers in the first place
---          bs = mempty
---      _ -> unapplicable rule
-
 -- | Controls for an Integer
 controlInteger ::
   HasCallStack =>
@@ -482,7 +391,7 @@ validateHalf cddl f rule =
     CRange (Range low (CTreeE (VRuleRef n)) bound) ->
       dereferenceAndValidate cddl n $ \hi -> validateHalf cddl f . CRange $ Range low hi bound
     CRange (Range (Literal (Value (VFloat16 n) _)) (Literal (Value (VFloat16 m) _)) bound)
-      | n <= realToFrac f && range bound f (realToFrac m) -> terminal rule
+      | f `isInRange` Range n m bound -> terminal rule
     _ -> unapplicable rule
 
 -- | Controls for `Float16`
@@ -535,7 +444,7 @@ validateFloat cddl f rule =
     CRange (Range low (CTreeE (VRuleRef n)) bound) ->
       dereferenceAndValidate cddl n $ \hi -> validateFloat cddl f . CRange $ Range low hi bound
     CRange (Range (unFloatLiteral -> Just low) (unFloatLiteral -> Just high) bound)
-      | range bound low high -> terminal rule
+      | realToFrac f `isInRange` Range low high bound -> terminal rule
     _ -> unapplicable rule
 
 -- | Controls for `Float32`
@@ -591,18 +500,10 @@ validateDouble cddl f rule =
       dereferenceAndValidate cddl n $ \lo -> validateDouble cddl f . CRange $ Range lo high bound
     CRange (Range low (CTreeE (VRuleRef n)) bound) ->
       dereferenceAndValidate cddl n $ \hi -> validateDouble cddl f . CRange $ Range low hi bound
-    CRange (Range (Literal (Value nv _)) (Literal (Value mv _)) bound)
-      | VFloat16 n <- nv
-      , VFloat16 m <- mv
-      , realToFrac n <= f && range bound f (realToFrac m) ->
-          terminal rule
-      | VFloat32 n <- nv
-      , VFloat32 m <- mv
-      , float2Double n <= f && range bound f (float2Double m) ->
-          terminal rule
-      | VFloat64 n <- nv
-      , VFloat64 m <- mv
-      , n <= f && range bound f m ->
+    CRange (Range nv mv bound)
+      | Just n <- unFloatLiteral nv
+      , Just m <- unFloatLiteral mv
+      , f `isInRange` Range (realToFrac n) (realToFrac m) bound ->
           terminal rule
     _ -> unapplicable rule
 
@@ -878,6 +779,17 @@ validateTagged cddl tag term (CTreeE (VValidator v _)) = runCustomValidator cddl
 validateTagged cddl tag term rule =
   case rule of
     Postlude PTAny -> terminal rule
+    Literal (Value (VBignum i) _)
+      | i >= 0
+      , tag == 2
+      , Just bs <- unwrapBytes term
+      , bytesToUnsigned bs == i ->
+          terminal rule
+      | i < 0
+      , tag == 3
+      , Just bs <- unwrapBytes term
+      , negate (bytesToUnsigned bs) == i ->
+          terminal rule
     Tag tag' rule' ->
       -- If the tag does not match, this is a direct fail
       if tag == tag'
@@ -914,6 +826,9 @@ boundPlacement x (Just lo, mHi) bounds
 boundPlacement x (Nothing, Just hi) bounds
   | range bounds x hi = WithinBounds
   | otherwise = AboveBounds
+  where
+    range ClOpen a upper = a < upper
+    range Closed a upper = a <= upper
 
 decrementBounds :: (Maybe Word64, Maybe Word64) -> OccurrenceIndicator
 decrementBounds (lb, ub) = OIBounded (clampedPred <$> lb) (clampedPred <$> ub)
@@ -1209,10 +1124,3 @@ dereferenceAndValidate ::
   Evidenced ValidationTrace
 dereferenceAndValidate cddl n f =
   mapTrace (ReferenceRule n) . f $ dereference cddl n
-
---------------------------------------------------------------------------------
--- Utils
-
-range :: Ord a => RangeBound -> a -> a -> Bool
-range Closed = (<=)
-range ClOpen = (<)

--- a/src/Codec/CBOR/Cuddle/CBOR/Validator.hs
+++ b/src/Codec/CBOR/Cuddle/CBOR/Validator.hs
@@ -245,7 +245,7 @@ validateNInt cddl i rule =
     CTreeE (VValidator v _) -> runCustomValidator cddl (SingleTerm $ TermNInt i) v
     Postlude PTAny -> terminal rule
     Postlude PTInt -> terminal rule
-    Postlude PTUInt -> terminal rule
+    Postlude PTNInt -> terminal rule
     Literal (Value (VNInt j) _) | i' == fromNInt j -> terminal rule
     Control op tgt ctrl -> ctrlDispatch (validateNInt cddl i) op tgt ctrl (controlInteger cddl i')
     Choice opts -> validateChoice (validateNInt cddl i) opts
@@ -255,7 +255,9 @@ validateNInt cddl i rule =
         (Literal (Value (VNInt (fromNInt -> n)) _), Literal (Value (VUInt (toInteger -> m)) _))
           | i' `isInRange` Range n m bound -> terminal rule
           | otherwise -> unapplicable rule
-        (Literal (Value (VNInt _) _), Literal (Value (VNInt _) _)) -> unapplicable rule
+        (Literal (Value (VNInt (fromNInt -> n)) _), Literal (Value (VNInt (fromNInt -> m)) _))
+          | i' `isInRange` Range n m bound -> terminal rule
+          | otherwise -> unapplicable rule
         (Literal (Value VUInt {} _), Literal (Value VNInt {} _)) -> error "range types mismatch"
         (Literal (Value (VBignum n) _), Literal (Value (VUInt (toInteger -> m)) _))
           | i' `isInRange` Range n m bound -> terminal rule

--- a/src/Codec/CBOR/Cuddle/CBOR/Validator.hs
+++ b/src/Codec/CBOR/Cuddle/CBOR/Validator.hs
@@ -702,7 +702,8 @@ validateTagged cddl tag term rule =
       | i < 0
       , tag == 3
       , Just bs <- unwrapBytes term
-      , negate (bytesToUnsigned bs) == i ->
+      , -- RFC 8949 §3.4.3: tag 3 content n denotes -1 - n
+        -1 - bytesToUnsigned bs == i ->
           terminal rule
     Tag tag' rule' ->
       -- If the tag does not match, this is a direct fail

--- a/src/Codec/CBOR/Cuddle/CBOR/Validator.hs
+++ b/src/Codec/CBOR/Cuddle/CBOR/Validator.hs
@@ -390,8 +390,8 @@ validateHalf cddl f rule =
       dereferenceAndValidate cddl n $ \lo -> validateHalf cddl f . CRange $ Range lo high bound
     CRange (Range low (CTreeE (VRuleRef n)) bound) ->
       dereferenceAndValidate cddl n $ \hi -> validateHalf cddl f . CRange $ Range low hi bound
-    CRange (Range (Literal (Value (VFloat16 n) _)) (Literal (Value (VFloat16 m) _)) bound)
-      | f `isInRange` Range n m bound -> terminal rule
+    CRange (Range (unFloatLiteral -> Just n) (unFloatLiteral -> Just m) bound)
+      | realToFrac f `isInRange` Range n m bound -> terminal rule
     _ -> unapplicable rule
 
 -- | Controls for `Float16`

--- a/src/Codec/CBOR/Cuddle/CBOR/Validator.hs
+++ b/src/Codec/CBOR/Cuddle/CBOR/Validator.hs
@@ -249,7 +249,7 @@ validateNInt cddl i rule =
   where
     i' = fromNInt i
 
--- | The integer value of a literal range bound. Unlike 'unIntLiteral' this
+-- | The integer value of a literal range bound. Unlike 'unIntegerLiteral' this
 -- also interprets bignum literals, which is safe here because the value is
 -- only compared against, never narrowed to a machine word.
 intBound :: CTree ValidatorPhase -> Maybe Integer
@@ -299,7 +299,7 @@ validateFloatRange ::
   Evidenced ValidationTrace
 validateFloatRange cddl self f rng@(Range low high bound) =
   case (low, high) of
-    (unFloatLiteral -> Just n, unFloatLiteral -> Just m)
+    (unDoubleLiteral -> Just n, unDoubleLiteral -> Just m)
       | f `isInRange` Range n m bound -> terminal rule
       | otherwise -> unapplicable rule
     (CTreeE (VRuleRef n), _) ->
@@ -340,22 +340,22 @@ controlInteger cddl i Bits ctrl = do
           allowed = not bitSet || IS.member idx indices
        in allowed && go indices (shiftR n 1) (idx + 1)
 controlInteger _ i Lt ctrl
-  | Just i' <- unIntLiteral ctrl = i < i'
+  | Just i' <- unIntegerLiteral ctrl = i < i'
   | otherwise = False
 controlInteger _ i Gt ctrl
-  | Just i' <- unIntLiteral ctrl = i > i'
+  | Just i' <- unIntegerLiteral ctrl = i > i'
   | otherwise = False
 controlInteger _ i Le ctrl
-  | Just i' <- unIntLiteral ctrl = i <= i'
+  | Just i' <- unIntegerLiteral ctrl = i <= i'
   | otherwise = False
 controlInteger _ i Ge ctrl
-  | Just i' <- unIntLiteral ctrl = i >= i'
+  | Just i' <- unIntegerLiteral ctrl = i >= i'
   | otherwise = False
 controlInteger _ i Eq ctrl
-  | Just i' <- unIntLiteral ctrl = i == i'
+  | Just i' <- unIntegerLiteral ctrl = i == i'
   | otherwise = False
 controlInteger _ i Ne ctrl
-  | Just i' <- unIntLiteral ctrl = i /= i'
+  | Just i' <- unIntegerLiteral ctrl = i /= i'
   | otherwise = False
 controlInteger _ _ _ ctrl = error $ "unexpected control: " <> showSimple ctrl
 
@@ -448,10 +448,10 @@ controlFloat ::
 controlFloat cddl f op (CTreeE (VRuleRef n)) =
   controlFloat cddl f op $ dereference cddl n
 controlFloat _ f Eq ctrl
-  | Just f' <- unFloatLiteral ctrl = realToFrac f == f'
+  | Just f' <- unDoubleLiteral ctrl = realToFrac f == f'
   | otherwise = False
 controlFloat _ f Ne ctrl
-  | Just f' <- unFloatLiteral ctrl = realToFrac f /= f'
+  | Just f' <- unDoubleLiteral ctrl = realToFrac f /= f'
   | otherwise = False
 controlFloat _ _ op _ = error $ "Not yet implemented for float: " <> show op
 
@@ -493,10 +493,10 @@ controlDouble ::
 controlDouble cddl f op (CTreeE (VRuleRef n)) =
   controlDouble cddl f op $ dereference cddl n
 controlDouble _ f Eq ctrl
-  | Just f' <- unFloatLiteral ctrl = f == f'
+  | Just f' <- unDoubleLiteral ctrl = f == f'
   | otherwise = False
 controlDouble _ f Ne ctrl
-  | Just f' <- unFloatLiteral ctrl = f /= f'
+  | Just f' <- unDoubleLiteral ctrl = f /= f'
   | otherwise = False
 controlDouble _ _ op _ = error $ "Not yet implmented for double: " <> show op
 
@@ -593,7 +593,7 @@ controlBytes cddl bs op@Size ctrl =
       dereference cddl n & \lo -> controlBytes cddl bs op . CRange $ Range lo high bound
     CRange (Range low (CTreeE (VRuleRef n)) bound) ->
       dereference cddl n & \hi -> controlBytes cddl bs op . CRange $ Range low hi bound
-    CRange (Range (unIntLiteral -> Just n) (unIntLiteral -> Just m) bound) ->
+    CRange (Range (unIntegerLiteral -> Just n) (unIntegerLiteral -> Just m) bound) ->
       let i = toInteger $ BS.length bs
        in boundPlacement i (Just n, Just m) bound == WithinBounds
     _ -> False
@@ -673,7 +673,7 @@ controlText cddl bs op@Size ctrl =
           dereference cddl n & \lo -> controlText cddl bs op . CRange $ Range lo high bound
         CRange (Range low (CTreeE (VRuleRef n)) bound) ->
           dereference cddl n & \hi -> controlText cddl bs op . CRange $ Range low hi bound
-        CRange (Range (unIntLiteral -> Just n) (unIntLiteral -> Just m) bound) ->
+        CRange (Range (unIntegerLiteral -> Just n) (unIntegerLiteral -> Just m) bound) ->
           bsSize `isInRange` Range n m bound
         _ -> error "Invalid control value in .size"
 controlText _ s Regexp ctrl =

--- a/src/Codec/CBOR/Cuddle/CBOR/Validator/Trace.hs
+++ b/src/Codec/CBOR/Cuddle/CBOR/Validator/Trace.hs
@@ -31,11 +31,11 @@ module Codec.CBOR.Cuddle.CBOR.Validator.Trace (
 ) where
 
 import Codec.CBOR.Cuddle.CBOR.Canonical (CanonicalTerm)
+import Codec.CBOR.Cuddle.CBOR.Term (CBORTerm)
 import Codec.CBOR.Cuddle.CDDL (Name (..))
 import Codec.CBOR.Cuddle.CDDL.CTree (CTree (..))
 import Codec.CBOR.Cuddle.CDDL.CtlOp (CtlOp)
 import Codec.CBOR.Cuddle.CDDL.Resolve (MonoSimplePhase)
-import Codec.CBOR.Term (Term)
 import Data.Foldable (Foldable (..))
 import Data.Function (on)
 import Data.Kind (Type)
@@ -108,7 +108,7 @@ deriving instance Show (ValidationTrace v)
 data ListValidationTrace (v :: Validity) where
   ListValidationDone :: ListValidationTrace IsValid
   ListValidationLeftoverTerms ::
-    NonEmpty Term ->
+    NonEmpty CBORTerm ->
     Maybe (CTree MonoSimplePhase, ValidationTrace IsInvalid) ->
     ListValidationTrace IsInvalid
   ListValidationUnappliedRule ::
@@ -138,7 +138,7 @@ deriving instance Show (ListValidationTrace v)
 data MapValidationTrace (v :: Validity) where
   MapValidationDone :: MapValidationTrace IsValid
   MapValidationLeftoverKVs ::
-    (Term, Term) ->
+    (CBORTerm, CBORTerm) ->
     Maybe (CTree MonoSimplePhase, MapValidationTrace IsInvalid) ->
     MapValidationTrace IsInvalid
   MapValidationUnappliedRules :: NonEmpty (CTree MonoSimplePhase) -> MapValidationTrace IsInvalid

--- a/src/Codec/CBOR/Cuddle/CDDL.hs
+++ b/src/Codec/CBOR/Cuddle/CDDL.hs
@@ -49,7 +49,7 @@ module Codec.CBOR.Cuddle.CDDL (
   XXType2,
 ) where
 
-import Codec.CBOR.Cuddle.CBOR.Term (NInt)
+import Codec.CBOR.Cuddle.CBOR.NInt (NInt)
 import Codec.CBOR.Cuddle.CDDL.CtlOp (CtlOp)
 import Codec.CBOR.Cuddle.Comments (CollectComments (..), Comment, HasComment (..))
 import Codec.CBOR.Cuddle.Orphans ()

--- a/src/Codec/CBOR/Cuddle/CDDL.hs
+++ b/src/Codec/CBOR/Cuddle/CDDL.hs
@@ -49,8 +49,10 @@ module Codec.CBOR.Cuddle.CDDL (
   XXType2,
 ) where
 
+import Codec.CBOR.Cuddle.CBOR.Term (NInt)
 import Codec.CBOR.Cuddle.CDDL.CtlOp (CtlOp)
 import Codec.CBOR.Cuddle.Comments (CollectComments (..), Comment, HasComment (..))
+import Codec.CBOR.Cuddle.Orphans ()
 import Data.ByteString qualified as B
 import Data.Default.Class (Default (..))
 import Data.Function (on)
@@ -63,6 +65,7 @@ import Data.Text qualified as T
 import Data.Word (Word64, Word8)
 import GHC.Base (Constraint, Type)
 import GHC.Generics (Generic)
+import Numeric.Half (Half)
 import Optics.Core ((%), (%~), (&))
 
 data family XXTopLevel i
@@ -559,9 +562,9 @@ value x = Value x mempty
 
 data ValueVariant
   = VUInt Word64
-  | VNInt Word64
+  | VNInt NInt
   | VBignum Integer
-  | VFloat16 Float
+  | VFloat16 Half
   | VFloat32 Float
   | VFloat64 Double
   | VText T.Text

--- a/src/Codec/CBOR/Cuddle/CDDL/CTree.hs
+++ b/src/Codec/CBOR/Cuddle/CDDL/CTree.hs
@@ -5,6 +5,7 @@
 
 module Codec.CBOR.Cuddle.CDDL.CTree (
   XXCTree,
+  Range (..),
   CTree (..),
   traverseCTree,
   foldCTree,
@@ -13,10 +14,12 @@ module Codec.CBOR.Cuddle.CDDL.CTree (
   PTerm (..),
   uintMax,
   nintMin,
+  unIntLiteral,
+  unFloatLiteral,
 ) where
 
-import Codec.CBOR.Cuddle.CBOR.Canonical (nintMin, uintMax)
-import Codec.CBOR.Cuddle.CDDL (Name, OccurrenceIndicator, RangeBound, Value)
+import Codec.CBOR.Cuddle.CBOR.Term (fromNInt, nintMin, uintMax)
+import Codec.CBOR.Cuddle.CDDL (Name, OccurrenceIndicator, RangeBound, Value (..), ValueVariant (..))
 import Codec.CBOR.Cuddle.CDDL.CtlOp
 import Control.Monad.Identity (Identity (..))
 import Data.Hashable (Hashable)
@@ -39,6 +42,15 @@ import Test.QuickCheck (Arbitrary (..))
 
 data family XXCTree i
 
+data Range a = Range
+  { rangeFrom :: a
+  , rangeTo :: a
+  , rangeBound :: RangeBound
+  }
+  deriving (Eq, Show, Generic)
+
+instance Hashable a => Hashable (Range a)
+
 data CTree i
   = Literal Value
   | Postlude PTerm
@@ -48,7 +60,7 @@ data CTree i
   | Group [CTree i]
   | KV {key :: CTree i, value :: CTree i, cut :: Bool}
   | Occur {item :: CTree i, occurs :: OccurrenceIndicator}
-  | Range {from :: CTree i, to :: CTree i, inclusive :: RangeBound}
+  | CRange (Range (CTree i))
   | Control {op :: CtlOp, target :: CTree i, controller :: CTree i}
   | Enum (CTree i)
   | Unwrap (CTree i)
@@ -76,10 +88,10 @@ traverseCTree _ atNode (KV k v c) = do
   v' <- atNode v
   pure $ KV k' v' c
 traverseCTree _ atNode (Occur i occ) = flip Occur occ <$> atNode i
-traverseCTree _ atNode (Range f t inc) = do
+traverseCTree _ atNode (CRange (Range f t inc)) = do
   f' <- atNode f
   t' <- atNode t
-  pure $ Range f' t' inc
+  pure $ CRange $ Range f' t' inc
 traverseCTree _ atNode (Control o t c) = do
   t' <- atNode t
   c' <- atNode c
@@ -156,3 +168,18 @@ instance Arbitrary PTerm where
   arbitrary = genericArbitraryU
 
 instance Hashable PTerm
+
+unIntLiteral :: CTree i -> Maybe Integer
+unIntLiteral (Literal (Value x _)) = case x of
+  VUInt v -> Just $ toInteger v
+  VNInt v -> Just $ fromNInt v
+  _ -> Nothing
+unIntLiteral _ = Nothing
+
+unFloatLiteral :: CTree i -> Maybe Double
+unFloatLiteral (Literal (Value x _)) = case x of
+  VFloat16 v -> Just $ realToFrac v
+  VFloat32 v -> Just $ realToFrac v
+  VFloat64 v -> Just v
+  _ -> Nothing
+unFloatLiteral _ = Nothing

--- a/src/Codec/CBOR/Cuddle/CDDL/CTree.hs
+++ b/src/Codec/CBOR/Cuddle/CDDL/CTree.hs
@@ -21,7 +21,7 @@ module Codec.CBOR.Cuddle.CDDL.CTree (
   unDoubleLiteral,
 ) where
 
-import Codec.CBOR.Cuddle.CBOR.Term (fromNInt, nintMin, uintMax)
+import Codec.CBOR.Cuddle.CBOR.NInt (fromNInt, nintMin, uintMax)
 import Codec.CBOR.Cuddle.CDDL (
   Name,
   OccurrenceIndicator,

--- a/src/Codec/CBOR/Cuddle/CDDL/CTree.hs
+++ b/src/Codec/CBOR/Cuddle/CDDL/CTree.hs
@@ -6,6 +6,9 @@
 module Codec.CBOR.Cuddle.CDDL.CTree (
   XXCTree,
   Range (..),
+  exclusive,
+  inclusive,
+  isInRange,
   CTree (..),
   traverseCTree,
   foldCTree,
@@ -19,7 +22,13 @@ module Codec.CBOR.Cuddle.CDDL.CTree (
 ) where
 
 import Codec.CBOR.Cuddle.CBOR.Term (fromNInt, nintMin, uintMax)
-import Codec.CBOR.Cuddle.CDDL (Name, OccurrenceIndicator, RangeBound, Value (..), ValueVariant (..))
+import Codec.CBOR.Cuddle.CDDL (
+  Name,
+  OccurrenceIndicator,
+  RangeBound (..),
+  Value (..),
+  ValueVariant (..),
+ )
 import Codec.CBOR.Cuddle.CDDL.CtlOp
 import Control.Monad.Identity (Identity (..))
 import Data.Hashable (Hashable)
@@ -50,6 +59,18 @@ data Range a = Range
   deriving (Eq, Show, Generic)
 
 instance Hashable a => Hashable (Range a)
+
+isInRange :: Ord a => a -> Range a -> Bool
+isInRange x (Range from to bound) =
+  x >= from && case bound of
+    ClOpen -> x < to
+    Closed -> x <= to
+
+exclusive :: a -> a -> Range a
+exclusive from to = Range from to ClOpen
+
+inclusive :: a -> a -> Range a
+inclusive from to = Range from to Closed
 
 data CTree i
   = Literal Value

--- a/src/Codec/CBOR/Cuddle/CDDL/CTree.hs
+++ b/src/Codec/CBOR/Cuddle/CDDL/CTree.hs
@@ -17,8 +17,8 @@ module Codec.CBOR.Cuddle.CDDL.CTree (
   PTerm (..),
   uintMax,
   nintMin,
-  unIntLiteral,
-  unFloatLiteral,
+  unIntegerLiteral,
+  unDoubleLiteral,
 ) where
 
 import Codec.CBOR.Cuddle.CBOR.Term (fromNInt, nintMin, uintMax)
@@ -190,17 +190,17 @@ instance Arbitrary PTerm where
 
 instance Hashable PTerm
 
-unIntLiteral :: CTree i -> Maybe Integer
-unIntLiteral (Literal (Value x _)) = case x of
+unIntegerLiteral :: CTree i -> Maybe Integer
+unIntegerLiteral (Literal (Value x _)) = case x of
   VUInt v -> Just $ toInteger v
   VNInt v -> Just $ fromNInt v
   _ -> Nothing
-unIntLiteral _ = Nothing
+unIntegerLiteral _ = Nothing
 
-unFloatLiteral :: CTree i -> Maybe Double
-unFloatLiteral (Literal (Value x _)) = case x of
+unDoubleLiteral :: CTree i -> Maybe Double
+unDoubleLiteral (Literal (Value x _)) = case x of
   VFloat16 v -> Just $ realToFrac v
   VFloat32 v -> Just $ realToFrac v
   VFloat64 v -> Just v
   _ -> Nothing
-unFloatLiteral _ = Nothing
+unDoubleLiteral _ = Nothing

--- a/src/Codec/CBOR/Cuddle/CDDL/Custom/Core.hs
+++ b/src/Codec/CBOR/Cuddle/CDDL/Custom/Core.hs
@@ -2,9 +2,9 @@
 
 module Codec.CBOR.Cuddle.CDDL.Custom.Core (MonadCddl (..), RuleTerm (..)) where
 
+import Codec.CBOR.Cuddle.CBOR.Term (CBORTerm)
 import Codec.CBOR.Cuddle.CDDL (GRef, Name)
 import Codec.CBOR.Cuddle.CDDL.CTree (CTree)
-import Codec.CBOR.Term (Term)
 import Data.Kind (Type)
 
 class MonadCddl m where
@@ -19,7 +19,7 @@ class MonadCddl m where
   lookupGRef :: GRef -> m (Maybe (CTree (Phase m)))
 
 data RuleTerm
-  = SingleTerm Term
-  | PairTerm Term Term
+  = SingleTerm CBORTerm
+  | PairTerm CBORTerm CBORTerm
   | GroupTerm [RuleTerm]
   deriving (Eq, Ord, Show)

--- a/src/Codec/CBOR/Cuddle/CDDL/Resolve.hs
+++ b/src/Codec/CBOR/Cuddle/CDDL/Resolve.hs
@@ -53,6 +53,7 @@ import Codec.CBOR.Cuddle.CDDL.CTree (
   CTree (..),
   CTreeRoot (..),
   PTerm (..),
+  Range (..),
   XXCTree,
   foldCTree,
  )
@@ -232,11 +233,12 @@ buildRefCTree rules = PartialCTreeRoot $ toCTreeRule <$> rules
     toCTreeT1 (Type1 t2 Nothing _) = toCTreeT2 t2
     toCTreeT1 (Type1 t2 (Just (op, t2')) _) = case op of
       RangeOp bound ->
-        CTree.Range
-          { CTree.from = toCTreeT2 t2
-          , CTree.to = toCTreeT2 t2'
-          , CTree.inclusive = bound
-          }
+        CTree.CRange $
+          Range
+            { rangeFrom = toCTreeT2 t2
+            , rangeTo = toCTreeT2 t2'
+            , rangeBound = bound
+            }
       CtrlOp ctlop ->
         CTree.Control
           { CTree.op = ctlop

--- a/src/Codec/CBOR/Cuddle/Huddle.hs
+++ b/src/Codec/CBOR/Cuddle/Huddle.hs
@@ -468,7 +468,7 @@ bool x = Literal (LBool x) mempty
 
 inferInteger :: Integer -> Literal
 inferInteger i
-  | i >= 0 && i < fromIntegral (maxBound @Word64) = Literal (LInt (fromInteger i)) mempty
+  | i >= 0 && i <= fromIntegral (maxBound @Word64) = Literal (LInt (fromInteger i)) mempty
   | Just i' <- toNInt i = Literal (LNInt i') mempty
   | otherwise = Literal (LBignum i) mempty
 

--- a/src/Codec/CBOR/Cuddle/Huddle.hs
+++ b/src/Codec/CBOR/Cuddle/Huddle.hs
@@ -109,6 +109,7 @@ module Codec.CBOR.Cuddle.Huddle (
 )
 where
 
+import Codec.CBOR.Cuddle.CBOR.Term (NInt, toNInt)
 import Codec.CBOR.Cuddle.CDDL (
   CDDL,
   GRef (..),
@@ -442,7 +443,7 @@ data LiteralVariant where
   -- | We store both int and nint as a Word64, since the sign is indicated in
   -- the type.
   LInt :: Word64 -> LiteralVariant
-  LNInt :: Word64 -> LiteralVariant
+  LNInt :: NInt -> LiteralVariant
   LBignum :: Integer -> LiteralVariant
   LText :: T.Text -> LiteralVariant
   LFloat :: Float -> LiteralVariant
@@ -468,7 +469,7 @@ bool x = Literal (LBool x) mempty
 inferInteger :: Integer -> Literal
 inferInteger i
   | i >= 0 && i < fromIntegral (maxBound @Word64) = Literal (LInt (fromInteger i)) mempty
-  | i < 0 && (-i) < fromIntegral (maxBound @Word64) = Literal (LNInt (fromInteger (-i))) mempty
+  | Just i' <- toNInt (-i) = Literal (LNInt i') mempty
   | otherwise = Literal (LBignum i) mempty
 
 --------------------------------------------------------------------------------

--- a/src/Codec/CBOR/Cuddle/Huddle.hs
+++ b/src/Codec/CBOR/Cuddle/Huddle.hs
@@ -109,7 +109,7 @@ module Codec.CBOR.Cuddle.Huddle (
 )
 where
 
-import Codec.CBOR.Cuddle.CBOR.Term (NInt, toNInt)
+import Codec.CBOR.Cuddle.CBOR.NInt (NInt, toNInt)
 import Codec.CBOR.Cuddle.CDDL (
   CDDL,
   GRef (..),

--- a/src/Codec/CBOR/Cuddle/Huddle.hs
+++ b/src/Codec/CBOR/Cuddle/Huddle.hs
@@ -469,7 +469,7 @@ bool x = Literal (LBool x) mempty
 inferInteger :: Integer -> Literal
 inferInteger i
   | i >= 0 && i < fromIntegral (maxBound @Word64) = Literal (LInt (fromInteger i)) mempty
-  | Just i' <- toNInt (-i) = Literal (LNInt i') mempty
+  | Just i' <- toNInt i = Literal (LNInt i') mempty
   | otherwise = Literal (LBignum i) mempty
 
 --------------------------------------------------------------------------------

--- a/src/Codec/CBOR/Cuddle/Orphans.hs
+++ b/src/Codec/CBOR/Cuddle/Orphans.hs
@@ -1,0 +1,25 @@
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Codec.CBOR.Cuddle.Orphans () where
+
+import Codec.CBOR.Cuddle.Comments (CollectComments (..))
+import Data.Hashable (Hashable (..))
+import Numeric.Half (Half (..))
+import Prettyprinter (Pretty (..))
+import Test.QuickCheck (Arbitrary (..))
+
+instance CollectComments Half where
+  collectComments _ = []
+
+instance Hashable Half where
+  hashWithSalt i (Half x) = hashWithSalt i $ toInteger x
+
+instance Pretty Half where
+  pretty (Half x) = pretty $ toInteger x
+
+instance Arbitrary Half where
+  arbitrary = do
+    half <- Half <$> arbitrary
+    if isDenormalized half
+      then arbitrary
+      else pure half

--- a/src/Codec/CBOR/Cuddle/Orphans.hs
+++ b/src/Codec/CBOR/Cuddle/Orphans.hs
@@ -15,7 +15,7 @@ instance Hashable Half where
   hashWithSalt i (Half x) = hashWithSalt i $ toInteger x
 
 instance Pretty Half where
-  pretty (Half x) = pretty $ toInteger x
+  pretty x = pretty $ realToFrac @_ @Float x
 
 instance Arbitrary Half where
   arbitrary = do

--- a/src/Codec/CBOR/Cuddle/Parser.hs
+++ b/src/Codec/CBOR/Cuddle/Parser.hs
@@ -6,6 +6,7 @@
 
 module Codec.CBOR.Cuddle.Parser where
 
+import Codec.CBOR.Cuddle.CBOR.Term (toNInt)
 import Codec.CBOR.Cuddle.CDDL
 import Codec.CBOR.Cuddle.CDDL.CtlOp (CtlOp)
 import Codec.CBOR.Cuddle.CDDL.CtlOp qualified as COp
@@ -306,7 +307,7 @@ pValue =
           | val <= fromIntegral (maxBound @Word64) -> pure . VUInt $ fromIntegral val
           | otherwise -> pure $ VBignum val
         (True, val)
-          | val <= fromIntegral (maxBound @Word64) -> pure . VNInt $ fromIntegral val
+          | Just nVal <- toNInt (-val) -> pure $ VNInt nVal
           | otherwise -> pure . VBignum $ -val
     pFloat =
       pSignedNum L.float >>= \case

--- a/src/Codec/CBOR/Cuddle/Parser.hs
+++ b/src/Codec/CBOR/Cuddle/Parser.hs
@@ -6,7 +6,7 @@
 
 module Codec.CBOR.Cuddle.Parser where
 
-import Codec.CBOR.Cuddle.CBOR.Term (toNInt)
+import Codec.CBOR.Cuddle.CBOR.NInt (toNInt)
 import Codec.CBOR.Cuddle.CDDL
 import Codec.CBOR.Cuddle.CDDL.CtlOp (CtlOp)
 import Codec.CBOR.Cuddle.CDDL.CtlOp qualified as COp

--- a/src/Codec/CBOR/Cuddle/Pretty.hs
+++ b/src/Codec/CBOR/Cuddle/Pretty.hs
@@ -19,8 +19,9 @@ module Codec.CBOR.Cuddle.Pretty (
   renderCDDL,
 ) where
 
+import Codec.CBOR.Cuddle.CBOR.Term (NInt, fromNInt)
 import Codec.CBOR.Cuddle.CDDL
-import Codec.CBOR.Cuddle.CDDL.CTree (CTree, PTerm (..), XXCTree)
+import Codec.CBOR.Cuddle.CDDL.CTree (CTree, PTerm (..), Range (..), XXCTree)
 import Codec.CBOR.Cuddle.CDDL.CTree qualified as CT
 import Codec.CBOR.Cuddle.CDDL.CtlOp (CtlOp)
 import Codec.CBOR.Cuddle.Comments (CollectComments (..), Comment, HasComment (..), unComment)
@@ -250,6 +251,9 @@ instance Pretty (MemberKey PrettyStage) where
 instance Pretty Value where
   pretty (Value v cmt) = pretty v <> prettyCommentNoBreakWS cmt
 
+instance Pretty NInt where
+  pretty = pretty . fromNInt
+
 instance Pretty ValueVariant where
   pretty (VUInt i) = pretty i
   pretty (VNInt i) = "-" <> pretty i
@@ -286,8 +290,8 @@ instance Pretty (XXCTree p) => Pretty (CTree p) where
   pretty = \case
     CT.Literal v -> pretty v
     CT.Postlude v -> pretty v
-    CT.Range lo hi ClOpen -> pretty lo <+> "..." <+> pretty hi
-    CT.Range lo hi Closed -> pretty lo <+> ".." <+> pretty hi
+    CT.CRange (Range lo hi ClOpen) -> pretty lo <+> "..." <+> pretty hi
+    CT.CRange (Range lo hi Closed) -> pretty lo <+> ".." <+> pretty hi
     CT.KV k v _ -> pretty k <+> "==>" <+> pretty v
     CT.CTreeE x -> pretty x
     CT.Occur v oi ->

--- a/src/Codec/CBOR/Cuddle/Pretty.hs
+++ b/src/Codec/CBOR/Cuddle/Pretty.hs
@@ -19,7 +19,7 @@ module Codec.CBOR.Cuddle.Pretty (
   renderCDDL,
 ) where
 
-import Codec.CBOR.Cuddle.CBOR.Term (NInt, fromNInt)
+import Codec.CBOR.Cuddle.CBOR.NInt (NInt, fromNInt)
 import Codec.CBOR.Cuddle.CDDL
 import Codec.CBOR.Cuddle.CDDL.CTree (CTree, PTerm (..), Range (..), XXCTree)
 import Codec.CBOR.Cuddle.CDDL.CTree qualified as CT

--- a/src/Codec/CBOR/Cuddle/Pretty.hs
+++ b/src/Codec/CBOR/Cuddle/Pretty.hs
@@ -256,7 +256,7 @@ instance Pretty NInt where
 
 instance Pretty ValueVariant where
   pretty (VUInt i) = pretty i
-  pretty (VNInt i) = "-" <> pretty i
+  pretty (VNInt i) = pretty i
   pretty (VBignum i) = pretty i
   pretty (VFloat16 i) = pretty i
   pretty (VFloat32 i) = pretty i

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -2,6 +2,7 @@ module Main (main) where
 
 import System.IO (BufferMode (..), hSetBuffering, hSetEncoding, stdout, utf8)
 import Test.Codec.CBOR.Cuddle.CBOR.Canonical qualified as Canonical
+import Test.Codec.CBOR.Cuddle.CBOR.NInt qualified as NInt
 import Test.Codec.CBOR.Cuddle.CBOR.Term qualified as Term
 import Test.Codec.CBOR.Cuddle.CDDL.Examples qualified as Examples
 import Test.Codec.CBOR.Cuddle.CDDL.GeneratorSpec qualified as Generator
@@ -27,6 +28,7 @@ main = do
   hspecWith hspecConfig $ do
     describe "Canonical" Canonical.spec
     describe "Term" Term.spec
+    describe "NInt" NInt.spec
     describe "Parser" parserSpec
     describe "Huddle" huddleSpec
     describe "Examples" Examples.spec

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -2,6 +2,7 @@ module Main (main) where
 
 import System.IO (BufferMode (..), hSetBuffering, hSetEncoding, stdout, utf8)
 import Test.Codec.CBOR.Cuddle.CBOR.Canonical qualified as Canonical
+import Test.Codec.CBOR.Cuddle.CBOR.Term qualified as Term
 import Test.Codec.CBOR.Cuddle.CDDL.Examples qualified as Examples
 import Test.Codec.CBOR.Cuddle.CDDL.GeneratorSpec qualified as Generator
 import Test.Codec.CBOR.Cuddle.CDDL.Parser (parserSpec)
@@ -25,6 +26,7 @@ main = do
   hSetEncoding stdout utf8
   hspecWith hspecConfig $ do
     describe "Canonical" Canonical.spec
+    describe "Term" Term.spec
     describe "Parser" parserSpec
     describe "Huddle" huddleSpec
     describe "Examples" Examples.spec

--- a/test/Test/Codec/CBOR/Cuddle/CBOR/Canonical.hs
+++ b/test/Test/Codec/CBOR/Cuddle/CBOR/Canonical.hs
@@ -9,8 +9,16 @@ import Codec.CBOR.Cuddle.CBOR.Canonical (
 import Codec.CBOR.Cuddle.CBOR.Term (
   CBORTerm (..),
   fromNInt,
+  mkTermArray,
+  mkTermBytes,
+  mkTermBytesI,
+  mkTermMap,
+  mkTermNInt,
+  mkTermString,
+  mkTermStringI,
+  mkTermTag,
+  mkTermUInt,
   nintMin,
-  toNInt,
   uintMax,
  )
 import Data.ByteString qualified as BS
@@ -22,76 +30,58 @@ import Test.QuickCheck
 
 spec :: Spec
 spec = do
-  describe "NInt" $ do
-    it "toNInt accepts exactly [-2^64, -1]" $ do
-      toNInt 0 `shouldBe` Nothing
-      toNInt 1 `shouldBe` Nothing
-      toNInt (nintMin - 1) `shouldBe` Nothing
-      toNInt nintMin `shouldNotBe` Nothing
-      toNInt (-1) `shouldNotBe` Nothing
-
-    prop "toNInt . fromNInt = Just" $ \n ->
-      toNInt (fromNInt n) === Just n
-
-    it "boundary values roundtrip" $ do
-      fmap fromNInt (toNInt (-1)) `shouldBe` Just (-1)
-      fmap fromNInt (toNInt nintMin) `shouldBe` Just nintMin
-
-    prop "Ord on NInt agrees with Ord on the represented Integer" $ \a b ->
-      compare a b === compare (fromNInt a) (fromNInt b)
-
   describe "toCanonical" $ do
     describe "integer normalization" $ do
       prop "TermUInt maps to CTInt" $ \w ->
-        toCanonical (TermUInt w) === CTInt w
+        toCanonical (mkTermUInt w) === CTInt w
 
       prop "TermNInt maps to CTNInt" $ \n ->
-        toCanonical (TermNInt n) === CTNInt n
+        toCanonical (mkTermNInt n) === CTNInt n
 
       prop "in-range positive bignum collapses to CTInt" $ \(w :: Word64) ->
-        toCanonical (TermTag 2 (TermBytes (unsignedBE (toInteger w))))
-          === toCanonical (TermUInt w)
+        toCanonical (mkTermTag 2 (mkTermBytes (unsignedBE (toInteger w))))
+          === toCanonical (mkTermUInt w)
 
       prop "in-range negative bignum collapses to CTNInt" $ \nint ->
         let n = fromNInt nint
-         in toCanonical (TermTag 3 (TermBytes (unsignedBE (-1 - n))))
-              === toCanonical (TermNInt nint)
+         in toCanonical (mkTermTag 3 (mkTermBytes (unsignedBE (-1 - n))))
+              === toCanonical (mkTermNInt nint)
 
       it "bignum with leading zeros canonicalizes" $
-        toCanonical (TermTag 2 (TermBytes (BS.pack [0, 0, 5])))
+        toCanonical (mkTermTag 2 (mkTermBytes (BS.pack [0, 0, 5])))
           `shouldBe` CTInt 5
 
       prop "bignum from TermBytesI matches TermBytes" $ \(w :: Word64) ->
         let bs = unsignedBE (toInteger w)
-         in toCanonical (TermTag 2 (TermBytesI [BSL.fromStrict bs]))
-              === toCanonical (TermTag 2 (TermBytes bs))
+         in toCanonical (mkTermTag 2 (mkTermBytesI [BSL.fromStrict bs]))
+              === toCanonical (mkTermTag 2 (mkTermBytes bs))
 
       it "true bignum (above uintMax) stays tagged" $
         let n = uintMax + 1
-         in toCanonical (TermTag 2 (TermBytes (unsignedBE n)))
+         in toCanonical (mkTermTag 2 (mkTermBytes (unsignedBE n)))
               `shouldBe` CTTagged 2 (CTBytes (unsignedBE n))
 
       it "true bignum (below nintMin) stays tagged" $
         let n = nintMin - 1
-         in toCanonical (TermTag 3 (TermBytes (unsignedBE (-1 - n))))
+         in toCanonical (mkTermTag 3 (mkTermBytes (unsignedBE (-1 - n))))
               `shouldBe` CTTagged 3 (CTBytes (unsignedBE (-1 - n)))
 
     describe "definite/indefinite variants merge" $ do
       it "TermBytes ≡ chunked TermBytesI" $
-        toCanonical (TermBytes "abc")
-          `shouldBe` toCanonical (TermBytesI ["a", "bc"])
+        toCanonical (mkTermBytes "abc")
+          `shouldBe` toCanonical (mkTermBytesI ["a", "bc"])
 
       it "TermString ≡ chunked TermStringI" $
-        toCanonical (TermString "abc")
-          `shouldBe` toCanonical (TermStringI ["a", "bc"])
+        toCanonical (mkTermString "abc")
+          `shouldBe` toCanonical (mkTermStringI ["a", "bc"])
 
       it "TermArray ≡ TermArrayI" $
-        toCanonical (TermArray [TermUInt 1, TermUInt 2])
-          `shouldBe` toCanonical (TermArrayI [TermUInt 1, TermUInt 2])
+        toCanonical (mkTermArray [mkTermUInt 1, mkTermUInt 2])
+          `shouldBe` toCanonical (TermArrayI [mkTermUInt 1, mkTermUInt 2])
 
       it "TermMap ≡ TermMapI" $
-        toCanonical (TermMap [(TermUInt 1, TermUInt 2)])
-          `shouldBe` toCanonical (TermMapI [(TermUInt 1, TermUInt 2)])
+        toCanonical (mkTermMap [(mkTermUInt 1, mkTermUInt 2)])
+          `shouldBe` toCanonical (TermMapI [(mkTermUInt 1, mkTermUInt 2)])
 
     describe "simple values" $ do
       prop "TermSimple maps to CTSimple" $ \w ->
@@ -99,8 +89,8 @@ spec = do
 
     describe "maps" $ do
       it "key order is irrelevant" $
-        toCanonical (TermMap [(TermUInt 1, TermUInt 10), (TermUInt 2, TermUInt 20)])
-          `shouldBe` toCanonical (TermMap [(TermUInt 2, TermUInt 20), (TermUInt 1, TermUInt 10)])
+        toCanonical (mkTermMap [(mkTermUInt 1, mkTermUInt 10), (mkTermUInt 2, mkTermUInt 20)])
+          `shouldBe` toCanonical (mkTermMap [(mkTermUInt 2, mkTermUInt 20), (mkTermUInt 1, mkTermUInt 10)])
 
     describe "floats stay distinct by width" $ do
       it "TermHalf 1.0 ≠ TermFloat 1.0" $

--- a/test/Test/Codec/CBOR/Cuddle/CBOR/Canonical.hs
+++ b/test/Test/Codec/CBOR/Cuddle/CBOR/Canonical.hs
@@ -6,9 +6,9 @@ import Codec.CBOR.Cuddle.CBOR.Canonical (
   CanonicalTerm (..),
   toCanonical,
  )
+import Codec.CBOR.Cuddle.CBOR.NInt (fromNInt, nintMin, uintMax)
 import Codec.CBOR.Cuddle.CBOR.Term (
   CBORTerm (..),
-  fromNInt,
   mkTermArray,
   mkTermBytes,
   mkTermBytesI,
@@ -18,8 +18,6 @@ import Codec.CBOR.Cuddle.CBOR.Term (
   mkTermStringI,
   mkTermTag,
   mkTermUInt,
-  nintMin,
-  uintMax,
  )
 import Data.ByteString qualified as BS
 import Data.ByteString.Lazy qualified as BSL

--- a/test/Test/Codec/CBOR/Cuddle/CBOR/Canonical.hs
+++ b/test/Test/Codec/CBOR/Cuddle/CBOR/Canonical.hs
@@ -4,16 +4,17 @@ module Test.Codec.CBOR.Cuddle.CBOR.Canonical (spec) where
 
 import Codec.CBOR.Cuddle.CBOR.Canonical (
   CanonicalTerm (..),
+  toCanonical,
+ )
+import Codec.CBOR.Cuddle.CBOR.Term (
+  CBORTerm (..),
   fromNInt,
   nintMin,
-  toCanonical,
   toNInt,
   uintMax,
  )
-import Codec.CBOR.Term (Term (..))
 import Data.ByteString qualified as BS
 import Data.ByteString.Lazy qualified as BSL
-import Data.Text.Lazy qualified as TL
 import Data.Word (Word64)
 import Test.Hspec
 import Test.Hspec.QuickCheck (prop)
@@ -41,73 +42,71 @@ spec = do
 
   describe "toCanonical" $ do
     describe "integer normalization" $ do
-      prop "TInt and TInteger of the same value are equal" $ \i ->
-        toCanonical (TInt i) === toCanonical (TInteger (toInteger i))
+      prop "TermUInt maps to CTInt" $ \w ->
+        toCanonical (TermUInt w) === CTInt w
+
+      prop "TermNInt maps to CTNInt" $ \n ->
+        toCanonical (TermNInt n) === CTNInt n
 
       prop "in-range positive bignum collapses to CTInt" $ \(w :: Word64) ->
-        let n = toInteger w
-         in toCanonical (TTagged 2 (TBytes (unsignedBE n)))
-              === toCanonical (TInteger n)
+        toCanonical (TermTag 2 (TermBytes (unsignedBE (toInteger w))))
+          === toCanonical (TermUInt w)
 
       prop "in-range negative bignum collapses to CTNInt" $ \nint ->
         let n = fromNInt nint
-         in toCanonical (TTagged 3 (TBytes (unsignedBE (-1 - n))))
-              === toCanonical (TInteger n)
+         in toCanonical (TermTag 3 (TermBytes (unsignedBE (-1 - n))))
+              === toCanonical (TermNInt nint)
 
       it "bignum with leading zeros canonicalizes" $
-        toCanonical (TTagged 2 (TBytes (BS.pack [0, 0, 5])))
+        toCanonical (TermTag 2 (TermBytes (BS.pack [0, 0, 5])))
           `shouldBe` CTInt 5
 
-      prop "bignum from TBytesI matches TBytes" $ \(w :: Word64) ->
+      prop "bignum from TermBytesI matches TermBytes" $ \(w :: Word64) ->
         let bs = unsignedBE (toInteger w)
-         in toCanonical (TTagged 2 (TBytesI (BSL.fromStrict bs)))
-              === toCanonical (TTagged 2 (TBytes bs))
+         in toCanonical (TermTag 2 (TermBytesI [BSL.fromStrict bs]))
+              === toCanonical (TermTag 2 (TermBytes bs))
 
       it "true bignum (above uintMax) stays tagged" $
         let n = uintMax + 1
-         in toCanonical (TInteger n)
+         in toCanonical (TermTag 2 (TermBytes (unsignedBE n)))
               `shouldBe` CTTagged 2 (CTBytes (unsignedBE n))
 
       it "true bignum (below nintMin) stays tagged" $
         let n = nintMin - 1
-         in toCanonical (TInteger n)
+         in toCanonical (TermTag 3 (TermBytes (unsignedBE (-1 - n))))
               `shouldBe` CTTagged 3 (CTBytes (unsignedBE (-1 - n)))
 
     describe "definite/indefinite variants merge" $ do
-      it "TBytes ≡ TBytesI" $
-        toCanonical (TBytes "abc")
-          `shouldBe` toCanonical (TBytesI (BSL.fromStrict "abc"))
+      it "TermBytes ≡ chunked TermBytesI" $
+        toCanonical (TermBytes "abc")
+          `shouldBe` toCanonical (TermBytesI ["a", "bc"])
 
-      it "TString ≡ TStringI" $
-        toCanonical (TString "abc")
-          `shouldBe` toCanonical (TStringI (TL.fromStrict "abc"))
+      it "TermString ≡ chunked TermStringI" $
+        toCanonical (TermString "abc")
+          `shouldBe` toCanonical (TermStringI ["a", "bc"])
 
-      it "TList ≡ TListI" $
-        toCanonical (TList [TInt 1, TInt 2])
-          `shouldBe` toCanonical (TListI [TInt 1, TInt 2])
+      it "TermArray ≡ TermArrayI" $
+        toCanonical (TermArray [TermUInt 1, TermUInt 2])
+          `shouldBe` toCanonical (TermArrayI [TermUInt 1, TermUInt 2])
 
-      it "TMap ≡ TMapI" $
-        toCanonical (TMap [(TInt 1, TInt 2)])
-          `shouldBe` toCanonical (TMapI [(TInt 1, TInt 2)])
+      it "TermMap ≡ TermMapI" $
+        toCanonical (TermMap [(TermUInt 1, TermUInt 2)])
+          `shouldBe` toCanonical (TermMapI [(TermUInt 1, TermUInt 2)])
 
-    describe "bool/null go through CTSimple" $ do
-      it "TBool False ≡ TSimple 20" $
-        toCanonical (TBool False) `shouldBe` toCanonical (TSimple 20)
-      it "TBool True ≡ TSimple 21" $
-        toCanonical (TBool True) `shouldBe` toCanonical (TSimple 21)
-      it "TNull ≡ TSimple 22" $
-        toCanonical TNull `shouldBe` toCanonical (TSimple 22)
+    describe "simple values" $ do
+      prop "TermSimple maps to CTSimple" $ \w ->
+        toCanonical (TermSimple w) === CTSimple w
 
     describe "maps" $ do
       it "key order is irrelevant" $
-        toCanonical (TMap [(TInt 1, TInt 10), (TInt 2, TInt 20)])
-          `shouldBe` toCanonical (TMap [(TInt 2, TInt 20), (TInt 1, TInt 10)])
+        toCanonical (TermMap [(TermUInt 1, TermUInt 10), (TermUInt 2, TermUInt 20)])
+          `shouldBe` toCanonical (TermMap [(TermUInt 2, TermUInt 20), (TermUInt 1, TermUInt 10)])
 
     describe "floats stay distinct by width" $ do
-      it "THalf 1.0 ≠ TFloat 1.0" $
-        toCanonical (THalf 1.0) `shouldNotBe` toCanonical (TFloat 1.0)
-      it "TFloat 1.0 ≠ TDouble 1.0" $
-        toCanonical (TFloat 1.0) `shouldNotBe` toCanonical (TDouble 1.0)
+      it "TermHalf 1.0 ≠ TermFloat 1.0" $
+        toCanonical (TermHalf 1.0) `shouldNotBe` toCanonical (TermFloat 1.0)
+      it "TermFloat 1.0 ≠ TermDouble 1.0" $
+        toCanonical (TermFloat 1.0) `shouldNotBe` toCanonical (TermDouble 1.0)
 
 -- | Encode a non-negative Integer as a big-endian byte string with no leading zeros.
 unsignedBE :: Integer -> BS.ByteString

--- a/test/Test/Codec/CBOR/Cuddle/CBOR/NInt.hs
+++ b/test/Test/Codec/CBOR/Cuddle/CBOR/NInt.hs
@@ -1,0 +1,25 @@
+module Test.Codec.CBOR.Cuddle.CBOR.NInt (spec) where
+
+import Codec.CBOR.Cuddle.CBOR.NInt
+import Test.Hspec
+import Test.Hspec.QuickCheck
+import Test.QuickCheck
+
+spec :: Spec
+spec = do
+  it "toNInt accepts exactly [-2^64, -1]" $ do
+    toNInt 0 `shouldBe` Nothing
+    toNInt 1 `shouldBe` Nothing
+    toNInt (nintMin - 1) `shouldBe` Nothing
+    toNInt nintMin `shouldNotBe` Nothing
+    toNInt (-1) `shouldNotBe` Nothing
+
+  prop "toNInt . fromNInt = Just" $ \n ->
+    toNInt (fromNInt n) === Just n
+
+  it "boundary values roundtrip" $ do
+    fmap fromNInt (toNInt (-1)) `shouldBe` Just (-1)
+    fmap fromNInt (toNInt nintMin) `shouldBe` Just nintMin
+
+  prop "Ord on NInt agrees with Ord on the represented Integer" $ \a b ->
+    compare a b === compare (fromNInt a) (fromNInt b)

--- a/test/Test/Codec/CBOR/Cuddle/CBOR/Term.hs
+++ b/test/Test/Codec/CBOR/Cuddle/CBOR/Term.hs
@@ -1,18 +1,16 @@
 module Test.Codec.CBOR.Cuddle.CBOR.Term (spec) where
 
+import Codec.CBOR.Cuddle.CBOR.NInt (nintMin, toNInt)
 import Codec.CBOR.Cuddle.CBOR.Term (
   ArgWidth (..),
   CBORTerm (..),
   decodeCBORTerm,
   encodeCBORTerm,
-  fromNInt,
   isValidWidth,
   mkTermBytes,
   mkTermNInt,
   mkTermTag,
-  nintMin,
   optimalWidth,
-  toNInt,
  )
 import Codec.CBOR.Read (DeserialiseFailure, deserialiseFromBytes)
 import Codec.CBOR.Write (toLazyByteString)
@@ -39,24 +37,6 @@ encode = toLazyByteString . encodeCBORTerm
 
 spec :: Spec
 spec = do
-  describe "NInt" $ do
-    it "toNInt accepts exactly [-2^64, -1]" $ do
-      toNInt 0 `shouldBe` Nothing
-      toNInt 1 `shouldBe` Nothing
-      toNInt (nintMin - 1) `shouldBe` Nothing
-      toNInt nintMin `shouldNotBe` Nothing
-      toNInt (-1) `shouldNotBe` Nothing
-
-    prop "toNInt . fromNInt = Just" $ \n ->
-      toNInt (fromNInt n) === Just n
-
-    it "boundary values roundtrip" $ do
-      fmap fromNInt (toNInt (-1)) `shouldBe` Just (-1)
-      fmap fromNInt (toNInt nintMin) `shouldBe` Just nintMin
-
-    prop "Ord on NInt agrees with Ord on the represented Integer" $ \a b ->
-      compare a b === compare (fromNInt a) (fromNInt b)
-
   describe "decode . encode" $ do
     prop "round-trips arbitrary terms" $ \t ->
       decode (encode t) === Right t

--- a/test/Test/Codec/CBOR/Cuddle/CBOR/Term.hs
+++ b/test/Test/Codec/CBOR/Cuddle/CBOR/Term.hs
@@ -1,0 +1,107 @@
+module Test.Codec.CBOR.Cuddle.CBOR.Term (spec) where
+
+import Codec.CBOR.Cuddle.CBOR.Term (
+  CBORTerm (..),
+  decodeCBORTerm,
+  encodeCBORTerm,
+  nintMin,
+  toNInt,
+ )
+import Codec.CBOR.Read (DeserialiseFailure, deserialiseFromBytes)
+import Codec.CBOR.Write (toLazyByteString)
+import Data.ByteString qualified as BS
+import Data.ByteString.Lazy qualified as BSL
+import Data.Either (isLeft)
+import Data.Maybe (fromJust)
+import Data.Word (Word8)
+import Test.Hspec
+import Test.Hspec.QuickCheck (prop)
+import Test.QuickCheck ((===))
+
+decode :: BSL.ByteString -> Either DeserialiseFailure CBORTerm
+decode bs = do
+  (rest, t) <- deserialiseFromBytes decodeCBORTerm bs
+  if BSL.null rest
+    then Right t
+    else error $ "decode: leftover bytes " <> show (BSL.unpack rest)
+
+encode :: CBORTerm -> BSL.ByteString
+encode = toLazyByteString . encodeCBORTerm
+
+spec :: Spec
+spec = do
+  describe "decode . encode" $ do
+    prop "round-trips arbitrary terms" $ \t ->
+      decode (encode t) === Right t
+
+  describe "encode . decode" $ do
+    it "reproduces minimal-width wire bytes" $
+      mapM_ shouldRoundtripBytes byteVectors
+
+  describe "wire-form fidelity" $ do
+    it "decodes bignums as uninterpreted tags" $ do
+      -- tag 2 with content 2^64, the smallest positive bignum
+      decode (BSL.pack (0xc2 : 0x49 : 0x01 : replicate 8 0x00))
+        `shouldBe` Right (TermTag 2 (TermBytes (BS.pack (0x01 : replicate 8 0x00))))
+      decode (BSL.pack [0xc3, 0x41, 0x2a])
+        `shouldBe` Right (TermTag 3 (TermBytes (BS.pack [0x2a])))
+
+    it "decodes major type 1 down to -2^64" $
+      decode (BSL.pack (0x3b : replicate 8 0xff))
+        `shouldBe` Right (TermNInt (fromJust (toNInt nintMin)))
+
+  describe "ill-formed input is rejected" $ do
+    it "a lone break stop code" $
+      decode (BSL.pack [0xff]) `shouldSatisfy` isLeft
+    it "reserved additional information 28..30" $
+      mapM_
+        (\w -> decode (BSL.pack [w]) `shouldSatisfy` isLeft)
+        [mt * 32 + ai | mt <- [0 .. 7], ai <- [28 .. 30]]
+    it "indefinite-length integers and tags" $
+      mapM_
+        (\w -> decode (BSL.pack [w]) `shouldSatisfy` isLeft)
+        [0x1f, 0x3f, 0xdf]
+    it "an indefinite string with a non-string chunk" $
+      decode (BSL.pack [0x7f, 0x41, 0x61, 0xff]) `shouldSatisfy` isLeft
+
+shouldRoundtripBytes :: [Word8] -> Expectation
+shouldRoundtripBytes ws =
+  fmap encode (decode (BSL.pack ws)) `shouldBe` Right (BSL.pack ws)
+
+-- | Wire encodings with minimal-width arguments, mostly from RFC 8949
+-- Appendix A, covering every major type in definite and indefinite form.
+byteVectors :: [[Word8]]
+byteVectors =
+  [ [0x00] -- 0
+  , [0x18, 0x2a] -- 42
+  , [0x1b, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff] -- 2^64 - 1
+  , [0x20] -- -1
+  , [0x3b, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff] -- -2^64
+  , [0xc2, 0x49, 0x01, 0, 0, 0, 0, 0, 0, 0, 0] -- tag 2 bignum 2^64
+  , [0xc3, 0x41, 0x2a] -- tag 3 bignum -43
+  , [0xc1, 0x1a, 0x51, 0x4b, 0x67, 0xb0] -- tag 1 epoch time
+  , [0x40] -- h''
+  , [0x44, 0x01, 0x02, 0x03, 0x04] -- h'01020304'
+  , [0x5f, 0x41, 0x61, 0x42, 0x62, 0x63, 0xff] -- (_ h'61', h'6263')
+  , [0x5f, 0xff] -- (_ ), empty indefinite bytes
+  , [0x60] -- ""
+  , [0x64, 0x49, 0x45, 0x54, 0x46] -- "IETF"
+  , [0x7f, 0x61, 0x61, 0xff] -- (_ "a")
+  , [0x80] -- []
+  , [0x83, 0x01, 0x02, 0x03] -- [1, 2, 3]
+  , [0x9f, 0x01, 0x02, 0xff] -- [_ 1, 2]
+  , [0x9f, 0xff] -- [_ ]
+  , [0xa0] -- {}
+  , [0xa1, 0x61, 0x61, 0x01] -- {"a": 1}
+  , [0xbf, 0x61, 0x61, 0x01, 0xff] -- {_ "a": 1}
+  , [0xf4] -- false
+  , [0xf5] -- true
+  , [0xf6] -- null
+  , [0xf7] -- undefined
+  , [0xf0] -- simple(16)
+  , [0xf8, 0xff] -- simple(255)
+  , [0xf9, 0x3c, 0x00] -- 1.0_1
+  , [0xf9, 0x7c, 0x00] -- Infinity_1
+  , [0xfa, 0x47, 0xc3, 0x50, 0x00] -- 100000.0_2
+  , [0xfb, 0x40, 0x09, 0x21, 0xfb, 0x54, 0x44, 0x2d, 0x18] -- pi_3
+  ]

--- a/test/Test/Codec/CBOR/Cuddle/CBOR/Term.hs
+++ b/test/Test/Codec/CBOR/Cuddle/CBOR/Term.hs
@@ -1,18 +1,27 @@
 module Test.Codec.CBOR.Cuddle.CBOR.Term (spec) where
 
 import Codec.CBOR.Cuddle.CBOR.Term (
+  ArgWidth (..),
   CBORTerm (..),
   decodeCBORTerm,
   encodeCBORTerm,
+  fromNInt,
+  isValidWidth,
+  mkTermBytes,
+  mkTermNInt,
+  mkTermTag,
   nintMin,
+  optimalWidth,
   toNInt,
  )
 import Codec.CBOR.Read (DeserialiseFailure, deserialiseFromBytes)
 import Codec.CBOR.Write (toLazyByteString)
+import Control.Exception (evaluate)
 import Data.ByteString qualified as BS
 import Data.ByteString.Lazy qualified as BSL
 import Data.Either (isLeft)
 import Data.Maybe (fromJust)
+import Data.Text qualified as T
 import Data.Word (Word8)
 import Test.Hspec
 import Test.Hspec.QuickCheck (prop)
@@ -30,6 +39,24 @@ encode = toLazyByteString . encodeCBORTerm
 
 spec :: Spec
 spec = do
+  describe "NInt" $ do
+    it "toNInt accepts exactly [-2^64, -1]" $ do
+      toNInt 0 `shouldBe` Nothing
+      toNInt 1 `shouldBe` Nothing
+      toNInt (nintMin - 1) `shouldBe` Nothing
+      toNInt nintMin `shouldNotBe` Nothing
+      toNInt (-1) `shouldNotBe` Nothing
+
+    prop "toNInt . fromNInt = Just" $ \n ->
+      toNInt (fromNInt n) === Just n
+
+    it "boundary values roundtrip" $ do
+      fmap fromNInt (toNInt (-1)) `shouldBe` Just (-1)
+      fmap fromNInt (toNInt nintMin) `shouldBe` Just nintMin
+
+    prop "Ord on NInt agrees with Ord on the represented Integer" $ \a b ->
+      compare a b === compare (fromNInt a) (fromNInt b)
+
   describe "decode . encode" $ do
     prop "round-trips arbitrary terms" $ \t ->
       decode (encode t) === Right t
@@ -42,13 +69,61 @@ spec = do
     it "decodes bignums as uninterpreted tags" $ do
       -- tag 2 with content 2^64, the smallest positive bignum
       decode (BSL.pack (0xc2 : 0x49 : 0x01 : replicate 8 0x00))
-        `shouldBe` Right (TermTag 2 (TermBytes (BS.pack (0x01 : replicate 8 0x00))))
+        `shouldBe` Right (mkTermTag 2 (mkTermBytes (BS.pack (0x01 : replicate 8 0x00))))
       decode (BSL.pack [0xc3, 0x41, 0x2a])
-        `shouldBe` Right (TermTag 3 (TermBytes (BS.pack [0x2a])))
+        `shouldBe` Right (mkTermTag 3 (mkTermBytes (BS.pack [0x2a])))
 
     it "decodes major type 1 down to -2^64" $
       decode (BSL.pack (0x3b : replicate 8 0xff))
-        `shouldBe` Right (TermNInt (fromJust (toNInt nintMin)))
+        `shouldBe` Right (mkTermNInt (fromJust (toNInt nintMin)))
+
+  describe "ArgWidth" $ do
+    it "optimalWidth picks the width at each boundary" $ do
+      optimalWidth 23 `shouldBe` InlineArg
+      optimalWidth 24 `shouldBe` OneByteArg
+      optimalWidth 0xff `shouldBe` OneByteArg
+      optimalWidth 0x100 `shouldBe` TwoByteArg
+      optimalWidth 0xff_ff `shouldBe` TwoByteArg
+      optimalWidth 0x1_00_00 `shouldBe` FourByteArg
+      optimalWidth 0xff_ff_ff_ff `shouldBe` FourByteArg
+      optimalWidth 0x1_00_00_00_00 `shouldBe` EightByteArg
+
+    prop "optimalWidth yields a valid width" $ \v ->
+      isValidWidth v (optimalWidth v)
+
+    prop "no width below optimalWidth is valid" $ \v ->
+      all (not . isValidWidth v) [w | w <- [InlineArg ..], w < optimalWidth v]
+
+    it "encodes the argument at each width" $ do
+      encode (TermUInt' InlineArg 5) `shouldBe` BSL.pack [0x05]
+      encode (TermUInt' OneByteArg 5) `shouldBe` BSL.pack [0x18, 0x05]
+      encode (TermUInt' TwoByteArg 5) `shouldBe` BSL.pack [0x19, 0x00, 0x05]
+      encode (TermUInt' FourByteArg 5) `shouldBe` BSL.pack [0x1a, 0x00, 0x00, 0x00, 0x05]
+      encode (TermUInt' EightByteArg 5)
+        `shouldBe` BSL.pack (0x1b : replicate 7 0x00 <> [0x05])
+
+    it "decodes non-minimal argument widths" $ do
+      decode (BSL.pack [0x18, 0x05]) `shouldBe` Right (TermUInt' OneByteArg 5)
+      decode (BSL.pack [0x38, 0x04])
+        `shouldBe` Right (TermNInt' OneByteArg (fromJust (toNInt (-5))))
+      decode (BSL.pack [0x58, 0x01, 0x00])
+        `shouldBe` Right (TermBytes' OneByteArg (BS.pack [0x00]))
+      decode (BSL.pack [0x78, 0x01, 0x61])
+        `shouldBe` Right (TermString' OneByteArg (T.pack "a"))
+      decode (BSL.pack [0x98, 0x02, 0x01, 0x02])
+        `shouldBe` Right (TermArray' OneByteArg [TermUInt' InlineArg 1, TermUInt' InlineArg 2])
+      decode (BSL.pack [0xb8, 0x01, 0x01, 0x02])
+        `shouldBe` Right (TermMap' OneByteArg [(TermUInt' InlineArg 1, TermUInt' InlineArg 2)])
+      decode (BSL.pack [0xd8, 0x2a, 0x00])
+        `shouldBe` Right (TermTag' OneByteArg 42 (TermUInt' InlineArg 0))
+      decode (BSL.pack [0x5f, 0x58, 0x01, 0x61, 0xff])
+        `shouldBe` Right (TermBytesI' [(OneByteArg, BSL.pack [0x61])])
+
+    it "round-trips non-minimal wire bytes exactly" $
+      mapM_ shouldRoundtripBytes nonMinimalByteVectors
+
+    it "refuses to encode an argument that does not fit the width" $
+      evaluate (BSL.length (encode (TermUInt' InlineArg 24))) `shouldThrow` anyErrorCall
 
   describe "ill-formed input is rejected" $ do
     it "a lone break stop code" $
@@ -104,4 +179,22 @@ byteVectors =
   , [0xf9, 0x7c, 0x00] -- Infinity_1
   , [0xfa, 0x47, 0xc3, 0x50, 0x00] -- 100000.0_2
   , [0xfb, 0x40, 0x09, 0x21, 0xfb, 0x54, 0x44, 0x2d, 0x18] -- pi_3
+  ]
+
+-- | Well-formed but non-preferred encodings: every argument is stored
+-- wider than necessary and must survive a decode/encode round-trip.
+nonMinimalByteVectors :: [[Word8]]
+nonMinimalByteVectors =
+  [ [0x18, 0x05] -- 5 with a one-byte argument
+  , [0x19, 0x00, 0x05] -- 5 with a two-byte argument
+  , [0x1a, 0x00, 0x00, 0x00, 0x05] -- 5 with a four-byte argument
+  , [0x1b, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x05] -- 5, eight bytes
+  , [0x38, 0x00] -- -1 with a one-byte argument
+  , [0x59, 0x00, 0x01, 0x2a] -- h'2a' with a two-byte length
+  , [0x7a, 0x00, 0x00, 0x00, 0x01, 0x61] -- "a" with a four-byte length
+  , [0x98, 0x01, 0x00] -- [0] with a one-byte length
+  , [0xb8, 0x01, 0x00, 0x01] -- {0: 1} with a one-byte length
+  , [0xd8, 0x01, 0x00] -- tag 1 with a one-byte argument
+  , [0x5f, 0x59, 0x00, 0x01, 0x61, 0xff] -- indefinite bytes, wide chunk length
+  , [0x7f, 0x78, 0x01, 0x61, 0xff] -- indefinite text, wide chunk length
   ]

--- a/test/Test/Codec/CBOR/Cuddle/CDDL/Examples/Huddle.hs
+++ b/test/Test/Codec/CBOR/Cuddle/CDDL/Examples/Huddle.hs
@@ -32,6 +32,7 @@ module Test.Codec.CBOR.Cuddle.CDDL.Examples.Huddle (
 ) where
 
 import Codec.CBOR.Cuddle.CBOR.Gen (generateFromGRef)
+import Codec.CBOR.Cuddle.CBOR.Term (CBORTerm (..))
 import Codec.CBOR.Cuddle.CBOR.Validator (validateFromGRef)
 import Codec.CBOR.Cuddle.CDDL (Name)
 import Codec.CBOR.Cuddle.CDDL.Custom.Core (RuleTerm (..))
@@ -57,7 +58,6 @@ import Codec.CBOR.Cuddle.Huddle (
   (==>),
  )
 import Codec.CBOR.Cuddle.Huddle qualified as H
-import Codec.CBOR.Term qualified as C
 import Data.Word (Word64)
 import Test.QuickCheck.GenT (MonadGen (..), frequency)
 
@@ -114,7 +114,7 @@ simpleRule :: Name -> Rule
 simpleRule n = n =:= arr [1, 2, 3]
 
 customGenRule :: Name -> Rule
-customGenRule = withCBORGen (SingleTerm . C.TInt <$> choose (4, 6)) . simpleRule
+customGenRule = withCBORGen (SingleTerm . TermUInt <$> choose (4, 6)) . simpleRule
 
 customGenExample :: Huddle
 customGenExample =
@@ -346,11 +346,11 @@ tagRangeExample =
               , (4, choose (1281, 1399))
               ]
           generateFromGRef x >>= \case
-            SingleTerm inner -> pure $ SingleTerm (C.TTagged tagN inner)
+            SingleTerm inner -> pure $ SingleTerm (TermTag tagN inner)
             _ -> error "tagRangeExample: generic argument must be a single term"
 
         validator x = \case
-          SingleTerm (C.TTagged t inner)
+          SingleTerm (TermTag t inner)
             | t >= 1280 && t <= 1400 -> validateFromGRef x inner
             | otherwise -> fail $ "Tag out of range 1280..1400: " <> show t
           wt -> fail $ "Expected a tagged term, got: " <> show wt

--- a/test/Test/Codec/CBOR/Cuddle/CDDL/Examples/Huddle.hs
+++ b/test/Test/Codec/CBOR/Cuddle/CDDL/Examples/Huddle.hs
@@ -32,7 +32,7 @@ module Test.Codec.CBOR.Cuddle.CDDL.Examples.Huddle (
 ) where
 
 import Codec.CBOR.Cuddle.CBOR.Gen (generateFromGRef)
-import Codec.CBOR.Cuddle.CBOR.Term (CBORTerm (..))
+import Codec.CBOR.Cuddle.CBOR.Term (CBORTerm (..), mkTermTag, mkTermUInt)
 import Codec.CBOR.Cuddle.CBOR.Validator (validateFromGRef)
 import Codec.CBOR.Cuddle.CDDL (Name)
 import Codec.CBOR.Cuddle.CDDL.Custom.Core (RuleTerm (..))
@@ -114,7 +114,7 @@ simpleRule :: Name -> Rule
 simpleRule n = n =:= arr [1, 2, 3]
 
 customGenRule :: Name -> Rule
-customGenRule = withCBORGen (SingleTerm . TermUInt <$> choose (4, 6)) . simpleRule
+customGenRule = withCBORGen (SingleTerm . mkTermUInt <$> choose (4, 6)) . simpleRule
 
 customGenExample :: Huddle
 customGenExample =
@@ -346,7 +346,7 @@ tagRangeExample =
               , (4, choose (1281, 1399))
               ]
           generateFromGRef x >>= \case
-            SingleTerm inner -> pure $ SingleTerm (TermTag tagN inner)
+            SingleTerm inner -> pure $ SingleTerm (mkTermTag tagN inner)
             _ -> error "tagRangeExample: generic argument must be a single term"
 
         validator x = \case

--- a/test/Test/Codec/CBOR/Cuddle/CDDL/GeneratorSpec.hs
+++ b/test/Test/Codec/CBOR/Cuddle/CDDL/GeneratorSpec.hs
@@ -5,6 +5,11 @@
 module Test.Codec.CBOR.Cuddle.CDDL.GeneratorSpec (spec) where
 
 import Codec.CBOR.Cuddle.CBOR.Gen (GenPhase, generateFromName)
+import Codec.CBOR.Cuddle.CBOR.Term (
+  CBORTerm (..),
+  decodeCBORTerm,
+  encodeCBORTerm,
+ )
 import Codec.CBOR.Cuddle.CDDL (Name)
 import Codec.CBOR.Cuddle.CDDL.CTree (CTreeRoot (..))
 import Codec.CBOR.Cuddle.CDDL.Custom.Generator (GenConfig (..), runCBORGen)
@@ -13,7 +18,6 @@ import Codec.CBOR.Cuddle.Huddle (Huddle, toCDDL)
 import Codec.CBOR.Cuddle.IndexMappable (IndexMappable (..), mapCDDLDropExt)
 import Codec.CBOR.Pretty (prettyHexEnc)
 import Codec.CBOR.Read (deserialiseFromBytes)
-import Codec.CBOR.Term (Term (..), decodeTerm, encodeTerm)
 import Codec.CBOR.Write (toStrictByteString)
 import Data.ByteString.Lazy qualified as LBS
 import Data.Text qualified as T
@@ -39,7 +43,7 @@ import Test.Hspec.QuickCheck (prop)
 import Test.QuickCheck (Gen, Property, Testable (..), classify, counterexample)
 import Text.Pretty.Simple (pShow)
 
-generateCDDL :: CTreeRoot GenPhase -> Gen Term
+generateCDDL :: CTreeRoot GenPhase -> Gen CBORTerm
 generateCDDL cddl = runAntiGen . runCBORGen cfg $ generateFromName "root"
   where
     cfg =
@@ -64,12 +68,12 @@ expectZapInvalidates cddl name = property $ do
         }
   res@ZapResult {zrValue} <- zapAntiGenResult 1 . runCBORGen cfg $ generateFromName name
   let
-    bs = toStrictByteString $ encodeTerm zrValue
+    bs = toStrictByteString $ encodeCBORTerm zrValue
     validationRes = validateCBOR_ bs name $ mapIndex cddl
     failMsg =
       unlines
-        [ case deserialiseFromBytes decodeTerm (LBS.fromStrict bs) of
-            Right (_, t) -> prettyHexEnc (encodeTerm t)
+        [ case deserialiseFromBytes decodeCBORTerm (LBS.fromStrict bs) of
+            Right (_, t) -> prettyHexEnc (encodeCBORTerm t)
             Left _ -> mempty
         , mempty
         , T.unpack $ prettyZapResult res
@@ -122,30 +126,30 @@ spec = do
         res <- generateCDDL $ mapIndex customGenExampleCddl
         pure $
           res `shouldSatisfy` \case
-            TInt i -> i > 3 && i < 7
+            TermUInt i -> i > 3 && i < 7
             _ -> False
       refTermExampleCddl <- tryResolveHuddle refTermExample
       prop "Custom generator works when called via reference" $ do
         res <- generateCDDL $ mapIndex refTermExampleCddl
         pure $
           res `shouldSatisfy` \case
-            TList [TInt 0, TInt i] -> i > 3 && i < 7
-            TListI [TInt 0, TInt i] -> i > 3 && i < 7
+            TermArray [TermUInt 0, TermUInt i] -> i > 3 && i < 7
+            TermArrayI [TermUInt 0, TermUInt i] -> i > 3 && i < 7
             _ -> False
       bytesExampleCddl <- tryResolveHuddle bytesExample
       prop "Bytes are generated correctly" $ do
         res <- generateCDDL $ mapIndex bytesExampleCddl
         pure $
           res `shouldSatisfy` \case
-            TBytes "\x01\x02\x03\xff" -> True
-            TBytesI "\x01\x02\x03\xff" -> True
+            TermBytes "\x01\x02\x03\xff" -> True
+            TermBytesI chunks -> mconcat chunks == "\x01\x02\x03\xff"
             _ -> False
       tagRangeExampleCddl <- tryResolveHuddle tagRangeExample
       prop "tagRange generator covers edges and middle" $ do
         res <- generateCDDL $ mapIndex tagRangeExampleCddl
         let tags = case res of
-              TList xs -> [t | TTagged t _ <- xs]
-              TListI xs -> [t | TTagged t _ <- xs]
+              TermArray xs -> [t | TermTag t _ <- xs]
+              TermArrayI xs -> [t | TermTag t _ <- xs]
               _ -> []
             classifyTag t p =
               classify (t == 1280 || t == 1400) "edge tag (1280 or 1400)" $
@@ -166,21 +170,21 @@ spec = do
       ZapResult {zrValue} <-
         zapAntiGenResult 1 . runCBORGen cfg $ generateFromName "root"
       let
-        isBytes TBytes {} = True
-        isBytes TBytesI {} = True
+        isBytes TermBytes {} = True
+        isBytes TermBytesI {} = True
         isBytes _ = False
         tagOmitted = case zrValue of
-          TTagged {} -> False
+          TermTag {} -> False
           _ -> True
         tagChanged = case zrValue of
-          TTagged t _ -> t /= 42
+          TermTag t _ -> t /= 42
           _ -> False
         innerValueZapped = case zrValue of
-          TTagged 42 inner -> not (isBytes inner)
+          TermTag 42 inner -> not (isBytes inner)
           _ -> False
       pure
         . classify tagOmitted "tag omitted"
         . classify tagChanged "tag changed"
         . classify innerValueZapped "inner value zapped"
         $ expectInvalid
-          (validateCBOR_ (toStrictByteString $ encodeTerm zrValue) "root" $ mapIndex taggedBytesCddl)
+          (validateCBOR_ (toStrictByteString $ encodeCBORTerm zrValue) "root" $ mapIndex taggedBytesCddl)

--- a/test/Test/Codec/CBOR/Cuddle/CDDL/Parser.hs
+++ b/test/Test/Codec/CBOR/Cuddle/CDDL/Parser.hs
@@ -2,7 +2,7 @@
 
 module Test.Codec.CBOR.Cuddle.CDDL.Parser where
 
-import Codec.CBOR.Cuddle.CBOR.Term (toNInt)
+import Codec.CBOR.Cuddle.CBOR.NInt (toNInt)
 import Codec.CBOR.Cuddle.CDDL
 import Codec.CBOR.Cuddle.CDDL.CtlOp qualified as CtlOp
 import Codec.CBOR.Cuddle.IndexMappable (IndexMappable (..))

--- a/test/Test/Codec/CBOR/Cuddle/CDDL/Parser.hs
+++ b/test/Test/Codec/CBOR/Cuddle/CDDL/Parser.hs
@@ -2,6 +2,7 @@
 
 module Test.Codec.CBOR.Cuddle.CDDL.Parser where
 
+import Codec.CBOR.Cuddle.CBOR.Term (toNInt)
 import Codec.CBOR.Cuddle.CDDL
 import Codec.CBOR.Cuddle.CDDL.CtlOp qualified as CtlOp
 import Codec.CBOR.Cuddle.IndexMappable (IndexMappable (..))
@@ -9,6 +10,7 @@ import Codec.CBOR.Cuddle.Parser
 import Codec.CBOR.Cuddle.Parser.Lexer (Parser)
 import Codec.CBOR.Cuddle.Pretty (PrettyStage)
 import Data.List.NonEmpty (NonEmpty (..))
+import Data.Maybe (fromJust)
 import Data.Text qualified as T
 import Data.TreeDiff (ToExpr (..), ansiWlBgEditExprCompact, exprDiff)
 import Prettyprinter (Pretty, defaultLayoutOptions, layoutPretty, pretty)
@@ -79,7 +81,7 @@ valueSpec = describe "pValue" $ do
   it "Parses integer" $
     parse pValue "" "123" `shouldParse` value (VUInt 123)
   it "Parses negative integer" $
-    parse pValue "" "-123" `shouldParse` value (VNInt 123)
+    parse pValue "" "-123" `shouldParse` value (VNInt (fromJust (toNInt (-123))))
   it "Parses float" $
     parse pValue "" "3.1415" `shouldParse` value (VFloat64 3.1415)
   it "Parses text" $

--- a/test/Test/Codec/CBOR/Cuddle/CDDL/Pretty.hs
+++ b/test/Test/Codec/CBOR/Cuddle/CDDL/Pretty.hs
@@ -7,7 +7,7 @@ module Test.Codec.CBOR.Cuddle.CDDL.Pretty (
   roundtripSpec,
 ) where
 
-import Codec.CBOR.Cuddle.CBOR.Term (toNInt)
+import Codec.CBOR.Cuddle.CBOR.NInt (toNInt)
 import Codec.CBOR.Cuddle.CDDL (
   Assign (..),
   CDDL,

--- a/test/Test/Codec/CBOR/Cuddle/CDDL/Pretty.hs
+++ b/test/Test/Codec/CBOR/Cuddle/CDDL/Pretty.hs
@@ -7,6 +7,7 @@ module Test.Codec.CBOR.Cuddle.CDDL.Pretty (
   roundtripSpec,
 ) where
 
+import Codec.CBOR.Cuddle.CBOR.Term (toNInt)
 import Codec.CBOR.Cuddle.CDDL (
   Assign (..),
   CDDL,
@@ -30,6 +31,7 @@ import Codec.CBOR.Cuddle.Parser (pCDDL)
 import Codec.CBOR.Cuddle.Pretty (PrettyStage, XRule (..), renderCDDL)
 import Data.Default.Class (Default (..))
 import Data.List.NonEmpty (NonEmpty (..))
+import Data.Maybe (fromJust)
 import Data.Text qualified as T
 import Data.Text.IO qualified as T
 import Data.TreeDiff (ToExpr (..), prettyExpr)
@@ -138,6 +140,11 @@ unitSpec = describe "HUnit" $ do
   describe "CDDL" $ do
     describe "Name" $ do
       it "names" $ Name "a" `prettyPrintsTo` "a"
+    describe "Value" $ do
+      it "negative integer literal" $
+        value (VNInt (fromJust (toNInt (-123)))) `prettyPrintsTo` "-123"
+      it "float16 literal" $
+        value (VFloat16 1.5) `prettyPrintsTo` "1.5"
     describe "Type0" $ do
       it "name" $ Type0 @PrettyStage (t1Name :| []) `prettyPrintsTo` "a"
     describe "Type1" $ do

--- a/test/Test/Codec/CBOR/Cuddle/CDDL/TreeDiff.hs
+++ b/test/Test/Codec/CBOR/Cuddle/CDDL/TreeDiff.hs
@@ -3,6 +3,7 @@
 
 module Test.Codec.CBOR.Cuddle.CDDL.TreeDiff () where
 
+import Codec.CBOR.Cuddle.CBOR.Term (NInt, fromNInt)
 import Codec.CBOR.Cuddle.CDDL (
   Assign,
   CDDL,
@@ -32,7 +33,8 @@ import Codec.CBOR.Cuddle.CDDL (
 import Codec.CBOR.Cuddle.CDDL.CtlOp (CtlOp)
 import Codec.CBOR.Cuddle.Comments (Comment)
 import Codec.CBOR.Cuddle.Pretty (PrettyStage, XRule, XTerm, XXTopLevel, XXType2)
-import Data.TreeDiff (ToExpr)
+import Data.TreeDiff (ToExpr (..))
+import Numeric.Half (Half, fromHalf)
 
 instance ToExpr Name
 
@@ -43,6 +45,12 @@ instance ForAllExtensions p ToExpr => ToExpr (GenericParameters p)
 instance ForAllExtensions p ToExpr => ToExpr (GenericArg p)
 
 instance ToExpr Comment
+
+instance ToExpr NInt where
+  toExpr = toExpr . fromNInt
+
+instance ToExpr Half where
+  toExpr = toExpr . fromHalf
 
 instance ToExpr ValueVariant
 

--- a/test/Test/Codec/CBOR/Cuddle/CDDL/TreeDiff.hs
+++ b/test/Test/Codec/CBOR/Cuddle/CDDL/TreeDiff.hs
@@ -3,7 +3,7 @@
 
 module Test.Codec.CBOR.Cuddle.CDDL.TreeDiff () where
 
-import Codec.CBOR.Cuddle.CBOR.Term (NInt, fromNInt)
+import Codec.CBOR.Cuddle.CBOR.NInt (NInt, fromNInt)
 import Codec.CBOR.Cuddle.CDDL (
   Assign,
   CDDL,

--- a/test/Test/Codec/CBOR/Cuddle/CDDL/Validator.hs
+++ b/test/Test/Codec/CBOR/Cuddle/CDDL/Validator.hs
@@ -13,6 +13,7 @@ module Test.Codec.CBOR.Cuddle.CDDL.Validator (
 
 import Codec.CBOR.Cuddle.CBOR.Canonical (toCanonical)
 import Codec.CBOR.Cuddle.CBOR.Gen (generateFromName)
+import Codec.CBOR.Cuddle.CBOR.NInt (toNInt)
 import Codec.CBOR.Cuddle.CBOR.Term (
   CBORTerm (..),
   encodeCBORTerm,
@@ -25,7 +26,6 @@ import Codec.CBOR.Cuddle.CBOR.Term (
   mkTermStringI,
   mkTermTag,
   mkTermUInt,
-  toNInt,
   unsignedToBytes,
  )
 import Codec.CBOR.Cuddle.CBOR.Validator (

--- a/test/Test/Codec/CBOR/Cuddle/CDDL/Validator.hs
+++ b/test/Test/Codec/CBOR/Cuddle/CDDL/Validator.hs
@@ -508,6 +508,12 @@ spec = describe "Validator" $ do
           expectValid $ validateTermText "a = -5 .. -1" "a" (termInt (-3))
           expectInvalid $ validateTermText "a = -5 .. -1" "a" (mkTermUInt 0)
       describe "Float" $ do
+        it "Accepts a float16 within the range" $
+          expectValid $
+            validateTermText "a = 0.0 .. 1.0" "a" (TermHalf 0.5)
+        it "Rejects a float16 outside the range" $
+          expectInvalid $
+            validateTermText "a = 0.0 .. 1.0" "a" (TermHalf 100.0)
         it "Accepts a float32 within the range" $
           expectValid $
             validateTermText "a = 0.0 .. 1.0" "a" (TermFloat 0.5)

--- a/test/Test/Codec/CBOR/Cuddle/CDDL/Validator.hs
+++ b/test/Test/Codec/CBOR/Cuddle/CDDL/Validator.hs
@@ -16,6 +16,15 @@ import Codec.CBOR.Cuddle.CBOR.Gen (generateFromName)
 import Codec.CBOR.Cuddle.CBOR.Term (
   CBORTerm (..),
   encodeCBORTerm,
+  mkTermArray,
+  mkTermBytes,
+  mkTermBytesI,
+  mkTermMap,
+  mkTermNInt,
+  mkTermString,
+  mkTermStringI,
+  mkTermTag,
+  mkTermUInt,
   toNInt,
   unsignedToBytes,
  )
@@ -71,7 +80,6 @@ import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Text.IO qualified as T
 import Data.Text.Lazy qualified as LT
-import Numeric.Half (toHalf)
 import Paths_cuddle (getDataFileName)
 import Prettyprinter (defaultLayoutOptions, layoutPretty)
 import Prettyprinter.Render.Terminal (renderStrict)
@@ -178,7 +186,7 @@ genHuddleArrayRequiredTerms = do
       [ (: []) <$> (genStringTerm . T.pack =<< arbitrary)
       , pure []
       ]
-  lastInt <- TermUInt <$> arbitrary
+  lastInt <- mkTermUInt <$> arbitrary
   pure $ ints <> text <> [lastInt]
 
 genHuddleArrayTerms :: Gen [CBORTerm]
@@ -203,7 +211,7 @@ genBadArrayMissingLastInt =
 genHuddleRangeArray :: Gen CBORTerm
 genHuddleRangeArray = do
   numInts <- choose (3, 4)
-  ints <- vectorOf numInts $ TermUInt <$> arbitrary
+  ints <- vectorOf numInts $ mkTermUInt <$> arbitrary
   numBools <- choose (0, 3)
   bools <- vectorOf numBools $ TermSimple <$> elements [20, 21]
   numTexts <- choose (3, 10)
@@ -211,21 +219,21 @@ genHuddleRangeArray = do
   genArrayTerm $ ints <> bools <> texts
 
 genArrayTerm :: [CBORTerm] -> Gen CBORTerm
-genArrayTerm xs = elements [TermArray xs, TermArrayI xs]
+genArrayTerm xs = elements [mkTermArray xs, TermArrayI xs]
 
 genMapTerm :: [(CBORTerm, CBORTerm)] -> Gen CBORTerm
-genMapTerm x = elements [TermMap x, TermMapI x]
+genMapTerm x = elements [mkTermMap x, TermMapI x]
 
 genStringTerm :: Text -> Gen CBORTerm
-genStringTerm x = elements [TermString x, TermStringI [LT.fromStrict x]]
+genStringTerm x = elements [mkTermString x, mkTermStringI [LT.fromStrict x]]
 
 genBytesTerm :: ByteString -> Gen CBORTerm
-genBytesTerm x = elements [TermBytes x, TermBytesI [LBS.fromStrict x]]
+genBytesTerm x = elements [mkTermBytes x, mkTermBytesI [LBS.fromStrict x]]
 
 termInt :: Int -> CBORTerm
 termInt n
-  | n >= 0 = TermUInt $ fromIntegral n
-  | otherwise = TermNInt . fromJust . toNInt $ toInteger n
+  | n >= 0 = mkTermUInt $ fromIntegral n
+  | otherwise = mkTermNInt . fromJust . toNInt $ toInteger n
 
 termBool :: Bool -> CBORTerm
 termBool False = TermSimple 20
@@ -234,39 +242,16 @@ termBool True = TermSimple 21
 arbitraryByteString :: Gen ByteString
 arbitraryByteString = BS.pack <$> arbitrary
 
-arbitraryTerm :: Gen CBORTerm
-arbitraryTerm =
-  oneof
-    [ TermUInt <$> arbitrary
-    , TermNInt <$> arbitrary
-    , TermBytes . BS.pack <$> arbitrary
-    , TermBytesI . fmap LBS.pack <$> arbitrary
-    , TermString . T.pack <$> arbitrary
-    , TermStringI . fmap LT.pack <$> arbitrary
-    , TermArray <$> listOf (scale (`div` 2) arbitraryTerm)
-    , TermArrayI <$> listOf (scale (`div` 2) arbitraryTerm)
-    , TermMap <$> listOf (scale (`div` 2) $ (,) <$> arbitraryTerm <*> arbitraryTerm)
-    , TermMapI <$> listOf (scale (`div` 2) $ (,) <$> arbitraryTerm <*> arbitraryTerm)
-    , -- TODO properly implement tagged generation
-      -- , TermTag <$> arbitrary <*> arbitraryTerm
-      termBool <$> arbitrary
-    , pure $ TermSimple 22
-    , pure $ TermSimple 23 -- TODO add other values once they are supported by cuddle
-    , TermHalf . toHalf <$> arbitrary
-    , TermFloat <$> arbitrary
-    , TermDouble <$> arbitrary
-    ]
-
 genFullMap :: Gen CBORTerm
 genFullMap = do
   field1 <- do
-    es <- listOf $ TermUInt <$> arbitrary
-    pure (TermUInt 1, TermArray es)
+    es <- listOf $ mkTermUInt <$> arbitrary
+    pure (mkTermUInt 1, mkTermArray es)
   lField2 <-
     oneof
       [ do
           b <- arbitrary
-          pure [(TermUInt 2, termBool b)]
+          pure [(mkTermUInt 2, termBool b)]
       , pure []
       ]
   strFields <-
@@ -274,17 +259,17 @@ genFullMap = do
       <$> listOf ((,) <$> (genStringTerm . T.pack =<< arbitrary) <*> (termInt <$> arbitrary))
   bytesFields <-
     nubOrdOn (toCanonical . fst)
-      <$> listOf1 ((,) <$> (genBytesTerm =<< arbitraryByteString) <*> arbitraryTerm)
+      <$> listOf1 ((,) <$> (genBytesTerm =<< arbitraryByteString) <*> arbitrary)
   allFields <- shuffle $ field1 : lField2 <> strFields <> bytesFields
   genMapTerm allFields
 
 genBadMapInvalidIndex :: Gen CBORTerm
 genBadMapInvalidIndex =
   pure $
-    TermMap
-      [ (TermUInt 1, TermArray [])
-      , (TermUInt 99, TermArray [])
-      , (TermBytes "foo", TermBytes "bar")
+    mkTermMap
+      [ (mkTermUInt 1, mkTermArray [])
+      , (mkTermUInt 99, mkTermArray [])
+      , (mkTermBytes "foo", mkTermBytes "bar")
       ]
 
 validateHuddle ::
@@ -413,10 +398,13 @@ spec = describe "Validator" $ do
                 ]
         it "Validates when optional entry is present" $
           expectValid $
-            validateHuddle optionalInGroupHuddle "root" (TermArray [TermUInt 1, termBool True, TermUInt 2])
+            validateHuddle
+              optionalInGroupHuddle
+              "root"
+              (mkTermArray [mkTermUInt 1, termBool True, mkTermUInt 2])
         it "Validates when optional entry is absent" $
           expectValid $
-            validateHuddle optionalInGroupHuddle "root" (TermArray [TermUInt 1, TermUInt 2])
+            validateHuddle optionalInGroupHuddle "root" (mkTermArray [mkTermUInt 1, mkTermUInt 2])
       describe "ZeroOrMore (*) inside a group referenced from an array" $ do
         let
           -- @
@@ -439,10 +427,10 @@ spec = describe "Validator" $ do
             validateHuddle
               zeroOrMoreInGroupHuddle
               "root"
-              (TermArray [termBool True, termBool False, TermUInt 42, TermString "hi"])
+              (mkTermArray [termBool True, termBool False, mkTermUInt 42, mkTermString "hi"])
         it "Validates when zero-or-more entry has zero elements" $
           expectValid $
-            validateHuddle zeroOrMoreInGroupHuddle "root" (TermArray [TermUInt 42, TermString "hi"])
+            validateHuddle zeroOrMoreInGroupHuddle "root" (mkTermArray [mkTermUInt 42, mkTermString "hi"])
       describe "Bounded (n..m) inside a group referenced from an array" $ do
         -- @
         --   root = [boundedGrp, text]
@@ -461,15 +449,15 @@ spec = describe "Validator" $ do
             validateHuddle
               boundedInGroupHuddle
               "root"
-              (TermArray [termBool True, TermUInt 42, TermString "hi"])
+              (mkTermArray [termBool True, mkTermUInt 42, mkTermString "hi"])
         it "Validates when bounded entry has zero elements (lower bound is 0)" $
           expectValid $
-            validateHuddle boundedInGroupHuddle "root" (TermArray [TermUInt 42, TermString "hi"])
+            validateHuddle boundedInGroupHuddle "root" (mkTermArray [mkTermUInt 42, mkTermString "hi"])
 
     describe "Bignums" $ do
       let
         bignum = 2 ^ (64 :: Int) :: Integer
-        bignumTerm = TermTag 2 . TermBytes $ unsignedToBytes bignum
+        bignumTerm = mkTermTag 2 . mkTermBytes $ unsignedToBytes bignum
       it "Validates a bignum >= 2^64 against biguint" $
         expectValid $
           validateTermText "a = biguint" "a" bignumTerm
@@ -491,34 +479,34 @@ spec = describe "Validator" $ do
       it "Accepts a matching positive bignum" $
         expectValid $
           validateTermText "a = 18446744073709551616" "a" $
-            TermTag 2 (TermBytes (unsignedToBytes bignum))
+            mkTermTag 2 (mkTermBytes (unsignedToBytes bignum))
       it "Rejects a positive bignum with a different value" $
         expectInvalid $
           validateTermText "a = 18446744073709551616" "a" $
-            TermTag 2 (TermBytes (unsignedToBytes (bignum + 1)))
+            mkTermTag 2 (mkTermBytes (unsignedToBytes (bignum + 1)))
       it "Accepts a matching negative bignum" $
         -- tag 3 content n denotes -1 - n: -18446744073709551617 = -1 - 2^64
         expectValid $
           validateTermText "a = -18446744073709551617" "a" $
-            TermTag 3 (TermBytes (unsignedToBytes bignum))
+            mkTermTag 3 (mkTermBytes (unsignedToBytes bignum))
 
     describe "Value ranges" $ do
       describe "Integer" $ do
         it "Accepts the bounds of a closed range" $ do
-          expectValid $ validateTermText "a = 1 .. 5" "a" (TermUInt 1)
-          expectValid $ validateTermText "a = 1 .. 5" "a" (TermUInt 5)
+          expectValid $ validateTermText "a = 1 .. 5" "a" (mkTermUInt 1)
+          expectValid $ validateTermText "a = 1 .. 5" "a" (mkTermUInt 5)
         it "Rejects values outside a closed range" $ do
-          expectInvalid $ validateTermText "a = 1 .. 5" "a" (TermUInt 0)
-          expectInvalid $ validateTermText "a = 1 .. 5" "a" (TermUInt 6)
+          expectInvalid $ validateTermText "a = 1 .. 5" "a" (mkTermUInt 0)
+          expectInvalid $ validateTermText "a = 1 .. 5" "a" (mkTermUInt 6)
         it "Excludes the upper bound of a half-open range" $ do
-          expectValid $ validateTermText "a = 1 ... 5" "a" (TermUInt 4)
-          expectInvalid $ validateTermText "a = 1 ... 5" "a" (TermUInt 5)
+          expectValid $ validateTermText "a = 1 ... 5" "a" (mkTermUInt 4)
+          expectInvalid $ validateTermText "a = 1 ... 5" "a" (mkTermUInt 5)
         it "Accepts the single member of a singleton range" $
           expectValid $
-            validateTermText "a = 5 .. 5" "a" (TermUInt 5)
+            validateTermText "a = 5 .. 5" "a" (mkTermUInt 5)
         it "Handles a range with two negative bounds" $ do
           expectValid $ validateTermText "a = -5 .. -1" "a" (termInt (-3))
-          expectInvalid $ validateTermText "a = -5 .. -1" "a" (TermUInt 0)
+          expectInvalid $ validateTermText "a = -5 .. -1" "a" (mkTermUInt 0)
       describe "Float" $ do
         it "Accepts a float32 within the range" $
           expectValid $
@@ -538,12 +526,12 @@ spec = describe "Validator" $ do
 
     describe "Size control" $ do
       it "Measures text size in UTF-8 bytes, not characters" $ do
-        expectValid $ validateTermText "a = text .size (0 .. 2)" "a" (TermString "é")
-        expectInvalid $ validateTermText "a = text .size (0 .. 2)" "a" (TermString "€")
+        expectValid $ validateTermText "a = text .size (0 .. 2)" "a" (mkTermString "é")
+        expectInvalid $ validateTermText "a = text .size (0 .. 2)" "a" (mkTermString "€")
       it "Handles a bytes size range with a negative lower bound" $ do
-        expectValid $ validateTermText "a = bytes .size (-2 .. 3)" "a" (TermBytes "")
-        expectValid $ validateTermText "a = bytes .size (-2 .. 3)" "a" (TermBytes "ab")
-        expectInvalid $ validateTermText "a = bytes .size (-2 .. 3)" "a" (TermBytes "abcd")
+        expectValid $ validateTermText "a = bytes .size (-2 .. 3)" "a" (mkTermBytes "")
+        expectValid $ validateTermText "a = bytes .size (-2 .. 3)" "a" (mkTermBytes "ab")
+        expectInvalid $ validateTermText "a = bytes .size (-2 .. 3)" "a" (mkTermBytes "abcd")
 
     describe "Simple values" $ do
       it "Validates an unassigned simple value against any" $
@@ -559,7 +547,7 @@ spec = describe "Validator" $ do
           validateHuddle
             (collectFrom [HIRule $ "a" =:= int 18446744073709551615])
             "a"
-            (TermUInt maxBound)
+            (mkTermUInt maxBound)
 
   describe "Custom validator" $ do
     describe "Positive" $ do
@@ -593,7 +581,7 @@ spec = describe "Validator" $ do
               [ HIRule ruleA
               , HIRule $ "b" =:= arr [0, a (ruleA H./ VNil)]
               ]
-        arrTerm <- genArrayTerm [TermUInt 0, TermBytes bs]
+        arrTerm <- genArrayTerm [mkTermUInt 0, mkTermBytes bs]
         pure . expectValid $ validateHuddle huddle "b" arrTerm
     describe "Negative" $ do
       prop "Fails if term is valid against the Huddle, but not the custom validator" $ do

--- a/test/Test/Codec/CBOR/Cuddle/CDDL/Validator.hs
+++ b/test/Test/Codec/CBOR/Cuddle/CDDL/Validator.hs
@@ -13,6 +13,7 @@ module Test.Codec.CBOR.Cuddle.CDDL.Validator (
 
 import Codec.CBOR.Cuddle.CBOR.Canonical (toCanonical)
 import Codec.CBOR.Cuddle.CBOR.Gen (generateFromName)
+import Codec.CBOR.Cuddle.CBOR.Term (CBORTerm (..))
 import Codec.CBOR.Cuddle.CBOR.Validator (
   ValidatorPhase,
   validateCBOR,
@@ -52,7 +53,6 @@ import Codec.CBOR.Cuddle.Huddle qualified as H
 import Codec.CBOR.Cuddle.IndexMappable (mapCDDLDropExt, mapIndex)
 import Codec.CBOR.Cuddle.Parser (pCDDL)
 import Codec.CBOR.Pretty (prettyHexEnc)
-import Codec.CBOR.Term (Term (..), encodeTerm)
 import Codec.CBOR.Write (toStrictByteString)
 import Control.Monad (forM_)
 import Data.ByteString (ByteString)
@@ -157,14 +157,14 @@ genAndValidateFromFile path = do
 genInfiniteUniqueListOn :: Ord b => (a -> b) -> Gen a -> Gen [a]
 genInfiniteUniqueListOn f = fmap (nubOrdOn f) . infiniteListOf
 
-genHuddleRangeMap :: (Int, Int) -> Gen Term
+genHuddleRangeMap :: (Int, Int) -> Gen CBORTerm
 genHuddleRangeMap rng@(lo, hi) = do
   n <- choose rng
   let genKV = (,) <$> fmap TInt arbitrary <*> fmap TBool arbitrary
   genMapTerm . take n
     =<< scale (const $ max lo hi) (genInfiniteUniqueListOn (toCanonical . fst) genKV)
 
-genHuddleArrayRequiredTerms :: Gen [Term]
+genHuddleArrayRequiredTerms :: Gen [CBORTerm]
 genHuddleArrayRequiredTerms = do
   ints <- listOf1 $ TInt <$> arbitrary
   text <-
@@ -175,51 +175,51 @@ genHuddleArrayRequiredTerms = do
   lastInt <- TInt . getNonNegative <$> arbitrary
   pure $ ints <> text <> [lastInt]
 
-genHuddleArrayTerms :: Gen [Term]
+genHuddleArrayTerms :: Gen [CBORTerm]
 genHuddleArrayTerms = do
   bools <- listOf $ TBool <$> arbitrary
   required <- genHuddleArrayRequiredTerms
   pure $ bools <> required
 
-genHuddleArray :: Gen Term
+genHuddleArray :: Gen CBORTerm
 genHuddleArray = genHuddleArrayTerms >>= genArrayTerm
 
-genBadArrayReversed :: Gen Term
-genBadArrayReversed = genHuddleArrayTerms >>= genArrayTerm . reverse . (TBool True :)
+genBadArrayReversed :: Gen CBORTerm
+genBadArrayReversed = genHuddleArrayTerms >>= genArrayTerm . reverse . (TermSimple 21 :)
 
-genBadArrayMissingLastInt :: Gen Term
+genBadArrayMissingLastInt :: Gen CBORTerm
 genBadArrayMissingLastInt =
   genHuddleArrayTerms >>= genArrayTerm . reverse . dropWhile isNonNegativeInt . reverse
   where
-    isNonNegativeInt (TInt x) | x >= 0 = True
+    isNonNegativeInt (TermUInt _) = True
     isNonNegativeInt _ = False
 
-genHuddleRangeArray :: Gen Term
+genHuddleRangeArray :: Gen CBORTerm
 genHuddleRangeArray = do
   numInts <- choose (3, 4)
-  ints <- vectorOf numInts $ TInt <$> arbitrary
+  ints <- vectorOf numInts $ TermUInt <$> arbitrary
   numBools <- choose (0, 3)
-  bools <- vectorOf numBools $ TBool <$> arbitrary
+  bools <- vectorOf numBools $ TermSimple <$> elements [20, 21]
   numTexts <- choose (3, 10)
   texts <- vectorOf numTexts $ genStringTerm . T.pack =<< arbitrary
   genArrayTerm $ ints <> bools <> texts
 
-genArrayTerm :: [Term] -> Gen Term
-genArrayTerm xs = elements [TList xs, TListI xs]
+genArrayTerm :: [CBORTerm] -> Gen CBORTerm
+genArrayTerm xs = elements [TermArray xs, TermArrayI xs]
 
-genMapTerm :: [(Term, Term)] -> Gen Term
-genMapTerm x = elements [TMap x, TMapI x]
+genMapTerm :: [(CBORTerm, CBORTerm)] -> Gen CBORTerm
+genMapTerm x = elements [TermMap x, TermMapI x]
 
-genStringTerm :: Text -> Gen Term
-genStringTerm x = elements [TString x, TStringI (LT.fromStrict x)]
+genStringTerm :: Text -> Gen CBORTerm
+genStringTerm x = elements [TermString x, TermStringI (LT.fromStrict x)]
 
-genBytesTerm :: ByteString -> Gen Term
-genBytesTerm x = elements [TBytes x, TBytesI $ LBS.fromStrict x]
+genBytesTerm :: ByteString -> Gen CBORTerm
+genBytesTerm x = elements [TermBytes x, TermBytesI $ LBS.fromStrict x]
 
 arbitraryByteString :: Gen ByteString
 arbitraryByteString = BS.pack <$> arbitrary
 
-arbitraryTerm :: Gen Term
+arbitraryTerm :: Gen CBORTerm
 arbitraryTerm =
   oneof
     [ TInt <$> arbitrary
@@ -242,7 +242,7 @@ arbitraryTerm =
     , TDouble <$> arbitrary
     ]
 
-genFullMap :: Gen Term
+genFullMap :: Gen CBORTerm
 genFullMap = do
   field1 <- do
     es <- listOf $ TInt . getNonNegative <$> arbitrary
@@ -263,7 +263,7 @@ genFullMap = do
   allFields <- shuffle $ field1 : lField2 <> strFields <> bytesFields
   genMapTerm allFields
 
-genBadMapInvalidIndex :: Gen Term
+genBadMapInvalidIndex :: Gen CBORTerm
 genBadMapInvalidIndex =
   pure $
     TMap
@@ -276,7 +276,7 @@ validateHuddle ::
   HasCallStack =>
   Huddle ->
   Name ->
-  Term ->
+  CBORTerm ->
   Evidenced ValidationTrace
 validateHuddle huddle name term = do
   let
@@ -301,13 +301,13 @@ expectInvalid (Evidenced SValid t) =
 expectInvalid _ = pure ()
 
 stringValidator :: TermValidator
-stringValidator (SingleTerm (TString _)) = pure ()
-stringValidator (SingleTerm (TStringI _)) = pure ()
+stringValidator (SingleTerm (TermString _)) = pure ()
+stringValidator (SingleTerm (TermStringI _)) = pure ()
 stringValidator t = fail $ "Expected a string, got\n" <> show t
 
 bytesValidator :: TermValidator
-bytesValidator (SingleTerm (TBytes _)) = pure ()
-bytesValidator (SingleTerm (TBytesI _)) = pure ()
+bytesValidator (SingleTerm (TermBytes _)) = pure ()
+bytesValidator (SingleTerm (TermBytesI _)) = pure ()
 bytesValidator t = fail $ "Expected bytes, got\n" <> show t
 
 spec :: Spec

--- a/test/Test/Codec/CBOR/Cuddle/CDDL/Validator.hs
+++ b/test/Test/Codec/CBOR/Cuddle/CDDL/Validator.hs
@@ -13,7 +13,12 @@ module Test.Codec.CBOR.Cuddle.CDDL.Validator (
 
 import Codec.CBOR.Cuddle.CBOR.Canonical (toCanonical)
 import Codec.CBOR.Cuddle.CBOR.Gen (generateFromName)
-import Codec.CBOR.Cuddle.CBOR.Term (CBORTerm (..))
+import Codec.CBOR.Cuddle.CBOR.Term (
+  CBORTerm (..),
+  encodeCBORTerm,
+  toNInt,
+  unsignedToBytes,
+ )
 import Codec.CBOR.Cuddle.CBOR.Validator (
   ValidatorPhase,
   validateCBOR,
@@ -61,10 +66,12 @@ import Data.ByteString.Lazy qualified as LBS
 import Data.Containers.ListUtils (nubOrdOn)
 import Data.Either (fromRight)
 import Data.Map qualified as Map
+import Data.Maybe (fromJust)
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Text.IO qualified as T
 import Data.Text.Lazy qualified as LT
+import Numeric.Half (toHalf)
 import Paths_cuddle (getDataFileName)
 import Prettyprinter (defaultLayoutOptions, layoutPretty)
 import Prettyprinter.Render.Terminal (renderStrict)
@@ -88,7 +95,6 @@ import Test.Hspec.QuickCheck
 import Test.QuickCheck (
   Arbitrary (..),
   Gen,
-  NonNegative (..),
   choose,
   counterexample,
   elements,
@@ -123,12 +129,12 @@ genAndValidateRule description name resolvedCddl =
           }
     cborTerm <- runAntiGen . runCBORGen genCfg $ generateFromName name
     let
-      generatedCbor = toStrictByteString $ encodeTerm cborTerm
+      generatedCbor = toStrictByteString $ encodeCBORTerm cborTerm
       res = validateCBOR_ generatedCbor name (mapIndex resolvedCddl)
       extraInfo =
         unlines
           [ "CBOR term:"
-          , prettyHexEnc $ encodeTerm cborTerm
+          , prettyHexEnc $ encodeCBORTerm cborTerm
           ]
     pure . counterexample extraInfo $ expectValid res
 
@@ -160,24 +166,24 @@ genInfiniteUniqueListOn f = fmap (nubOrdOn f) . infiniteListOf
 genHuddleRangeMap :: (Int, Int) -> Gen CBORTerm
 genHuddleRangeMap rng@(lo, hi) = do
   n <- choose rng
-  let genKV = (,) <$> fmap TInt arbitrary <*> fmap TBool arbitrary
+  let genKV = (,) <$> fmap termInt arbitrary <*> fmap termBool arbitrary
   genMapTerm . take n
     =<< scale (const $ max lo hi) (genInfiniteUniqueListOn (toCanonical . fst) genKV)
 
 genHuddleArrayRequiredTerms :: Gen [CBORTerm]
 genHuddleArrayRequiredTerms = do
-  ints <- listOf1 $ TInt <$> arbitrary
+  ints <- listOf1 $ termInt <$> arbitrary
   text <-
     oneof
       [ (: []) <$> (genStringTerm . T.pack =<< arbitrary)
       , pure []
       ]
-  lastInt <- TInt . getNonNegative <$> arbitrary
+  lastInt <- TermUInt <$> arbitrary
   pure $ ints <> text <> [lastInt]
 
 genHuddleArrayTerms :: Gen [CBORTerm]
 genHuddleArrayTerms = do
-  bools <- listOf $ TBool <$> arbitrary
+  bools <- listOf $ termBool <$> arbitrary
   required <- genHuddleArrayRequiredTerms
   pure $ bools <> required
 
@@ -211,10 +217,19 @@ genMapTerm :: [(CBORTerm, CBORTerm)] -> Gen CBORTerm
 genMapTerm x = elements [TermMap x, TermMapI x]
 
 genStringTerm :: Text -> Gen CBORTerm
-genStringTerm x = elements [TermString x, TermStringI (LT.fromStrict x)]
+genStringTerm x = elements [TermString x, TermStringI [LT.fromStrict x]]
 
 genBytesTerm :: ByteString -> Gen CBORTerm
-genBytesTerm x = elements [TermBytes x, TermBytesI $ LBS.fromStrict x]
+genBytesTerm x = elements [TermBytes x, TermBytesI [LBS.fromStrict x]]
+
+termInt :: Int -> CBORTerm
+termInt n
+  | n >= 0 = TermUInt $ fromIntegral n
+  | otherwise = TermNInt . fromJust . toNInt $ toInteger n
+
+termBool :: Bool -> CBORTerm
+termBool False = TermSimple 20
+termBool True = TermSimple 21
 
 arbitraryByteString :: Gen ByteString
 arbitraryByteString = BS.pack <$> arbitrary
@@ -222,41 +237,41 @@ arbitraryByteString = BS.pack <$> arbitrary
 arbitraryTerm :: Gen CBORTerm
 arbitraryTerm =
   oneof
-    [ TInt <$> arbitrary
-    , TInteger <$> arbitrary
-    , TBytes . BS.pack <$> arbitrary
-    , TBytesI . LBS.pack <$> arbitrary
-    , TString . T.pack <$> arbitrary
-    , TStringI . LT.pack <$> arbitrary
-    , TList <$> listOf (scale (`div` 2) arbitraryTerm)
-    , TListI <$> listOf (scale (`div` 2) arbitraryTerm)
-    , TMap <$> listOf (scale (`div` 2) $ (,) <$> arbitraryTerm <*> arbitraryTerm)
-    , TMapI <$> listOf (scale (`div` 2) $ (,) <$> arbitraryTerm <*> arbitraryTerm)
+    [ TermUInt <$> arbitrary
+    , TermNInt <$> arbitrary
+    , TermBytes . BS.pack <$> arbitrary
+    , TermBytesI . fmap LBS.pack <$> arbitrary
+    , TermString . T.pack <$> arbitrary
+    , TermStringI . fmap LT.pack <$> arbitrary
+    , TermArray <$> listOf (scale (`div` 2) arbitraryTerm)
+    , TermArrayI <$> listOf (scale (`div` 2) arbitraryTerm)
+    , TermMap <$> listOf (scale (`div` 2) $ (,) <$> arbitraryTerm <*> arbitraryTerm)
+    , TermMapI <$> listOf (scale (`div` 2) $ (,) <$> arbitraryTerm <*> arbitraryTerm)
     , -- TODO properly implement tagged generation
-      -- , TTagged <$> arbitrary <*> arbitraryTerm
-      TBool <$> arbitrary
-    , pure TNull
-    , pure $ TSimple 23 -- TODO add other values once they are supported by cuddle
-    , THalf <$> arbitrary
-    , TFloat <$> arbitrary
-    , TDouble <$> arbitrary
+      -- , TermTag <$> arbitrary <*> arbitraryTerm
+      termBool <$> arbitrary
+    , pure $ TermSimple 22
+    , pure $ TermSimple 23 -- TODO add other values once they are supported by cuddle
+    , TermHalf . toHalf <$> arbitrary
+    , TermFloat <$> arbitrary
+    , TermDouble <$> arbitrary
     ]
 
 genFullMap :: Gen CBORTerm
 genFullMap = do
   field1 <- do
-    es <- listOf $ TInt . getNonNegative <$> arbitrary
-    pure (TInt 1, TList es)
+    es <- listOf $ TermUInt <$> arbitrary
+    pure (TermUInt 1, TermArray es)
   lField2 <-
     oneof
       [ do
           b <- arbitrary
-          pure [(TInt 2, TBool b)]
+          pure [(TermUInt 2, termBool b)]
       , pure []
       ]
   strFields <-
     nubOrdOn (toCanonical . fst)
-      <$> listOf ((,) <$> (genStringTerm . T.pack =<< arbitrary) <*> (TInt <$> arbitrary))
+      <$> listOf ((,) <$> (genStringTerm . T.pack =<< arbitrary) <*> (termInt <$> arbitrary))
   bytesFields <-
     nubOrdOn (toCanonical . fst)
       <$> listOf1 ((,) <$> (genBytesTerm =<< arbitraryByteString) <*> arbitraryTerm)
@@ -266,10 +281,10 @@ genFullMap = do
 genBadMapInvalidIndex :: Gen CBORTerm
 genBadMapInvalidIndex =
   pure $
-    TMap
-      [ (TInt 1, TList [])
-      , (TInt 99, TList [])
-      , (TBytes "foo", TBytes "bar")
+    TermMap
+      [ (TermUInt 1, TermArray [])
+      , (TermUInt 99, TermArray [])
+      , (TermBytes "foo", TermBytes "bar")
       ]
 
 validateHuddle ::
@@ -283,7 +298,7 @@ validateHuddle huddle name term = do
     resolvedCddl = case fullResolveCDDL . mapCDDLDropExt $ toCDDL huddle of
       Right root -> root
       Left err -> error $ show err
-    bs = toStrictByteString $ encodeTerm term
+    bs = toStrictByteString $ encodeCBORTerm term
   validateCBOR_ bs name (mapIndex resolvedCddl)
 
 expectValid :: Evidenced ValidationTrace -> Expectation
@@ -374,10 +389,10 @@ spec = describe "Validator" $ do
                 ]
         it "Validates when optional entry is present" $
           expectValid $
-            validateHuddle optionalInGroupHuddle "root" (TList [TInt 1, TBool True, TInt 2])
+            validateHuddle optionalInGroupHuddle "root" (TermArray [TermUInt 1, termBool True, TermUInt 2])
         it "Validates when optional entry is absent" $
           expectValid $
-            validateHuddle optionalInGroupHuddle "root" (TList [TInt 1, TInt 2])
+            validateHuddle optionalInGroupHuddle "root" (TermArray [TermUInt 1, TermUInt 2])
       describe "ZeroOrMore (*) inside a group referenced from an array" $ do
         let
           -- @
@@ -400,10 +415,10 @@ spec = describe "Validator" $ do
             validateHuddle
               zeroOrMoreInGroupHuddle
               "root"
-              (TList [TBool True, TBool False, TInt 42, TString "hi"])
+              (TermArray [termBool True, termBool False, TermUInt 42, TermString "hi"])
         it "Validates when zero-or-more entry has zero elements" $
           expectValid $
-            validateHuddle zeroOrMoreInGroupHuddle "root" (TList [TInt 42, TString "hi"])
+            validateHuddle zeroOrMoreInGroupHuddle "root" (TermArray [TermUInt 42, TermString "hi"])
       describe "Bounded (n..m) inside a group referenced from an array" $ do
         -- @
         --   root = [boundedGrp, text]
@@ -422,15 +437,16 @@ spec = describe "Validator" $ do
             validateHuddle
               boundedInGroupHuddle
               "root"
-              (TList [TBool True, TInt 42, TString "hi"])
+              (TermArray [termBool True, TermUInt 42, TermString "hi"])
         it "Validates when bounded entry has zero elements (lower bound is 0)" $
           expectValid $
-            validateHuddle boundedInGroupHuddle "root" (TList [TInt 42, TString "hi"])
+            validateHuddle boundedInGroupHuddle "root" (TermArray [TermUInt 42, TermString "hi"])
 
     describe "Bignums" $ do
       let
         bignum = 2 ^ (64 :: Int) :: Integer
-        bignumCBOR = toStrictByteString . encodeTerm $ TInteger bignum
+        bignumCBOR =
+          toStrictByteString . encodeCBORTerm . TermTag 2 . TermBytes $ unsignedToBytes bignum
         resolveCDDL cddlText =
           let cddl = fromRight (error "Failed to parse CDDL") $ runParser pCDDL "" cddlText
            in either (error . show) id . fullResolveCDDL . appendPostlude $ mapCDDLDropExt cddl
@@ -482,7 +498,7 @@ spec = describe "Validator" $ do
               [ HIRule ruleA
               , HIRule $ "b" =:= arr [0, a (ruleA H./ VNil)]
               ]
-        arrTerm <- genArrayTerm [TInt 0, TBytes bs]
+        arrTerm <- genArrayTerm [TermUInt 0, TermBytes bs]
         pure . expectValid $ validateHuddle huddle "b" arrTerm
     describe "Negative" $ do
       prop "Fails if term is valid against the Huddle, but not the custom validator" $ do

--- a/test/Test/Codec/CBOR/Cuddle/CDDL/Validator.hs
+++ b/test/Test/Codec/CBOR/Cuddle/CDDL/Validator.hs
@@ -301,6 +301,19 @@ validateHuddle huddle name term = do
     bs = toStrictByteString $ encodeCBORTerm term
   validateCBOR_ bs name (mapIndex resolvedCddl)
 
+resolveCDDLText :: HasCallStack => Text -> CTreeRoot MonoReferenced
+resolveCDDLText cddlText =
+  let cddl = fromRight (error "Failed to parse CDDL") $ runParser pCDDL "" cddlText
+   in either (error . show) id . fullResolveCDDL . appendPostlude $ mapCDDLDropExt cddl
+
+-- | Validate a single term against a rule in an inline CDDL snippet.
+validateTermText :: HasCallStack => Text -> Name -> CBORTerm -> Evidenced ValidationTrace
+validateTermText cddlText name term =
+  validateCBOR_
+    (toStrictByteString $ encodeCBORTerm term)
+    name
+    (mapIndex $ resolveCDDLText cddlText)
+
 expectValid :: Evidenced ValidationTrace -> Expectation
 expectValid (Evidenced SValid _) = pure ()
 expectValid (Evidenced SInvalid t) =
@@ -335,6 +348,17 @@ spec = describe "Validator" $ do
     genAndValidateFromFile "cddl/pretty.cddl"
     genAndValidateFromFile "cddl/shelley.cddl"
     genAndValidateFromFile "cddl/validator.cddl"
+    genAndValidateCddl "inline: value ranges and bignum literals" . resolveCDDLText $
+      T.unlines
+        [ "closedRange = 1 .. 5"
+        , "singletonRange = 5 .. 5"
+        , "halfOpenRange = 1 ... 5"
+        , "negativeRange = -5 .. -1"
+        , "floatRange = 0.0 .. 1.0"
+        , "halfOpenFloatRange = 0.0 ... 1.0"
+        , "positiveBignum = 18446744073709551616"
+        , "negativeBignum = -18446744073709551617"
+        ]
   describe "Term tests" $ do
     describe "Maps and arrays" $ do
       describe "Positive" $ do
@@ -445,26 +469,97 @@ spec = describe "Validator" $ do
     describe "Bignums" $ do
       let
         bignum = 2 ^ (64 :: Int) :: Integer
-        bignumCBOR =
-          toStrictByteString . encodeCBORTerm . TermTag 2 . TermBytes $ unsignedToBytes bignum
-        resolveCDDL cddlText =
-          let cddl = fromRight (error "Failed to parse CDDL") $ runParser pCDDL "" cddlText
-           in either (error . show) id . fullResolveCDDL . appendPostlude $ mapCDDLDropExt cddl
+        bignumTerm = TermTag 2 . TermBytes $ unsignedToBytes bignum
       it "Validates a bignum >= 2^64 against biguint" $
         expectValid $
-          validateCBOR_ bignumCBOR "a" (mapIndex $ resolveCDDL "a = biguint")
+          validateTermText "a = biguint" "a" bignumTerm
       it "Validates a bignum >= 2^64 against bigint" $
         expectValid $
-          validateCBOR_ bignumCBOR "a" (mapIndex $ resolveCDDL "a = bigint")
+          validateTermText "a = bigint" "a" bignumTerm
       it "Validates a bignum >= 2^64 against integer" $
         expectValid $
-          validateCBOR_ bignumCBOR "a" (mapIndex $ resolveCDDL "a = integer")
+          validateTermText "a = integer" "a" bignumTerm
       it "Rejects a bignum >= 2^64 against int" $
         expectInvalid $
-          validateCBOR_ bignumCBOR "a" (mapIndex $ resolveCDDL "a = int")
+          validateTermText "a = int" "a" bignumTerm
       it "Rejects a bignum >= 2^64 against uint" $
         expectInvalid $
-          validateCBOR_ bignumCBOR "a" (mapIndex $ resolveCDDL "a = uint")
+          validateTermText "a = uint" "a" bignumTerm
+
+    describe "Bignum literals" $ do
+      let bignum = 2 ^ (64 :: Int) :: Integer
+      it "Accepts a matching positive bignum" $
+        expectValid $
+          validateTermText "a = 18446744073709551616" "a" $
+            TermTag 2 (TermBytes (unsignedToBytes bignum))
+      it "Rejects a positive bignum with a different value" $
+        expectInvalid $
+          validateTermText "a = 18446744073709551616" "a" $
+            TermTag 2 (TermBytes (unsignedToBytes (bignum + 1)))
+      it "Accepts a matching negative bignum" $
+        -- tag 3 content n denotes -1 - n: -18446744073709551617 = -1 - 2^64
+        expectValid $
+          validateTermText "a = -18446744073709551617" "a" $
+            TermTag 3 (TermBytes (unsignedToBytes bignum))
+
+    describe "Value ranges" $ do
+      describe "Integer" $ do
+        it "Accepts the bounds of a closed range" $ do
+          expectValid $ validateTermText "a = 1 .. 5" "a" (TermUInt 1)
+          expectValid $ validateTermText "a = 1 .. 5" "a" (TermUInt 5)
+        it "Rejects values outside a closed range" $ do
+          expectInvalid $ validateTermText "a = 1 .. 5" "a" (TermUInt 0)
+          expectInvalid $ validateTermText "a = 1 .. 5" "a" (TermUInt 6)
+        it "Excludes the upper bound of a half-open range" $ do
+          expectValid $ validateTermText "a = 1 ... 5" "a" (TermUInt 4)
+          expectInvalid $ validateTermText "a = 1 ... 5" "a" (TermUInt 5)
+        it "Accepts the single member of a singleton range" $
+          expectValid $
+            validateTermText "a = 5 .. 5" "a" (TermUInt 5)
+        it "Handles a range with two negative bounds" $ do
+          expectValid $ validateTermText "a = -5 .. -1" "a" (termInt (-3))
+          expectInvalid $ validateTermText "a = -5 .. -1" "a" (TermUInt 0)
+      describe "Float" $ do
+        it "Accepts a float32 within the range" $
+          expectValid $
+            validateTermText "a = 0.0 .. 1.0" "a" (TermFloat 0.5)
+        it "Rejects a float32 outside the range" $
+          expectInvalid $
+            validateTermText "a = 0.0 .. 1.0" "a" (TermFloat 100.0)
+        it "Accepts a float64 within the range" $
+          expectValid $
+            validateTermText "a = 0.0 .. 1.0" "a" (TermDouble 0.5)
+        it "Rejects a float64 outside the range" $
+          expectInvalid $
+            validateTermText "a = 0.0 .. 1.0" "a" (TermDouble 100.0)
+        it "Excludes the upper bound of a half-open range" $
+          expectInvalid $
+            validateTermText "a = 0.0 ... 1.0" "a" (TermDouble 1.0)
+
+    describe "Size control" $ do
+      it "Measures text size in UTF-8 bytes, not characters" $ do
+        expectValid $ validateTermText "a = text .size (0 .. 2)" "a" (TermString "é")
+        expectInvalid $ validateTermText "a = text .size (0 .. 2)" "a" (TermString "€")
+      it "Handles a bytes size range with a negative lower bound" $ do
+        expectValid $ validateTermText "a = bytes .size (-2 .. 3)" "a" (TermBytes "")
+        expectValid $ validateTermText "a = bytes .size (-2 .. 3)" "a" (TermBytes "ab")
+        expectInvalid $ validateTermText "a = bytes .size (-2 .. 3)" "a" (TermBytes "abcd")
+
+    describe "Simple values" $ do
+      it "Validates an unassigned simple value against any" $
+        expectValid $
+          validateTermText "a = any" "a" (TermSimple 0)
+
+    describe "Huddle integer literals" $ do
+      it "Infers nint for negative literals" $
+        expectValid $
+          validateHuddle (collectFrom [HIRule $ "a" =:= int (-5)]) "a" (termInt (-5))
+      it "Infers uint for the maximum Word64" $
+        expectValid $
+          validateHuddle
+            (collectFrom [HIRule $ "a" =:= int 18446744073709551615])
+            "a"
+            (TermUInt maxBound)
 
   describe "Custom validator" $ do
     describe "Positive" $ do


### PR DESCRIPTION
The `Term` datatype in `cborg` has multiple issues, which can mask some discrepancies in CDDL conformance testing. 

The first problem is how `Term` handles `uint`, `nint` and `bigint` values. As soon as a numerical value is decoded using `decodeInteger`, we lose the information about the exact encoding used. 

The second problem is that the CBOR spec is lax about how the arguments of data items can be encoded. The `cborg` encoders always try to pack data items as tightly as possible, but unless canonicity is enforced, it is also valid to encode data items with byte widths wider than strictly necessary.

To address these issues, in this PR I introduced the `CBORTerm` datatype. It is fairly similar to the `Term` datatype, except that:
  * There is no constructor like `TInteger`: `uint` and `nint` get their own constructors and `biguint`/`binnint` are constructed as bytestrings with tag 2 or 3 accordingly.
  * The constructor of `float16` uses `Half` instead of `Float`
  * Some constructors have an `ArgWidth` field where relevant. This is used to specify exactly which byte width should be used to encode the argument.

The twiddling option when generating CBOR now also affects whether the arguments are always encoded in the optimal byte-width (if twiddling is disabled) or with a random byte-width.

close #207 